### PR TITLE
Rename the environment variables to the same as in Packer

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -202,8 +202,8 @@ func initFlagsAndEnv(fs *pflag.FlagSet) {
 	klog.InitFlags(nil)
 
 	ProxmoxURL = env.GetString("PROXMOX_URL", "")
-	ProxmoxTokenID = env.GetString("PROXMOX_TOKEN", "")
-	ProxmoxSecret = env.GetString("PROXMOX_SECRET", "")
+	ProxmoxTokenID = env.GetString("PROXMOX_USERNAME", "")
+	ProxmoxSecret = env.GetString("PROXMOX_TOKEN", "")
 
 	fs.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	fs.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -227,10 +227,10 @@ func validate() error {
 		return errors.New("required variable `PROXMOX_URL` is not set")
 	}
 	if ProxmoxTokenID == "" {
-		return errors.New("required variable `PROXMOX_TOKEN` is not set")
+		return errors.New("required variable `PROXMOX_USERNAME` is not set")
 	}
 	if ProxmoxSecret == "" {
-		return errors.New("required variable `PROXMOX_SECRET` is not set")
+		return errors.New("required variable `PROXMOX_TOKEN` is not set")
 	}
 	return nil
 }

--- a/config/default/manager_credentials_patch.yaml
+++ b/config/default/manager_credentials_patch.yaml
@@ -20,8 +20,8 @@ spec:
             secretKeyRef:
               key: token
               name: capmox-manager-credentials
-        - name: PROXMOX_SECRET
+        - name: PROXMOX_USERNAME
           valueFrom:
             secretKeyRef:
-              key: secret
+              key: user
               name: capmox-manager-credentials

--- a/config/default/proxmox-credentials-secret.yaml
+++ b/config/default/proxmox-credentials-secret.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 stringData:
-  secret: ${PROXMOX_SECRET}
+  username: ${PROXMOX_USERNAME}
   token: ${PROXMOX_TOKEN}
   url: ${PROXMOX_URL}
 kind: Secret

--- a/docs/Local-Providers.md
+++ b/docs/Local-Providers.md
@@ -79,8 +79,8 @@ Prior to executing `clusterctl init`, make sure to export the required environme
 ```
 # required
 export PROXMOX_URL=https://pve.example.com
-export PROXMOX_TOKEN="<TOKEN_ID>"
-export PROXMOX_SECRET="<TOKEN_SECRET>"
+export PROXMOX_USERNAME="<TOKEN_ID>"
+export PROXMOX_TOKEN="<TOKEN_SECRET>"
 
 # optional
 export CAPMOX_LOGLEVEL=4

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -4,7 +4,7 @@
 To check if your api token works, you can use the following curl
 ```
 . envfile
-curl -v -H "Authorization: PVEAPIToken=$PROXMOX_TOKEN=$PROXMOX_SECRET" ${PROXMOX_URL%/}/api2/json/
+curl -v -H "Authorization: PVEAPIToken=$PROXMOX_USERNAME=$PROXMOX_TOKEN" ${PROXMOX_URL%/}/api2/json/
 ```
 ## kind/Docker cgroups v2
 Kind [requires](https://serverfault.com/questions/1053187/systemd-fails-to-run-in-a-docker-container-when-using-cgroupv2-cgroupns-priva/1054414#1054414)

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -74,11 +74,11 @@ on your Proxmox VE node.
 
 clusterctl requires the following variables, which should be set in `~/.cluster-api/clusterctl.yaml` as the following:
 
-```env
+```env 
 ## -- Controller settings -- ##
 PROXMOX_URL: "https://pve.example:8006"                       # The Proxmox VE host
-PROXMOX_TOKEN: "root@pam!capi"                                # The Proxmox VE TokenID for authentication
-PROXMOX_SECRET: "REDACTED"                                    # The secret associated with the TokenID
+PROXMOX_USERNAME: "root@pam!capi"                             # The Proxmox VE TokenID for authentication
+PROXMOX_TOKEN: "REDACTED"                                     # The secret associated with the TokenID
 
 
 ## -- Required workload cluster default settings -- ##

--- a/envfile.example
+++ b/envfile.example
@@ -1,6 +1,6 @@
 export PROXMOX_URL=https://pve.example.com
 export PROXMOX_TOKEN=""
-export PROXMOX_SECRET=""
+export PROXMOX_USERNAME=""
 export PROXMOX_SOURCENODE="pve"
 export TEMPLATE_VMID=100
 export VM_SSH_KEYS="ssh-ed25519 ..., ssh-ed25519 ..."

--- a/hack/start-capi-tilt.sh
+++ b/hack/start-capi-tilt.sh
@@ -39,7 +39,7 @@ fi
 # check that required environment variables to start capmox are set
 [[ -n ${PROXMOX_URL-} ]] || { echo "PROXMOX_URL is not set" >&2; exit 1; }
 [[ -n ${PROXMOX_TOKEN-} ]] || { echo "PROXMOX_TOKEN is not set" >&2; exit 1; }
-[[ -n ${PROXMOX_SECRET-} ]] || { echo "PROXMOX_SECRET is not set" >&2; exit 1; }
+[[ -n ${PROXMOX_USERNAME} ]] || { echo "PROXMOX_USERNAME is not set" >&2; exit 1; }
 
 export EXP_CLUSTER_RESOURCE_SET=true
 


### PR DESCRIPTION
fixes #52 
**Draft** 
not tested (have to set up my development environment and tools first) 
*Description of changes:*
Renames the Variable `PROXMOX_TOKEN` to `PROXMOX_USERNAME`
Renames the Variable `PROXMOX_SECRET` to `PROXMOX_TOKEN`

This should be easier to understand and is the same as in Packer which should prevent #52.

*Testing performed:*
