### PR TITLE
cluster-template-external-creds: Fix name of the Secret

### DIFF
--- a/templates/cluster-template-external-creds.yaml
+++ b/templates/cluster-template-external-creds.yaml
@@ -40,7 +40,7 @@ stringData:
   url: ${PROXMOX_URL}
 kind: Secret
 metadata:
-  name: "${CLUSTER_NAME}"-proxmox-credentials
+  name: "${CLUSTER_NAME}-proxmox-credentials"
   labels:
     platform.ionos.com/secret-type: "proxmox-credentials"
 ---


### PR DESCRIPTION
When using the `cluster-template-external-creds` template with `clusterctl`, the following error is obtained:

```
Error: failed to parse yaml: failed to unmarshal the 3rd yaml document: "apiVersion: v1\nstringData:\n  secret: REDACTED\n  token: REDACTED\n  url: https://REDACTED:8006\nkind: Secret\nmetadata:\n  name: \"kind-monk2\"-proxmox-credentials\n  labels:\n    platform.ionos.com/secret-type: \"proxmox-credentials\"\n": error converting YAML to JSON: yaml: line 7: did not find expected key
```

Fixing the `name` key as outlined by this commit resolves the issue.
