### PR TITLE
Fixes pause of IPAddressClaim

### DIFF
--- a/internal/service/vmservice/ip.go
+++ b/internal/service/vmservice/ip.go
@@ -91,7 +91,7 @@ func handleIPAddressForDevice(ctx context.Context, machineScope *scope.MachineSc
 		}
 		machineScope.Logger.V(4).Info("IPAddress not found, creating it.", "device", device)
 		// IpAddress not yet created.
-		err = machineScope.IPAMHelper.CreateIPAddressClaim(ctx, machineScope.ProxmoxMachine, device, format, ipamRef)
+		err = machineScope.IPAMHelper.CreateIPAddressClaim(ctx, machineScope.ProxmoxMachine, device, format, machineScope.InfraCluster.Cluster.GetName(), ipamRef)
 		if err != nil {
 			return "", errors.Wrapf(err, "unable to create Ip address claim for machine %s", machineScope.Name())
 		}

--- a/pkg/kubernetes/ipam/ipam.go
+++ b/pkg/kubernetes/ipam/ipam.go
@@ -152,7 +152,7 @@ func (h *Helper) GetGlobalInClusterIPPool(ctx context.Context, ref *corev1.Typed
 }
 
 // CreateIPAddressClaim creates an IPAddressClaim for a given object.
-func (h *Helper) CreateIPAddressClaim(ctx context.Context, owner client.Object, device, format string, ref *corev1.TypedLocalObjectReference) error {
+func (h *Helper) CreateIPAddressClaim(ctx context.Context, owner client.Object, device, format, clusterNameLabel string, ref *corev1.TypedLocalObjectReference) error {
 	var gvk schema.GroupVersionKind
 	key := client.ObjectKey{
 		Namespace: owner.GetNamespace(),
@@ -201,7 +201,7 @@ func (h *Helper) CreateIPAddressClaim(ctx context.Context, owner client.Object, 
 	// Ensures that the claim has a reference to the cluster of the VM to
 	// support pausing reconciliation.
 	labels := map[string]string{
-		clusterv1.ClusterNameLabel: h.cluster.GetName(),
+		clusterv1.ClusterNameLabel: clusterNameLabel,
 	}
 
 	desired := &ipamv1.IPAddressClaim{

--- a/pkg/kubernetes/ipam/ipam.go
+++ b/pkg/kubernetes/ipam/ipam.go
@@ -200,15 +200,15 @@ func (h *Helper) CreateIPAddressClaim(ctx context.Context, owner client.Object, 
 
 	// Ensures that the claim has a reference to the cluster of the VM to
 	// support pausing reconciliation.
-	annotations := map[string]string{
-		clusterv1.ClusterNameAnnotation: h.cluster.GetName(),
+	labels := map[string]string{
+		clusterv1.ClusterNameLabel: h.cluster.GetName(),
 	}
 
 	desired := &ipamv1.IPAddressClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        fmt.Sprintf("%s-%s-%s", owner.GetName(), device, suffix),
-			Namespace:   owner.GetNamespace(),
-			Annotations: annotations,
+			Name:      fmt.Sprintf("%s-%s-%s", owner.GetName(), device, suffix),
+			Namespace: owner.GetNamespace(),
+			Labels:    labels,
 		},
 		Spec: ipamv1.IPAddressClaimSpec{
 			PoolRef: corev1.TypedLocalObjectReference{

--- a/pkg/kubernetes/ipam/ipam_test.go
+++ b/pkg/kubernetes/ipam/ipam_test.go
@@ -235,7 +235,8 @@ func (s *IPAMTestSuite) Test_CreateIPAddressClaim() {
 
 	device := "net0"
 
-	err := s.helper.CreateIPAddressClaim(s.ctx, getCluster(), device, infrav1.IPV4Format, nil)
+	rootClusterName := "test"
+	err := s.helper.CreateIPAddressClaim(s.ctx, getCluster(), device, infrav1.IPV4Format, rootClusterName, nil)
 	s.NoError(err)
 
 	// Ensure cluster label is set.
@@ -245,7 +246,7 @@ func (s *IPAMTestSuite) Test_CreateIPAddressClaim() {
 	err = s.cl.Get(s.ctx, nn, &claim)
 	s.NoError(err)
 	s.Contains(claim.ObjectMeta.Labels, clusterv1.ClusterNameLabel)
-	s.Equal(getCluster().GetName(), claim.ObjectMeta.Labels[clusterv1.ClusterNameLabel])
+	s.Equal(rootClusterName, claim.ObjectMeta.Labels[clusterv1.ClusterNameLabel])
 
 	// additional device with InClusterIPPool
 	s.NoError(s.helper.ctrlClient.Create(s.ctx, &ipamicv1.InClusterIPPool{
@@ -268,7 +269,7 @@ func (s *IPAMTestSuite) Test_CreateIPAddressClaim() {
 
 	additionalDevice := "net1"
 
-	err = s.helper.CreateIPAddressClaim(s.ctx, getCluster(), additionalDevice, infrav1.IPV4Format, &corev1.TypedLocalObjectReference{
+	err = s.helper.CreateIPAddressClaim(s.ctx, getCluster(), additionalDevice, infrav1.IPV4Format, "test-cluster", &corev1.TypedLocalObjectReference{
 		Name:     "test-additional-cluster-icip",
 		Kind:     "InClusterIPPool",
 		APIGroup: ptr.To("ipam.cluster.x-k8s.io"),
@@ -294,7 +295,7 @@ func (s *IPAMTestSuite) Test_CreateIPAddressClaim() {
 
 	globalDevice := "net2"
 
-	err = s.helper.CreateIPAddressClaim(s.ctx, getCluster(), globalDevice, infrav1.IPV4Format, &corev1.TypedLocalObjectReference{
+	err = s.helper.CreateIPAddressClaim(s.ctx, getCluster(), globalDevice, infrav1.IPV4Format, "test-cluster", &corev1.TypedLocalObjectReference{
 		Name:     "test-global-cluster-icip",
 		Kind:     "GlobalInClusterIPPool",
 		APIGroup: ptr.To("ipam.cluster.x-k8s.io"),
@@ -315,7 +316,7 @@ func (s *IPAMTestSuite) Test_CreateIPAddressClaim() {
 		Name:      "test-cluster-v6-icip",
 	}, &poolV6))
 
-	err = s.helper.CreateIPAddressClaim(s.ctx, getCluster(), device, infrav1.IPV6Format, nil)
+	err = s.helper.CreateIPAddressClaim(s.ctx, getCluster(), device, infrav1.IPV6Format, "test-cluster", nil)
 	s.NoError(err)
 }
 
@@ -328,7 +329,7 @@ func (s *IPAMTestSuite) Test_GetIPAddress() {
 		Name:      "test-cluster-v4-icip",
 	}, &pool))
 
-	err := s.helper.CreateIPAddressClaim(s.ctx, getCluster(), "net0", infrav1.IPV4Format, &corev1.TypedLocalObjectReference{
+	err := s.helper.CreateIPAddressClaim(s.ctx, getCluster(), "net0", infrav1.IPV4Format, "test-cluster", &corev1.TypedLocalObjectReference{
 		Name: "test-cluster-icip",
 	})
 	s.NoError(err)

--- a/pkg/kubernetes/ipam/ipam_test.go
+++ b/pkg/kubernetes/ipam/ipam_test.go
@@ -18,6 +18,7 @@ package ipam
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -236,6 +237,15 @@ func (s *IPAMTestSuite) Test_CreateIPAddressClaim() {
 
 	err := s.helper.CreateIPAddressClaim(s.ctx, getCluster(), device, infrav1.IPV4Format, nil)
 	s.NoError(err)
+
+	// Ensure cluster label is set.
+	var claim ipamv1.IPAddressClaim
+	name := fmt.Sprintf("%s-%s-%s", getCluster().GetName(), device, infrav1.DefaultSuffix)
+	nn := types.NamespacedName{Name: name, Namespace: getCluster().GetNamespace()}
+	err = s.cl.Get(s.ctx, nn, &claim)
+	s.NoError(err)
+	s.Contains(claim.ObjectMeta.Labels, clusterv1.ClusterNameLabel)
+	s.Equal(getCluster().GetName(), claim.ObjectMeta.Labels[clusterv1.ClusterNameLabel])
 
 	// additional device with InClusterIPPool
 	s.NoError(s.helper.ctrlClient.Create(s.ctx, &ipamicv1.InClusterIPPool{


### PR DESCRIPTION
## Overview 


IPAddressClaim is not paused due to the pausing implementation was not correct:

The correct check is the clusterName label:


https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster/blob/b8ccdf8c362cd51ee120e50f8ec2b637f02e3755/internal/controllers/ipaddressclaim.go#L180

