### PR TITLE
docs/Troubleshooting: add calico ipvs interface detection issue

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -63,3 +63,7 @@ or others, please check the image tag of the `capi-controller-manager` Deploymen
 kubectl get deployment/capi-controller-manager -o yaml | yq '.spec.template.spec.containers[].image'
 ```
 If your capi-controller is too new, you can pass a `--core cluster-api:v1.6.1` during `clusterctl init`, to force an older version. By default it installs the latest version from the [kubernetes-sigs/cluster-api](https://github.com/kubernetes-sigs/cluster-api) project.
+
+## Calico fails in IPVS mode with loadBalancers to expose services
+Calico unfortunately does not test connectivity when it choses a node ip to use for IPVS communication.
+This can be altered manually. More on this topic in [Calicos documentation](https://docs.tigera.io/calico/latest/networking/ipam/ip-autodetection#autodetection-methods).


### PR DESCRIPTION
*Description of changes:*
If you have multiple interfaces in your cluster, with some interfaces only available to some nodes, calico can fail to guess the right ip range/interface to use for IPVS. I've added some troubleshooting documentation for this case.

*Testing performed:*
No tests required from our side.