### PR TITLE
Fix CNI cluster templates

### DIFF
--- a/internal/webhook/proxmoxmachine_webhook.go
+++ b/internal/webhook/proxmoxmachine_webhook.go
@@ -84,6 +84,10 @@ func (p *ProxmoxMachine) ValidateDelete(_ context.Context, _ runtime.Object) (wa
 }
 
 func validateNetworks(machine *infrav1.ProxmoxMachine) error {
+	if machine.Spec.Network == nil {
+		return nil
+	}
+
 	gk, name := machine.GroupVersionKind().GroupKind(), machine.GetName()
 
 	if machine.Spec.Network.Default != nil {

--- a/templates/cluster-class-calico.yaml
+++ b/templates/cluster-class-calico.yaml
@@ -978,6 +978,10 @@ spec:
       templateID: 100
       format: qcow2
       full: true
+      network:
+        default:
+          bridge: ${BRIDGE}
+          model: virtio
 ---
 kind: ProxmoxMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
@@ -990,6 +994,10 @@ spec:
       templateID: 100
       format: qcow2
       full: true
+      network:
+        default:
+          bridge: ${BRIDGE}
+          model: virtio
 ---
 kind: KubeadmConfigTemplate
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1

--- a/templates/cluster-class-cilium.yaml
+++ b/templates/cluster-class-cilium.yaml
@@ -978,6 +978,10 @@ spec:
       templateID: 100
       format: qcow2
       full: true
+      network:
+        default:
+          bridge: ${BRIDGE}
+          model: virtio
 ---
 kind: ProxmoxMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
@@ -990,6 +994,10 @@ spec:
       templateID: 100
       format: qcow2
       full: true
+      network:
+        default:
+          bridge: ${BRIDGE}
+          model: virtio
 ---
 kind: KubeadmConfigTemplate
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1

--- a/templates/cluster-template-cilium.yaml
+++ b/templates/cluster-template-cilium.yaml
@@ -175,6 +175,10 @@ spec:
       templateID: ${TEMPLATE_VMID}
       format: "qcow2"
       full: true
+      network:
+        default:
+          bridge: ${BRIDGE}
+          model: virtio
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -216,6 +220,10 @@ spec:
       templateID: ${TEMPLATE_VMID}
       format: "qcow2"
       full: true
+      network:
+        default:
+          bridge: ${BRIDGE}
+          model: virtio
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate


### PR DESCRIPTION
The webhook fails cause the `spec.network` is nil

Fixes #255 