### PR TITLE
Fix ipv4config error in example cluster-class

### DIFF
--- a/templates/cluster-class.yaml
+++ b/templates/cluster-class.yaml
@@ -394,7 +394,7 @@ spec:
           - op: add
             path: /spec/template/spec/ipv4Config
             valueFrom:
-              variable: ipv4Config.addresses
+              variable: ipv4Config
   - name: ClusterIPv6Config
     description: "Configure Cluster IPv6 config"
     enabledIf: "{{ if .ipv6Config }}true{{ end }}"


### PR DESCRIPTION
Was getting

**.spec.ipv4Config: expected map, got &{[10.10.10.10-10.10.10.20]}**

Assuming it is because of this recent [commit](https://github.com/ionos-cloud/cluster-api-provider-proxmox/commit/032869f1590c5623ede6aecce6cfb444cbe9f855) which did some changes to the cluster-class example.

Removes the **.addresses** from the patching configuration. With these changes the validation error no longer occurs on my setup.
