### PR TITLE
Fixing Usage docs

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -52,7 +52,7 @@ We need to add the IPAM provider to your clusterctl config file `~/.cluster-api/
 ```yaml
 providers:
   - name: in-cluster
-    url: https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster/releases/download/v0.1.0-alpha.3/ipam-components.yaml
+    url: https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster/releases/v0.1.0-alpha.3/ipam-components.yaml
     type: IPAMProvider
 ```
 


### PR DESCRIPTION
used fresh clusterctl config. 
Got:

```
> clusterctl init --infrastructure proxmox --ipam in-cluster
Fetching providers
Error: failed to get provider components for the "in-cluster" provider: failed to read "ipam-components.yaml" from provider's repository "ipam-in-cluster": release not found for version download, please retry later or set "GOPROXY=off" to get the current stable release: 404 Not Found
```

*Issue #, if available:*

*Description of changes:*

*Testing performed:*
