### PR TITLE
cloudinit: fix multiple vrf device templating

### DIFF
--- a/pkg/cloudinit/network.go
+++ b/pkg/cloudinit/network.go
@@ -41,17 +41,17 @@ const (
       {{- end }}
       {{- if and $element.IPV6Address (not $element.DHCP6)}}
         - '{{ $element.IPV6Address }}'
-	  {{- end }}
+      {{- end }}
       {{- if or (and $element.Gateway (not $element.DHCP4)) (and $element.Gateway6 (not $element.DHCP6)) }}
       routes:
       {{- if and $element.Gateway (not $element.DHCP4) }}
         - to: 0.0.0.0/0
           via: {{ $element.Gateway }}
-	  {{- end }}
+      {{- end }}
       {{- if and $element.Gateway6 (not $element.DHCP6) }}
         - to: '::/0'
           via: '{{ $element.Gateway6 }}'
-	  {{- end }}
+      {{- end }}
       {{- end }}
       {{- end }}
       {{- if $element.DNSServers }}
@@ -68,7 +68,7 @@ const (
   {{- if eq $element.Type "vrf" }}
   {{- if eq $vrf 0 }}
   vrfs:
-  {{- $vrf := 1 }}
+  {{- $vrf = 1 }}
   {{- end }}
     {{$element.Name}}:
       table: {{ $element.Table }}


### PR DESCRIPTION
*Description of changes:*
This very little templating error made it into production. It creates the same yaml key multiple times, which makes the last VRF device win in cloudinit.

*Testing performed:*
I've added testcases for multiple vrfs, so we don't get any repeats.
