### PR TITLE
chore(ci): Enable golangci-lint-action PR annotations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,8 @@ on: [ pull_request ]
 permissions:
   # Required: allow read access to the content for analysis.
   contents: read
+  # Optional: Allow write access to checks to allow the action to annotate code in the PR.
+  checks: write
 
 jobs:
   golangci:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Give golangci-lint-action permission to write checks to display issues as annotations on the PR.
See: https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#comments-and-annotations

*Testing performed:*
