### PR TITLE
correct product name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# Kubernetes Cluster API Provider for Proxmox - CAPMOX
+# Kubernetes Cluster API Provider for Proxmox VE - CAPMOX
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ionos-cloud_cluster-api-provider-proxmox&metric=alert_status&token=fb1b4c0a87d83a780c76c21be0f89dc13efc2ca0)](https://sonarcloud.io/summary/new_code?id=ionos-cloud_cluster-api-provider-proxmox)
 
 ## Overview
 
 The [Cluster API](https://github.com/kubernetes-sigs/cluster-api) brings declarative, Kubernetes-style APIs to cluster creation, configuration and management.
-Cluster API Provider for Proxmox is a concrete implementation of Cluster API for Proxmox VE.
+Cluster API Provider for Proxmox VE is a concrete implementation of Cluster API for Proxmox VE.
 
-## Launching a Kubernetes cluster on Proxmox
+## Launching a Kubernetes cluster on Proxmox VE
 
-Check out the [quickstart guide](./docs/Usage.md#quick-start) for launching a cluster on Proxmox.
+Check out the [quickstart guide](./docs/Usage.md#quick-start) for launching a cluster on Proxmox VE.
 
 ## Compatibility with Cluster API and Kubernetes Versions
 This provider's versions are compatible with the following versions of Cluster API:


### PR DESCRIPTION
The product has to adhere to the Proxmox Band Guideline, so Proxmox VE is the product name. Maybe it is present on other pages too. Proxmox itself is the company and does not reference to concrete product.

 I don't know if the name of the repo has to be changed too, yet I suggest it.