### PR TITLE
use pre-release for IPAMProvider

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -52,7 +52,7 @@ We need to add the IPAM provider to your clusterctl config file `~/.cluster-api/
 ```yaml
 providers:
   - name: in-cluster
-    url: https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster/releases/latest/ipam-components.yaml
+    url: https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster/releases/download/v0.1.0-alpha.3/ipam-components.yaml
     type: IPAMProvider
 ```
 


### PR DESCRIPTION
fixes #22 

Updated ink to IPAMProivder to a pre-release version.