### PR TITLE
fix: exclude VM templates and include containers when calculating a host's reserveable memory

### DIFF
--- a/pkg/proxmox/goproxmox/api_client.go
+++ b/pkg/proxmox/goproxmox/api_client.go
@@ -195,10 +195,27 @@ func (c *APIClient) GetReservableMemoryBytes(ctx context.Context, nodeName strin
 	}
 
 	for _, vm := range vms {
+		// Ignore VM Templates, as they can't be started.
+		if vm.Template {
+			continue
+		}
 		if reservableMemory < vm.MaxMem {
 			reservableMemory = 0
 		} else {
 			reservableMemory -= vm.MaxMem
+		}
+	}
+
+	containers, err := node.Containers(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("cannot list containers for node %s: %w", nodeName, err)
+	}
+
+	for _, ct := range containers {
+		if reservableMemory < ct.MaxMem {
+			reservableMemory = 0
+		} else {
+			reservableMemory -= ct.MaxMem
 		}
 	}
 

--- a/pkg/proxmox/goproxmox/api_client_test.go
+++ b/pkg/proxmox/goproxmox/api_client_test.go
@@ -64,7 +64,45 @@ func TestProxmoxAPIClient_GetReservableMemoryBytes(t *testing.T) {
 				newJSONResponder(200, proxmox.Node{Memory: proxmox.Memory{Total: 30}}))
 
 			httpmock.RegisterResponder(http.MethodGet, `=~/nodes/test/qemu`,
-				newJSONResponder(200, proxmox.VirtualMachines{{MaxMem: test.maxMem}}))
+				// Somehow, setting proxmox.VirtualMachines{} ALWAYS has `Template: true` when defined this way.
+				// So it's better to just define a legitimate json response
+				newJSONResponder(200, []interface{}{
+					map[string]interface{}{
+						"name":      "legit-worker",
+						"maxmem":    test.maxMem,
+						"vmid":      1111,
+						"diskwrite": 0,
+						"mem":       0,
+						"uptime":    0,
+						"disk":      0,
+						"cpu":       0,
+						"cpus":      1,
+						"status":    "stopped",
+						"netout":    0,
+						"maxdisk":   0,
+						"netin":     0,
+						"diskread":  0,
+					},
+					map[string]interface{}{
+						"name":      "template",
+						"maxmem":    102400,
+						"vmid":      2222,
+						"diskwrite": 0,
+						"mem":       0,
+						"uptime":    0,
+						"disk":      0,
+						"cpu":       0,
+						"template":  1,
+						"cpus":      1,
+						"status":    "stopped",
+						"netout":    0,
+						"maxdisk":   0,
+						"netin":     0,
+						"diskread":  0,
+					}}))
+
+			httpmock.RegisterResponder(http.MethodGet, `=~/nodes/test/lxc`,
+				newJSONResponder(200, proxmox.Containers{}))
 
 			reservable, err := client.GetReservableMemoryBytes(context.Background(), "test")
 			require.NoError(t, err)


### PR DESCRIPTION
*Description of changes:*

Previously, it was only checked for VMs, without taking their Template status into consideration. (A Template VM can't be started, without explicitly removing the flag.). Existing LXCs on a host weren't taken into consideration either.

Now, we'll no longer include VM Template in our calculations. But in exchange we include LXCs now.

*Issue #, if available:*
Fixes #36.

*Testing performed:*
* provisioned a cluster
* assigned an unrealistic amount of memory to a template
* tried to scale out the cluster to provoke a failure
* applied patched CAPMOX image
* tried to scale out the cluster again, which worked this time around