### PR TITLE
ci: fix sonarcloud scan pr source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,21 @@ jobs:
       - name: Run tests
         run: "make test"
 
-      - name: SonarCloud Scan
+      - name: SonarCloud Scan ${{ github.ref }}
         uses: SonarSource/sonarcloud-github-action@v2.1.1
+        if: ${{ github.event_name == 'push' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      # If triggered by a PR, we have to use the PR's source
+      - name: SonarCloud Scan (preview) merge commit for PR ${{ github.event.pull_request.number }}
+        uses: SonarSource/sonarcloud-github-action@v2.1.1
+        if: ${{ github.event_name == 'pull_request_target' }}
+        with:
+         args: >
+           -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
+           -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Sonarcloud thinks that every branch is "main" (see https://sonarcloud.io/project/branches_list?id=ionos-cloud_cluster-api-provider-proxmox)

This is an attempt to fix that

Warning: the check run here uses the workflow from main, so I cant be sure if this works. I'd be happy to receive other suggestions