### PR TITLE
Go 1.21 touchups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 AS builder
+FROM golang:1.21 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240208111015-5923139bc5bd
 
 ##@ Test
 

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -33,7 +33,7 @@ The following dependencies are required to setup a development environment:
 
 - git
 - make
-- Go v1.20 (newer versions break testing)
+- Go v1.21 (newer versions break testing)
 - Kubebuilder (only required for making new controllers)
 - Docker (required for Kind)
 - Tilt


### PR DESCRIPTION
*Description of changes:*
The test harness started failing on my end. This is because setup-envtest now depends on golang 1.22. At the moment I get segfaults when testing with golang 1.22.
While at it, I've also fixed documentation and docker build.

*Testing performed:*
Docker image built.
Test harness now runs again with golang 1.21