### PR TITLE
fix(ci): fold verify under go_test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,15 +7,6 @@ on:
     branches: ["main"]
 
 jobs:
-  verify:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: go.mod
-      - name: Verify
-        run: "make verify"
   go_test:
     runs-on: ubuntu-latest
     steps:
@@ -40,6 +31,9 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
+
+      - name: Verify
+        run: "make verify"
 
       - name: Run tests
         run: "make test"


### PR DESCRIPTION
`verify` running in `pull_request_target` context verifies the upstream rather than the PR.

*Issue #, if available:*
https://github.com/ionos-cloud/cluster-api-provider-proxmox/actions/runs/7627247798/job/20775470951

*Description of changes:*
Moved `verify` to `go_test`, as `verify` also needs to checkout the PR. Whilst it's possible for those two to run in parallel, in practice `verify` is very fast anyway and we're avoiding copying the checkout dance which wouldn't be good for maintainability.
