### PR TITLE
fly-by: Allow specifying packages to test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.26.1
+ENVTEST_K8S_VERSION = 1.28.0
 
 TOOLS_DIR := hack/tools
 

--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,12 @@ vet: ## Run go vet against code.
 lint: ## Run lint.
 	go run -modfile ./hack/tools/go.mod github.com/golangci/golangci-lint/cmd/golangci-lint run --timeout 5m -c .golangci.yml
 
+# Package names to test
+WHAT ?= ./...
+
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
+test: manifests generate fmt vet envtest ## Run tests. Specify packages to test using WHAT.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(WHAT) -coverprofile cover.out
 
 .PHONY: mockgen
 mockgen: ## Generate mocks.


### PR DESCRIPTION
*Issue #, if available:*

I wanted to test the webhook package, but found there was no easy way of running the tests because it needs envtest binaries.

*Description of changes:*

Add Makefile variable `WHAT` that controls what tests should be run. Defaults to `./...`.
`WHAT` must be a valid go package specification.

Also updated the envtest k8s version to 1.28.0, because the go.mod uses 1.28.X.

*Testing performed:*

I ran `make test` with different values of `WHAT` locally.
