### PR TITLE
ci: run sonarcloud via pull_request_target

### DIFF
--- a/.github/workflows/code-qa-sonarcloud.yaml
+++ b/.github/workflows/code-qa-sonarcloud.yaml
@@ -1,0 +1,44 @@
+name: Code QA - SonarCloud
+
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - main
+    paths-ignore:
+      - '.github/**'
+
+jobs:
+  sonarcloud:
+    runs-on: ubuntu-latest
+
+    steps:
+      # If triggered by a push to **our** repository, we can directly checkout the code.
+      - name: Checkout branch ${{ github.ref }}
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/checkout@v4.1.1
+        with:
+          # Disabling shallow clone is recommended for improving relevancy of reporting
+          fetch-depth: 0
+
+      # If triggered by a PR, we have to check out the PR's source
+      - name: Checkout (preview) merge commit for PR ${{ github.event.pull_request.number }}
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: actions/checkout@v4.1.1
+        with:
+          # Disabling shallow clone is recommended for improving relevancy of reporting
+          fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@v2.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,3 @@ jobs:
           go-version-file: go.mod
       - name: Run tests
         run: "make test"
-
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v2.1.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
`on.pull_request` executes the workflow out of a forked repository. This means the `SONAR_TOKEN` secret will not be available and therefore the workflow will fail. By changing it to `on.pull_request_target`, the workflow definition (and code) from the trusted original repository is run and the secret will be available.

See https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

This should fix issues with failed SonarCloud runs on external PRs like in https://github.com/ionos-cloud/cluster-api-provider-proxmox/actions/runs/7240484604/job/19723537444