### PR TITLE
fix(cloudinit): wrap ipv6 addresses in quotation marks

### DIFF
--- a/pkg/cloudinit/network.go
+++ b/pkg/cloudinit/network.go
@@ -38,7 +38,7 @@ const (
         - {{ $element.IPAddress }}
       {{- end }}
       {{- if and $element.IPV6Address (not $element.DHCP6)}}
-        - {{ $element.IPV6Address }}
+        - '{{ $element.IPV6Address }}'
 	  {{- end }}
       routes:
       {{- if and $element.Gateway (not $element.DHCP4) }}
@@ -47,14 +47,14 @@ const (
 	  {{- end }}
       {{- if and $element.Gateway6 (not $element.DHCP6) }}
         - to: '::/0'
-          via: {{ $element.Gateway6 }}
+          via: '{{ $element.Gateway6 }}'
 	  {{- end }}
       {{- end }}
       {{- if $element.DNSServers }}
       nameservers:
         addresses:
         {{- range $element.DNSServers }}
-          - {{ . }}
+          - '{{ . }}'
         {{- end -}}
       {{- end -}}
   {{- end -}}`

--- a/pkg/cloudinit/network_test.go
+++ b/pkg/cloudinit/network_test.go
@@ -40,8 +40,8 @@ const (
           via: 10.10.10.1
       nameservers:
         addresses:
-          - 8.8.8.8
-          - 8.8.4.4`
+          - '8.8.8.8'
+          - '8.8.4.4'`
 
 	expectedValidNetworkConfigWithoutDNS = `network:
   version: 2
@@ -74,8 +74,8 @@ const (
           via: 10.10.10.1
       nameservers:
         addresses:
-          - 8.8.8.8
-          - 8.8.4.4
+          - '8.8.8.8'
+          - '8.8.4.4'
     eth1:
       match:
         macaddress: b4:87:18:bf:a3:60
@@ -88,8 +88,8 @@ const (
           via: 196.168.100.254
       nameservers:
         addresses:
-          - 8.8.8.8
-          - 8.8.4.4`
+          - '8.8.8.8'
+          - '8.8.4.4'`
 
 	expectedValidNetworkConfigDualStack = `network:
   version: 2
@@ -102,16 +102,16 @@ const (
       dhcp6: false
       addresses:
         - 10.10.10.12/24
-        - 2001:db8::1/64
+        - '2001:db8::1/64'
       routes:
         - to: 0.0.0.0/0
           via: 10.10.10.1
         - to: '::/0'
-          via: 2001:db8::1
+          via: '2001:db8::1'
       nameservers:
         addresses:
-          - 8.8.8.8
-          - 8.8.4.4`
+          - '8.8.8.8'
+          - '8.8.4.4'`
 
 	expectedValidNetworkConfigIPV6 = `network:
   version: 2
@@ -123,14 +123,14 @@ const (
       dhcp4: false
       dhcp6: false
       addresses:
-        - 2001:db8::1/64
+        - '2001:db8::1/64'
       routes:
         - to: '::/0'
-          via: 2001:db8::1
+          via: '2001:db8::1'
       nameservers:
         addresses:
-          - 8.8.8.8
-          - 8.8.4.4`
+          - '8.8.8.8'
+          - '8.8.4.4'`
 
 	expectedValidNetworkConfigDHCP = `network:
   version: 2
@@ -143,8 +143,8 @@ const (
       dhcp6: true
       nameservers:
         addresses:
-          - 8.8.8.8
-          - 8.8.4.4`
+          - '8.8.8.8'
+          - '8.8.4.4'`
 
 	expectedValidNetworkConfigDHCP4 = `network:
   version: 2
@@ -157,8 +157,8 @@ const (
       dhcp6: false
       nameservers:
         addresses:
-          - 8.8.8.8
-          - 8.8.4.4`
+          - '8.8.8.8'
+          - '8.8.4.4'`
 
 	expectedValidNetworkConfigDHCP6 = `network:
   version: 2
@@ -171,8 +171,8 @@ const (
       dhcp6: true
       nameservers:
         addresses:
-          - 8.8.8.8
-          - 8.8.4.4`
+          - '8.8.8.8'
+          - '8.8.4.4'`
 
 	expectedValidNetworkConfigWithDHCP = `network:
   version: 2
@@ -190,8 +190,8 @@ const (
           via: 10.10.10.1
       nameservers:
         addresses:
-          - 8.8.8.8
-          - 8.8.4.4`
+          - '8.8.8.8'
+          - '8.8.4.4'`
 )
 
 func TestNetworkConfig_Render(t *testing.T) {


### PR DESCRIPTION
The ipv6 gateway needs to be wrapped in quotation marks, otherwise it can produce invalid yaml.

Example (invalid, caused by ::, ::1 is fine, can be checked by a yaml linter like https://www.yamllint.com):

```yaml
network:
  version: 2
  renderer: networkd
  ethernets:
    eth0:
      match:
        macaddress: BC:24:11:75:4E:D2
      dhcp4: false
      dhcp6: false
      addresses:
        - 2a01:7e01:e003:3b04:ffff::/64
      routes:
        - to: '::/0'
          via: 2a01:7e01:e003:3b04::
      nameservers:
        addresses:
          - 2a01:7e01:e003:3b00::6464
 ```

Results into:

<img width="969" alt="image" src="https://github.com/ionos-cloud/cluster-api-provider-proxmox/assets/17984007/2ef77755-e0f7-48e6-83d8-214681062d36">
