### PR TITLE
Update quickstart

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -46,16 +46,13 @@ In order to deploy a K8s cluster with CAPMOX, you require the following:
 
 In order to install Cluster API Provider Proxmox, you need to have a Kubernetes cluster up and running, and `clusterctl` installed.
 
-We need to add the Proxmox infrastructure provider and the IPAM provider to your clusterctl config file `~/.cluster-api/clusterctl.yaml`:
+We need to add the IPAM provider to your clusterctl config file `~/.cluster-api/clusterctl.yaml`:
 
 ```yaml
 providers:
   - name: in-cluster
     url: https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster/releases/latest/ipam-components.yaml
     type: IPAMProvider
-  - name: proxmox
-    url: https://github.com/ionos-cloud/cluster-api-provider-proxmox/releases/latest/infrastructure-components.yaml
-    type: InfrastructureProvider
 ```
 
 ### Configuring and installing Cluster API Provider Proxmox in a management cluster


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The proxmox provider will no longer needed to be added to clusterctl config, 

this will be merged after this: https://github.com/kubernetes-sigs/cluster-api/pull/9798
*Testing performed:*
