### PR TITLE
fix: prevent deletion attempts for non-existent vmID -1

### DIFF
--- a/pkg/proxmox/goproxmox/api_client.go
+++ b/pkg/proxmox/goproxmox/api_client.go
@@ -138,6 +138,12 @@ func (c *APIClient) FindVMResource(ctx context.Context, vmID uint64) (*proxmox.C
 
 // DeleteVM deletes a VM based on the nodeName and vmID.
 func (c *APIClient) DeleteVM(ctx context.Context, nodeName string, vmID int64) (*proxmox.Task, error) {
+	// A vmID can not be lower than 100.
+	// If the provided vmID is lower (like -1 in issue #31), just error out without calling the API.
+	if vmID < 100 {
+		return nil, fmt.Errorf("vm with id %d does not exist", vmID)
+	}
+
 	node, err := c.Node(ctx, nodeName)
 	if err != nil {
 		return nil, fmt.Errorf("cannot find node with name %s: %w", nodeName, err)


### PR DESCRIPTION
This should fix #31. It simply checks if the passed vmID is `< 100` (which is not allowed by Proxmox) and then returns the `does not exist` error, which we'd expect anyways, in case a VM does not exist. That way it also spares us from making unnecessary API calls to Proxmox.

Alternative solution would be to just reword our  error in the same function from `cannot find vm with id %d` to `vm with id %d does not exist`, which would effectively have the same functional effect in our controller, but would in turn make unnecessary API calls to Proxmox for a VM that could've never existed.

Both solutions would work with https://github.com/ionos-cloud/cluster-api-provider-proxmox/blob/5f6d700a2d39e0c54818354485c8fbadf8cb442d/internal/service/vmservice/delete.go#L52C1-L55C2