### PR TITLE
e2e: skip workflow on 'skip e2e' label

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,11 +4,12 @@ on:
   push:
     branches: ["main"]
   pull_request_target:
-    types: ["opened", "synchronize", "reopened"]
+    types: ["opened", "synchronize", "reopened", "labeled", "unlabeled"]
     branches: ["main"]
 
 jobs:
   e2e:
+    if: ${{ ! contains( github.event.pull_request.labels.*.name, 'skip e2e') }}
     runs-on: [capmox,e2e,dcd-playground]
     environment: e2e
     env:


### PR DESCRIPTION
*Issue #, if available:*
fixes #199

*Description of changes:*
1. `labeled` and `unlabeled` added to trigger types so that the label can be modified after the PR is submitted
2. e2e job runs if the PR does not have the `skip e2e` label.

*Testing performed:*
As this modifies a `pull_request_target` workflow it will only take effect once merged to main.