### PR TITLE
feat: making control plane endpoint fields optional

### DIFF
--- a/api/v1alpha1/conditions_consts.go
+++ b/api/v1alpha1/conditions_consts.go
@@ -83,4 +83,7 @@ const (
 const (
 	// ProxmoxClusterReady documents the status of ProxmoxCluster and its underlying resources.
 	ProxmoxClusterReady clusterv1.ConditionType = "ClusterReady"
+	// Status of the ProxmoxCluster control plane endpoint fields.
+	MissingControlPlaneEndpointPortReason = "MissingControlPlaneEndpointPort"
+	MissingControlPlaneEndpointHostReason = "MissingControlPlaneEndpointHost"
 )

--- a/internal/controller/proxmoxcluster_controller.go
+++ b/internal/controller/proxmoxcluster_controller.go
@@ -168,6 +168,31 @@ func (r *ProxmoxClusterReconciler) reconcileNormal(ctx context.Context, clusterS
 	// If the ProxmoxCluster doesn't have our finalizer, add it.
 	ctrlutil.AddFinalizer(clusterScope.ProxmoxCluster, infrav1alpha1.ClusterFinalizer)
 
+	cpe := clusterScope.ControlPlaneEndpoint()
+	if cpe.Port == 0 {
+		conditions.MarkFalse(
+			clusterScope.ProxmoxCluster,
+			infrav1alpha1.ProxmoxClusterReady,
+			infrav1alpha1.MissingControlPlaneEndpointPortReason,
+			clusterv1.ConditionSeverityWarning,
+			"The ProxmoxCluster is missing or waiting for a ControlPlaneEndpoint port",
+		)
+
+		return reconcile.Result{}, nil
+	}
+
+	if cpe.Host == "" {
+		conditions.MarkFalse(
+			clusterScope.ProxmoxCluster,
+			infrav1alpha1.ProxmoxClusterReady,
+			infrav1alpha1.MissingControlPlaneEndpointHostReason,
+			clusterv1.ConditionSeverityWarning,
+			"The ProxmoxCluster is missing or waiting for a ControlPlaneEndpoint hostname",
+		)
+
+		return reconcile.Result{}, nil
+	}
+
 	res, err := r.reconcileIPAM(ctx, clusterScope)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/internal/webhook/proxmoxcluster_webhook.go
+++ b/internal/webhook/proxmoxcluster_webhook.go
@@ -94,64 +94,64 @@ func (*ProxmoxCluster) ValidateUpdate(_ context.Context, _ runtime.Object, newOb
 func validateIPs(cluster *infrav1.ProxmoxCluster) error {
 	ep := cluster.Spec.ControlPlaneEndpoint
 
-	gk, name := cluster.GroupVersionKind().GroupKind(), cluster.GetName()
+	if ep.Host != "" && ep.Port > 0 {
+		gk, name := cluster.GroupVersionKind().GroupKind(), cluster.GetName()
 
-	ipAddr, err := netip.ParseAddrPort(fmt.Sprintf("%s:%d", ep.Host, ep.Port))
-	if err != nil {
-		return apierrors.NewInvalid(
-			gk,
-			name,
-			field.ErrorList{
-				field.Invalid(
-					field.NewPath("spec", "controlplaneEndpoint"), fmt.Sprintf("%s:%d", ep.Host, ep.Port), "provided endpoint is not in a valid IP and port format"),
-			})
-	}
-
-	// IPv4
-	if cluster.Spec.IPv4Config != nil {
-		set, err := buildSetFromAddresses(cluster.Spec.IPv4Config.Addresses)
+		ipAddr, err := netip.ParseAddrPort(fmt.Sprintf("%s:%d", ep.Host, ep.Port))
 		if err != nil {
 			return apierrors.NewInvalid(
 				gk,
 				name,
 				field.ErrorList{
 					field.Invalid(
-						field.NewPath("spec", "IPv4Config", "addresses"), cluster.Spec.IPv4Config.Addresses, "provided addresses are not valid IP addresses, ranges or CIDRs"),
+						field.NewPath("spec", "controlplaneEndpoint"), fmt.Sprintf("%s:%d", ep.Host, ep.Port), "provided endpoint is not in a valid IP and port format"),
 				})
 		}
+		// IPv4
+		if cluster.Spec.IPv4Config != nil {
+			set, err := buildSetFromAddresses(cluster.Spec.IPv4Config.Addresses)
+			if err != nil {
+				return apierrors.NewInvalid(
+					gk,
+					name,
+					field.ErrorList{
+						field.Invalid(
+							field.NewPath("spec", "IPv4Config", "addresses"), cluster.Spec.IPv4Config.Addresses, "provided addresses are not valid IP addresses, ranges or CIDRs"),
+					})
+			}
 
-		if set.Contains(ipAddr.Addr()) {
-			return apierrors.NewInvalid(
-				gk,
-				name,
-				field.ErrorList{
-					field.Invalid(
-						field.NewPath("spec", "IPv4Config", "addresses"), cluster.Spec.IPv4Config.Addresses, "addresses may not contain the endpoint IP"),
-				})
+			if set.Contains(ipAddr.Addr()) {
+				return apierrors.NewInvalid(
+					gk,
+					name,
+					field.ErrorList{
+						field.Invalid(
+							field.NewPath("spec", "IPv4Config", "addresses"), cluster.Spec.IPv4Config.Addresses, "addresses may not contain the endpoint IP"),
+					})
+			}
 		}
-	}
+		// IPV6
+		if cluster.Spec.IPv6Config != nil {
+			set6, err := buildSetFromAddresses(cluster.Spec.IPv6Config.Addresses)
+			if err != nil {
+				return apierrors.NewInvalid(
+					gk,
+					name,
+					field.ErrorList{
+						field.Invalid(
+							field.NewPath("spec", "IPv6Config", "addresses"), cluster.Spec.IPv6Config.Addresses, "provided addresses are not valid IP addresses, ranges or CIDRs"),
+					})
+			}
 
-	// IPV6
-	if cluster.Spec.IPv6Config != nil {
-		set6, err := buildSetFromAddresses(cluster.Spec.IPv6Config.Addresses)
-		if err != nil {
-			return apierrors.NewInvalid(
-				gk,
-				name,
-				field.ErrorList{
-					field.Invalid(
-						field.NewPath("spec", "IPv6Config", "addresses"), cluster.Spec.IPv6Config.Addresses, "provided addresses are not valid IP addresses, ranges or CIDRs"),
-				})
-		}
-
-		if set6.Contains(ipAddr.Addr()) {
-			return apierrors.NewInvalid(
-				gk,
-				name,
-				field.ErrorList{
-					field.Invalid(
-						field.NewPath("spec", "IPv6Config", "addresses"), cluster.Spec.IPv6Config.Addresses, "addresses may not contain the endpoint IP"),
-				})
+			if set6.Contains(ipAddr.Addr()) {
+				return apierrors.NewInvalid(
+					gk,
+					name,
+					field.ErrorList{
+						field.Invalid(
+							field.NewPath("spec", "IPv6Config", "addresses"), cluster.Spec.IPv6Config.Addresses, "addresses may not contain the endpoint IP"),
+					})
+			}
 		}
 	}
 


### PR DESCRIPTION
*Issue #95*

*Description of changes:*

Skipping webhook validation for the `ProxmoxCluster` Control Plane endpoint field.

The `ProxmoxCluster` controller will wait for a valid IP before proceeding to mark the infrastructure ready.

*Testing performed:*

N.A.