### PR TITLE
USe cluster namespace if no namespace provided in credentials Ref

### DIFF
--- a/api/v1alpha1/proxmoxcluster_types.go
+++ b/api/v1alpha1/proxmoxcluster_types.go
@@ -76,6 +76,7 @@ type ProxmoxClusterSpec struct {
 
 	// CredentialsRef is a reference to a Secret that contains the credentials to use for provisioning this cluster. If not
 	// supplied then the credentials of the controller will be used.
+	// if no namespace is provided, the namespace of the ProxmoxCluster will be used.
 	// +optional
 	CredentialsRef *corev1.SecretReference `json:"credentialsRef,omitempty"`
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclusters.yaml
@@ -567,7 +567,8 @@ spec:
               credentialsRef:
                 description: CredentialsRef is a reference to a Secret that contains
                   the credentials to use for provisioning this cluster. If not supplied
-                  then the credentials of the controller will be used.
+                  then the credentials of the controller will be used. if no namespace
+                  is provided, the namespace of the ProxmoxCluster will be used.
                 properties:
                   name:
                     description: name is unique within a namespace to reference a

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclustertemplates.yaml
@@ -617,7 +617,8 @@ spec:
                         description: CredentialsRef is a reference to a Secret that
                           contains the credentials to use for provisioning this cluster.
                           If not supplied then the credentials of the controller will
-                          be used.
+                          be used. if no namespace is provided, the namespace of the
+                          ProxmoxCluster will be used.
                         properties:
                           name:
                             description: name is unique within a namespace to reference

--- a/pkg/scope/cluster.go
+++ b/pkg/scope/cluster.go
@@ -129,8 +129,12 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 func (s *ClusterScope) setupProxmoxClient(ctx context.Context) (capmox.Client, error) {
 	// get the credentials secret
 	secret := corev1.Secret{}
+	namespace := s.ProxmoxCluster.Spec.CredentialsRef.Namespace
+	if len(namespace) == 0 {
+		namespace = s.ProxmoxCluster.GetNamespace()
+	}
 	err := s.client.Get(ctx, client.ObjectKey{
-		Namespace: s.ProxmoxCluster.Spec.CredentialsRef.Namespace,
+		Namespace: namespace,
 		Name:      s.ProxmoxCluster.Spec.CredentialsRef.Name,
 	}, &secret)
 	if err != nil {


### PR DESCRIPTION
This PR:

Fixes an issue, if a user provided a ProxmoxCluster manifest with external creds with only the name of secret