### PR TITLE
manifests: remove command parameter from container

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -67,9 +67,7 @@ spec:
         # seccompProfile:
         #   type: RuntimeDefault
       containers:
-      - command:
-        - /manager
-        args:
+      - args:
         - --leader-elect
         - --feature-gates=ClusterTopology=${ClusterTopology:=false}
         - "--metrics-bind-address=localhost:8080"


### PR DESCRIPTION
As we just discussed, having a valid `ENTRYPOINT` is enough (which we have in the `Dockerfile`) and removing it from the manifests allows us to more easily transition to ko or goreleaser for example. 

Additionally, when trying to quickly build and test a container (like i just did with `ko build`), not being forced into `/manager` makes it much easier.