### PR TITLE
Adjust cloudinit to support dhcp

### DIFF
--- a/pkg/cloudinit/network.go
+++ b/pkg/cloudinit/network.go
@@ -30,30 +30,22 @@ const (
     eth{{ $index }}:
       match:
         macaddress: {{ $element.MacAddress }}
-      {{- if $element.DHCP4 }}
-      dhcp4: true
-      {{- else }}
-      dhcp4: 'no'
-      {{- end }}
-      {{- if $element.DHCP6 }}
-      dhcp6: true
-      {{- else }}
-      dhcp6: 'no'
-      {{- end }}
+      dhcp4: {{ if $element.DHCP4 }}true{{ else }}false{{ end }}
+      dhcp6: {{ if $element.DHCP6 }}true{{ else }}false{{ end }}
       {{- if or (and (not $element.DHCP4) $element.IPAddress) (and (not $element.DHCP6) $element.IPV6Address) }}
       addresses:
-      {{- if $element.IPAddress }}
+      {{- if and $element.IPAddress (not $element.DHCP4) }}
         - {{ $element.IPAddress }}
       {{- end }}
-      {{- if $element.IPV6Address }}
+      {{- if and $element.IPV6Address (not $element.DHCP6)}}
         - {{ $element.IPV6Address }}
 	  {{- end }}
       routes:
-      {{- if $element.Gateway }}
+      {{- if and $element.Gateway (not $element.DHCP4) }}
         - to: 0.0.0.0/0
           via: {{ $element.Gateway }}
 	  {{- end }}
-      {{- if $element.Gateway6 }}
+      {{- if and $element.Gateway6 (not $element.DHCP6) }}
         - to: '::/0'
           via: {{ $element.Gateway6 }}
 	  {{- end }}

--- a/pkg/cloudinit/network_test.go
+++ b/pkg/cloudinit/network_test.go
@@ -31,8 +31,8 @@ const (
     eth0:
       match:
         macaddress: 92:60:a0:5b:22:c2
-      dhcp4: 'no'
-      dhcp6: 'no'
+      dhcp4: false
+      dhcp6: false
       addresses:
         - 10.10.10.12/24
       routes:
@@ -50,8 +50,8 @@ const (
     eth0:
       match:
         macaddress: 92:60:a0:5b:22:c2
-      dhcp4: 'no'
-      dhcp6: 'no'
+      dhcp4: false
+      dhcp6: false
       addresses:
         - 10.10.10.12/24
       routes:
@@ -65,8 +65,8 @@ const (
     eth0:
       match:
         macaddress: 92:60:a0:5b:22:c2
-      dhcp4: 'no'
-      dhcp6: 'no'
+      dhcp4: false
+      dhcp6: false
       addresses:
         - 10.10.10.12/24
       routes:
@@ -79,8 +79,8 @@ const (
     eth1:
       match:
         macaddress: b4:87:18:bf:a3:60
-      dhcp4: 'no'
-      dhcp6: 'no'
+      dhcp4: false
+      dhcp6: false
       addresses:
         - 196.168.100.124/24
       routes:
@@ -98,8 +98,8 @@ const (
     eth0:
       match:
         macaddress: 92:60:a0:5b:22:c2
-      dhcp4: 'no'
-      dhcp6: 'no'
+      dhcp4: false
+      dhcp6: false
       addresses:
         - 10.10.10.12/24
         - 2001:db8::1/64
@@ -120,8 +120,8 @@ const (
     eth0:
       match:
         macaddress: 92:60:a0:5b:22:c2
-      dhcp4: 'no'
-      dhcp6: 'no'
+      dhcp4: false
+      dhcp6: false
       addresses:
         - 2001:db8::1/64
       routes:
@@ -154,7 +154,7 @@ const (
       match:
         macaddress: 92:60:a0:5b:22:c2
       dhcp4: true
-      dhcp6: 'no'
+      dhcp6: false
       nameservers:
         addresses:
           - 8.8.8.8
@@ -167,7 +167,7 @@ const (
     eth0:
       match:
         macaddress: 92:60:a0:5b:22:c2
-      dhcp4: 'no'
+      dhcp4: false
       dhcp6: true
       nameservers:
         addresses:
@@ -181,7 +181,7 @@ const (
     eth0:
       match:
         macaddress: 92:60:a0:5b:22:c2
-      dhcp4: 'no'
+      dhcp4: false
       dhcp6: true
       addresses:
         - 10.10.10.12/24

--- a/pkg/cloudinit/network_test.go
+++ b/pkg/cloudinit/network_test.go
@@ -277,23 +277,6 @@ func TestNetworkConfig_Render(t *testing.T) {
 				err:     ErrMalformedIPAddress,
 			},
 		},
-		"InvalidNetworkConfigMalformedIP": {
-			reason: "ip address malformed",
-			args: args{
-				nics: []NetworkConfigData{
-					{
-						MacAddress: "92:60:a0:5b:22:c2",
-						IPAddress:  "10.10.10.115",
-						Gateway:    "10.10.10.1",
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
-					},
-				},
-			},
-			want: want{
-				network: "",
-				err:     ErrMalformedIPAddress,
-			},
-		},
 		"InvalidNetworkConfigGW": {
 			reason: "gw is not set",
 			args: args{

--- a/pkg/cloudinit/network_test.go
+++ b/pkg/cloudinit/network_test.go
@@ -32,6 +32,7 @@ const (
       match:
         macaddress: 92:60:a0:5b:22:c2
       dhcp4: 'no'
+      dhcp6: 'no'
       addresses:
         - 10.10.10.12/24
       routes:
@@ -50,6 +51,7 @@ const (
       match:
         macaddress: 92:60:a0:5b:22:c2
       dhcp4: 'no'
+      dhcp6: 'no'
       addresses:
         - 10.10.10.12/24
       routes:
@@ -64,6 +66,7 @@ const (
       match:
         macaddress: 92:60:a0:5b:22:c2
       dhcp4: 'no'
+      dhcp6: 'no'
       addresses:
         - 10.10.10.12/24
       routes:
@@ -77,6 +80,7 @@ const (
       match:
         macaddress: b4:87:18:bf:a3:60
       dhcp4: 'no'
+      dhcp6: 'no'
       addresses:
         - 196.168.100.124/24
       routes:
@@ -95,6 +99,7 @@ const (
       match:
         macaddress: 92:60:a0:5b:22:c2
       dhcp4: 'no'
+      dhcp6: 'no'
       addresses:
         - 10.10.10.12/24
         - 2001:db8::1/64
@@ -116,11 +121,73 @@ const (
       match:
         macaddress: 92:60:a0:5b:22:c2
       dhcp4: 'no'
+      dhcp6: 'no'
       addresses:
         - 2001:db8::1/64
       routes:
         - to: '::/0'
           via: 2001:db8::1
+      nameservers:
+        addresses:
+          - 8.8.8.8
+          - 8.8.4.4`
+
+	expectedValidNetworkConfigDHCP = `network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    eth0:
+      match:
+        macaddress: 92:60:a0:5b:22:c2
+      dhcp4: true
+      dhcp6: true
+      nameservers:
+        addresses:
+          - 8.8.8.8
+          - 8.8.4.4`
+
+	expectedValidNetworkConfigDHCP4 = `network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    eth0:
+      match:
+        macaddress: 92:60:a0:5b:22:c2
+      dhcp4: true
+      dhcp6: 'no'
+      nameservers:
+        addresses:
+          - 8.8.8.8
+          - 8.8.4.4`
+
+	expectedValidNetworkConfigDHCP6 = `network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    eth0:
+      match:
+        macaddress: 92:60:a0:5b:22:c2
+      dhcp4: 'no'
+      dhcp6: true
+      nameservers:
+        addresses:
+          - 8.8.8.8
+          - 8.8.4.4`
+
+	expectedValidNetworkConfigWithDHCP = `network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    eth0:
+      match:
+        macaddress: 92:60:a0:5b:22:c2
+      dhcp4: 'no'
+      dhcp6: true
+      addresses:
+        - 10.10.10.12/24
+      routes:
+        - to: 0.0.0.0/0
+          via: 10.10.10.1
       nameservers:
         addresses:
           - 8.8.8.8
@@ -142,8 +209,8 @@ func TestNetworkConfig_Render(t *testing.T) {
 		args   args
 		want   want
 	}{
-		"ValidNetworkConfig": {
-			reason: "render valid network-config",
+		"ValidStaticNetworkConfig": {
+			reason: "render valid network-config with static ip",
 			args: args{
 				nics: []NetworkConfigData{
 					{
@@ -156,6 +223,24 @@ func TestNetworkConfig_Render(t *testing.T) {
 			},
 			want: want{
 				network: expectedValidNetworkConfig,
+				err:     nil,
+			},
+		},
+		"ValidStaticNetworkConfigWithDHCP": {
+			reason: "render valid network-config with ipv6 static ip and dhcp",
+			args: args{
+				nics: []NetworkConfigData{
+					{
+						MacAddress: "92:60:a0:5b:22:c2",
+						DHCP6:      true,
+						IPAddress:  "10.10.10.12/24",
+						Gateway:    "10.10.10.1",
+						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+					},
+				},
+			},
+			want: want{
+				network: expectedValidNetworkConfigWithDHCP,
 				err:     nil,
 			},
 		},
@@ -323,6 +408,57 @@ func TestNetworkConfig_Render(t *testing.T) {
 			},
 			want: want{
 				network: expectedValidNetworkConfigIPV6,
+				err:     nil,
+			},
+		},
+		"ValidNetworkConfigDHCP": {
+			reason: "render valid network-config with dhcp",
+			args: args{
+				nics: []NetworkConfigData{
+					{
+						MacAddress: "92:60:a0:5b:22:c2",
+						DHCP4:      true,
+						DHCP6:      true,
+						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+					},
+				},
+			},
+			want: want{
+				network: expectedValidNetworkConfigDHCP,
+				err:     nil,
+			},
+		},
+		"ValidNetworkConfigDHCP4": {
+			reason: "render valid network-config with dhcp",
+			args: args{
+				nics: []NetworkConfigData{
+					{
+						MacAddress: "92:60:a0:5b:22:c2",
+						DHCP4:      true,
+						DHCP6:      false,
+						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+					},
+				},
+			},
+			want: want{
+				network: expectedValidNetworkConfigDHCP4,
+				err:     nil,
+			},
+		},
+		"ValidNetworkConfigDHCP6": {
+			reason: "render valid network-config with dhcp",
+			args: args{
+				nics: []NetworkConfigData{
+					{
+						MacAddress: "92:60:a0:5b:22:c2",
+						DHCP4:      false,
+						DHCP6:      true,
+						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+					},
+				},
+			},
+			want: want{
+				network: expectedValidNetworkConfigDHCP6,
 				err:     nil,
 			},
 		},

--- a/pkg/cloudinit/types.go
+++ b/pkg/cloudinit/types.go
@@ -22,12 +22,13 @@ type BaseCloudInitData struct {
 	Hostname          string
 	InstanceID        string
 	NetworkConfigData []NetworkConfigData
-	IPAddresses       string
 }
 
 // NetworkConfigData is used to render network-config.
 type NetworkConfigData struct {
 	MacAddress  string
+	DHCP4       bool
+	DHCP6       bool
 	IPAddress   string
 	IPV6Address string
 	Gateway     string


### PR DESCRIPTION
Towards #29 

I decided to create multiple PRs, for better and faster reviews.

This PR:

- Adds dhcp options in the network-config for cloud-init