### PR TITLE
Add documentation for Proxmox RBAC with least privileges

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -64,6 +64,9 @@ pveum user token add capmox@pve capi -privsep 0
 ```
 on your Proxmox VE node.
 
+
+If you want to create a CAPMOX user with least privileges, see the [advanced setups docs](advanced-setups.md#proxmox-rbac-with-least-privileges).
+
 ---
 
 clusterctl requires the following variables, which should be set in `~/.cluster-api/clusterctl.yaml` as the following:

--- a/docs/advanced-setups.md
+++ b/docs/advanced-setups.md
@@ -184,7 +184,7 @@ For the Proxmox API user/token you create for CAPMOX, these are the minimum requ
 
 * Create a role called `Sys.Audit` with the `Sys.Audit` permission and a role called `Datastore.AllocateSpace` with the `Datastore.AllocateSpace` permission only. Apart from these roles, we only need the built-in roles.
 
-* Create a pool for the VMs created and managed by CAPMOX (called `capi`` in the example).
+* Create a pool for the VMs created and managed by CAPMOX (called `capi` in the example).
 * Create a pool for the templates used by CAPMOX (called `templates` in the example) and assign all templates that should be accessible by CAPMOX to this pool.
 
 ### Privileges


### PR DESCRIPTION
*Description of changes:*

Now that https://github.com/ionos-cloud/cluster-api-provider-proxmox/pull/278 has been merged, we are able to restrict the rights of the CAPMOX API user much more. 

*Testing performed:*

We have tested this permission set extensively on our internal test cluster.

Unfortunately, it is not possible for me to create an end-to-end test as I do not have access to the end-to-end test infrastructure.