### PR TITLE
mockery: don't use boilerplate

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -2,7 +2,6 @@ quiet: false
 disable-version-string: true
 with-expecter: true
 include-auto-generated: false
-boilerplate-file: hack/boilerplate.go.txt
 packages:
   github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/proxmox:
     interfaces:


### PR DESCRIPTION
*Issue #, if available:*
#234

*Description of changes:*
We decided against forcing one boilerplate to keep the copyright lines correct and because it's questionable whether generated files are subject to copyright.
However, we forgot to actually remove the boilerplate file from mockery config.

*Testing performed:*
`make mockgen` no longer fails.