### PR TITLE
docs: Refer to Proxmox VE correctly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Cluster API Provider for Proxmox
+# Contributing to Cluster API Provider for Proxmox Virtual Environment
 
-Thank you for considering contributing to the Cluster API provider for Proxmox. We appreciate your time and effort to help make this project better. To ensure a smooth collaboration, please follow the guidelines below.
+Thank you for considering contributing to the Cluster API Provider for Proxmox VE. We appreciate your time and effort to help make this project better. To ensure a smooth collaboration, please follow the guidelines below.
 
 ## Code of Conduct
 
@@ -59,4 +59,4 @@ Ensure that your changes are reflected in the documentation. If you are introduc
 If you encounter any issues or have suggestions for improvement, please open an issue on the GitHub repository.
 
 ## Thank You
-Thank you for your contribution! Your efforts help make the Cluster API provider for Proxmox better for everyone. We appreciate your dedication to the project and the CNCF community.
+Thank you for your contribution! Your efforts help make the Cluster API Provider for Proxmox VE better for everyone. We appreciate your dedication to the project and the CNCF community.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# Kubernetes Cluster API Provider for Proxmox - CAPMOX
+# Kubernetes Cluster API Provider for Proxmox Virtual Environment - CAPMOX
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ionos-cloud_cluster-api-provider-proxmox&metric=alert_status&token=fb1b4c0a87d83a780c76c21be0f89dc13efc2ca0)](https://sonarcloud.io/summary/new_code?id=ionos-cloud_cluster-api-provider-proxmox)
 
 ## Overview
 
 The [Cluster API](https://github.com/kubernetes-sigs/cluster-api) brings declarative, Kubernetes-style APIs to cluster creation, configuration and management.
-Cluster API Provider for Proxmox is a concrete implementation of Cluster API for Proxmox VE.
+Cluster API Provider for Proxmox VE is a concrete implementation of Cluster API for Proxmox VE.
 
-## Launching a Kubernetes cluster on Proxmox
+## Launching a Kubernetes cluster on Proxmox VE
 
-Check out the [quickstart guide](./docs/Usage.md#quick-start) for launching a cluster on Proxmox.
+Check out the [quickstart guide](./docs/Usage.md#quick-start) for launching a cluster on Proxmox VE.
 
 ## Compatibility with Cluster API and Kubernetes Versions
 This provider's versions are compatible with the following versions of Cluster API:

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -8,7 +8,7 @@ Table of contents
 * [About CAPMOX](#about-capmox)
 * [CAPMOX Dependencies](#capmox-dependencies)
 * [Getting Started](#getting-started)
-    * [Proxmox API Token](#promox-api-token)
+    * [Proxmox VE API Token](#promox-api-token)
 * [Setting up a development environment](#how-to-setup-a-development-environment)
     * [Running Tilt](#running-tilt)
 * [Make Targets](#make-targets)
@@ -19,7 +19,7 @@ Table of contents
     * [Uninstalling CAPMOX](#uninstalling-capmox)
 
 ## About CAPMOX
-CAPMOX is a Kubernetes Cluster API provider for Proxmox.
+CAPMOX is a Kubernetes Cluster API provider for Proxmox Virtual Environment.
 
 This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
 
@@ -55,8 +55,8 @@ in cluster-api's Tiltfile do not hold. We strongly advise against this approach.
 
 If you're having trouble setting any of this up, check the [Troubleshooting](Troubleshooting.md) docs.
 
-### Proxmox API Token
-Cluster-api-provider-proxmox requires a running proxmox instance and an API token for access. See the [Proxmox wiki](https://pve.proxmox.com/wiki/Proxmox_VE_API#API_Tokens)
+### Proxmox VE API Token
+Cluster-api-provider-proxmox requires a running Proxmox VE instance and an API token for access. See the [Proxmox wiki](https://pve.proxmox.com/wiki/Proxmox_VE_API#API_Tokens)
 for more information.
 
 ## How to setup a development environment
@@ -90,14 +90,14 @@ for more information.
   }
 }
 ```
-  This file instructs Tilt to use the Proxmox and ipam-provider-in-cluster repositories. `allowed_contexts` is used to add
+  This file instructs Tilt to use the cluster-api-provider-proxmox and ipam-provider-in-cluster repositories. `allowed_contexts` is used to add
   allowed clusters other than kind (which is always implicitly enabled).
 
 - If you don't have a cluster, create a new kind cluster:
 ```
 kind create cluster --name capi-test
 ```
-- cluster-api-provider-proxmox uses environment variables to connect to Proxmox. These need to be set in the shell which spawns Tilt.
+- cluster-api-provider-proxmox uses environment variables to connect to Proxmox VE. These need to be set in the shell which spawns Tilt.
   Tilt will pass these to the respective Kubernetes pods created. All variables are documented in `../cluster-api-provider-proxmox/envfile.example`.
   Copy `../cluster-api-provider-proxmox/envfile.example` to `../cluster-api-provider-proxmox/envfile` and make changes pertaining to your configuration.
   For documentation on environment variables, see [usage](Usage.md#environment-variables)

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -1,6 +1,6 @@
 # Usage
 
-This is a guide on how to get started with Cluster API Provider Proxmox. To learn more about cluster API in more depth, check out the [Cluster API book](https://cluster-api.sigs.k8s.io/).
+This is a guide on how to get started with Cluster API Provider for Proxmox Virtual Environment. To learn more about cluster API in more depth, check out the [Cluster API book](https://cluster-api.sigs.k8s.io/).
 
 Table of contents
 =================
@@ -10,7 +10,7 @@ Table of contents
       * [Dependencies](#dependencies)
       * [Quick start](#quick-start)
          * [Pre-requisites](#pre-requisites)
-         * [Configuring and installing Cluster API Provider Proxmox in a management cluster](#configuring-and-installing-cluster-api-provider-proxmox-in-a-management-cluster)
+         * [Configuring and installing Cluster API Provider for Proxmox VE in a management cluster](#configuring-and-installing-cluster-api-provider-for-proxmox-ve-in-a-management-cluster)
          * [Create a Workload Cluster](#create-a-workload-cluster)
          * [Check the status of the cluster](#check-the-status-of-the-cluster)
          * [Access the cluster](#access-the-cluster)
@@ -28,25 +28,25 @@ Table of contents
 
 In order to deploy a K8s cluster with CAPMOX, you require the following:
 
-* Proxmox template in order to be able to create a cluster.
+* Proxmox VE template in order to be able to create a cluster.
 
   * You can build VM template using [image-builder](https://github.com/kubernetes-sigs/image-builder)
-    * **we recommend using** [the Proxmox builder](https://image-builder.sigs.k8s.io/capi/providers/proxmox)
+    * **we recommend using** [the Proxmox VE builder](https://image-builder.sigs.k8s.io/capi/providers/proxmox)
     * OR by [Building Raw Images](https://image-builder.sigs.k8s.io/capi/providers/proxmox)
 
 * clusterctl, which you can download it from Cluster API (CAPI) [releases](https://github.com/kubernetes-sigs/cluster-api/releases) on GitHub.
 
 * Kubernetes cluster for running your CAPMOX controller
 
-* Proxmox Bridge e.g. `vmbr0` with an IP Range for VMs.
+* Proxmox VE Bridge e.g. `vmbr0` with an IP Range for VMs.
 
 ## Quick start
 
 ### Prerequisites
 
-In order to install Cluster API Provider Proxmox, you need to have a Kubernetes cluster up and running, and `clusterctl` installed.
+In order to install Cluster API Provider for Proxmox VE, you need to have a Kubernetes cluster up and running, and `clusterctl` installed.
 
-We need to add the Proxmox infrastructure provider and the IPAM provider to your clusterctl config file `~/.cluster-api/clusterctl.yaml`:
+We need to add the Proxmox VE infrastructure provider and the IPAM provider to your clusterctl config file `~/.cluster-api/clusterctl.yaml`:
 
 ```yaml
 providers:
@@ -58,7 +58,7 @@ providers:
     type: InfrastructureProvider
 ```
 
-### Configuring and installing Cluster API Provider Proxmox in a management cluster
+### Configuring and installing Cluster API Provider for Proxmox VE in a management cluster
 
 Before you can create a cluster, you need to configure your management cluster. 
 This is done by setting up the environment variables for CAPMOX and generating a cluster manifest.
@@ -67,15 +67,15 @@ clusterctl requires the following variables, which should be set in `~/.cluster-
 
 ```env
 ## -- Controller settings -- ##
-PROXMOX_URL: "https://pve.example:8006"                       # The Proxmox host
-PROXMOX_TOKEN: "root@pam!capi"                                # The Proxmox tokenID for authentication
-PROXMOX_SECRET: "REDACTED"                                    # The secret associated with the tokenID
+PROXMOX_URL: "https://pve.example:8006"                       # The Proxmox VE host
+PROXMOX_TOKEN: "root@pam!capi"                                # The Proxmox VE TokenID for authentication
+PROXMOX_SECRET: "REDACTED"                                    # The secret associated with the TokenID
 
 
 ## -- Required workload cluster default settings -- ##
 PROXMOX_SOURCENODE: "pve"                                     # The node that hosts the VM template to be used to provision VMs
 TEMPLATE_VMID: "100"                                          # The template VM ID used for cloning VMs
-ALLOWED_NODES: "[pve1,pve2,pve3, ...]"                        # The Proxmox nodes used for VM deployments
+ALLOWED_NODES: "[pve1,pve2,pve3, ...]"                        # The Proxmox VE nodes used for VM deployments
 VM_SSH_KEYS: "ssh-ed25519 ..., ssh-ed25519 ..."               # The ssh authorized keys used to ssh to the machines.
 
 ## -- networking configuration-- ##
@@ -84,7 +84,7 @@ NODE_IP_RANGES: "[10.10.10.5-10.10.10.50, ...]"               # The IP ranges fo
 GATEWAY: "10.10.10.1"                                         # The gateway for the machines network-config.
 IP_PREFIX: "25"                                               # Subnet Mask in CIDR notation for your node IP ranges
 DNS_SERVERS: "[8.8.8.8,8.8.4.4]"                              # The dns nameservers for the machines network-config.
-BRIDGE: "vmbr1"                                               # The Proxmox network device for VMs
+BRIDGE: "vmbr1"                                               # The network bridge device for Proxmox VE VMs
 
 ## -- xl nodes-- ## 
 BOOT_VOLUME_DEVICE: "scsi0"                                    # The device used for the boot disk.   


### PR DESCRIPTION
*Issue #, if available:*
#20 (actually a PR)

*Description of changes:*
The Proxmox brand guidelines https://www.proxmox.com/images/proxmox/Proxmox-Corporate-Brandguideline-2018.pdf request that products are referred to by their full or abbreviated names.

Honour this request by updating our usage of the word Proxmox to refer to Proxmox VE.

*Testing performed:*
none needed