### PR TITLE
fix cloud-init default routes

### DIFF
--- a/pkg/cloudinit/network.go
+++ b/pkg/cloudinit/network.go
@@ -40,11 +40,11 @@ const (
 	  {{- end }}
       routes:
       {{- if $element.Gateway }}
-        - to: default
+        - to: 0.0.0.0/0
           via: {{ $element.Gateway }}
 	  {{- end }}
       {{- if $element.Gateway6 }}
-        - to: default
+        - to: '::/0'
           via: {{ $element.Gateway6 }}
 	  {{- end }}
       {{- if $element.DNSServers }}

--- a/pkg/cloudinit/network_test.go
+++ b/pkg/cloudinit/network_test.go
@@ -35,7 +35,7 @@ const (
       addresses:
         - 10.10.10.12/24
       routes:
-        - to: default
+        - to: 0.0.0.0/0
           via: 10.10.10.1
       nameservers:
         addresses:
@@ -53,7 +53,7 @@ const (
       addresses:
         - 10.10.10.12/24
       routes:
-        - to: default
+        - to: 0.0.0.0/0
           via: 10.10.10.1`
 
 	expectedValidNetworkConfigMultipleNics = `network:
@@ -67,7 +67,7 @@ const (
       addresses:
         - 10.10.10.12/24
       routes:
-        - to: default
+        - to: 0.0.0.0/0
           via: 10.10.10.1
       nameservers:
         addresses:
@@ -80,7 +80,7 @@ const (
       addresses:
         - 196.168.100.124/24
       routes:
-        - to: default
+        - to: 0.0.0.0/0
           via: 196.168.100.254
       nameservers:
         addresses:
@@ -99,9 +99,9 @@ const (
         - 10.10.10.12/24
         - 2001:db8::1/64
       routes:
-        - to: default
+        - to: 0.0.0.0/0
           via: 10.10.10.1
-        - to: default
+        - to: '::/0'
           via: 2001:db8::1
       nameservers:
         addresses:
@@ -119,7 +119,7 @@ const (
       addresses:
         - 2001:db8::1/64
       routes:
-        - to: default
+        - to: '::/0'
           via: 2001:db8::1
       nameservers:
         addresses:


### PR DESCRIPTION
Fixes the `ValueError: Address default is not a valid ip address` error during cloud-init on RPM-based distributions.

```
2023-12-14 13:24:13,681 - stages.py[DEBUG]: applying net config names for {'version': 2, 'renderer': 'networkd', 'ethernets': {'eth0': {'match': {'macaddress': '9E:88:BA:6F:CC:1A'}, 'dhcp4': 'no', 'addresses': ['192.168.69.111/24'], 'routes': [{'to': 'default', 'via': '192.168.69.1'}], 'nameservers': {'addresses': ['8.8.8.8', '8.8.4.4']}}}}
2023-12-14 13:24:13,681 - __init__.py[DEBUG]: no interfaces to rename
2023-12-14 13:24:13,681 - stages.py[INFO]: Applying network configuration from ds bringup=False: {'version': 2, 'renderer': 'networkd', 'ethernets': {'eth0': {'match': {'macaddress': '9E:88:BA:6F:CC:1A'}, 'dhcp4': 'no', 'addresses': ['192.168.69.111/24'], 'routes': [{'to': 'default', 'via': '192.168.69.1'}], 'nameservers': {'addresses': ['8.8.8.8', '8.8.4.4']}}}}


2023-12-14 13:24:13,684 - util.py[DEBUG]: failed stage init-local
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/cloudinit/cmd/main.py", line 767, in status_wrapper
    ret = functor(name, args)
  File "/usr/lib/python3.9/site-packages/cloudinit/cmd/main.py", line 433, in main_init
    init.apply_network_config(bring_up=bring_up_interfaces)
  File "/usr/lib/python3.9/site-packages/cloudinit/stages.py", line 954, in apply_network_config
    return self.distro.apply_network_config(
  File "/usr/lib/python3.9/site-packages/cloudinit/distros/__init__.py", line 277, in apply_network_config
    network_state = parse_net_config_data(netconfig, renderer=renderer)
  File "/usr/lib/python3.9/site-packages/cloudinit/net/network_state.py", line 1118, in parse_net_config_data
    nsi.parse_config(skip_broken=skip_broken)
  File "/usr/lib/python3.9/site-packages/cloudinit/net/network_state.py", line 316, in parse_config
    self.parse_config_v2(skip_broken=skip_broken)
  File "/usr/lib/python3.9/site-packages/cloudinit/net/network_state.py", line 371, in parse_config_v2
    handler(self, command)
  File "/usr/lib/python3.9/site-packages/cloudinit/net/network_state.py", line 765, in handle_ethernets
    subnets = self._v2_to_v1_ipcfg(cfg)
  File "/usr/lib/python3.9/site-packages/cloudinit/net/network_state.py", line 936, in _v2_to_v1_ipcfg
    _normalize_route(
  File "/usr/lib/python3.9/site-packages/cloudinit/net/network_state.py", line 1075, in _normalize_route
    _normalize_net_keys(
  File "/usr/lib/python3.9/site-packages/cloudinit/net/network_state.py", line 1009, in _normalize_net_keys
    raise ValueError(f"Address {addr} is not a valid ip address")
ValueError: Address default is not a valid ip address
```

Tested it for IPv4-only both under AlmaLinux and Ubuntu 22.04. 