### PR TITLE
Add support for setting VLAN in network devices through config

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -91,6 +91,7 @@ GATEWAY: "10.10.10.1"                                         # The gateway for 
 IP_PREFIX: "25"                                               # Subnet Mask in CIDR notation for your node IP ranges
 DNS_SERVERS: "[8.8.8.8,8.8.4.4]"                              # The dns nameservers for the machines network-config.
 BRIDGE: "vmbr1"                                               # The network bridge device for Proxmox VE VMs
+VLAN: "2"                                                     # (optional) The VLAN to put the bridge device into
 
 ## -- xl nodes -- ##
 BOOT_VOLUME_DEVICE: "scsi0"                                   # The device used for the boot disk.

--- a/templates/cluster-class-calico.yaml
+++ b/templates/cluster-class-calico.yaml
@@ -982,6 +982,7 @@ spec:
         default:
           bridge: ${BRIDGE}
           model: virtio
+          vlan: ${VLAN:=null}
 ---
 kind: ProxmoxMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
@@ -998,6 +999,7 @@ spec:
         default:
           bridge: ${BRIDGE}
           model: virtio
+          vlan: ${VLAN:=null}
 ---
 kind: KubeadmConfigTemplate
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1

--- a/templates/cluster-class-cilium.yaml
+++ b/templates/cluster-class-cilium.yaml
@@ -982,6 +982,7 @@ spec:
         default:
           bridge: ${BRIDGE}
           model: virtio
+          vlan: ${VLAN:=null}
 ---
 kind: ProxmoxMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
@@ -998,6 +999,7 @@ spec:
         default:
           bridge: ${BRIDGE}
           model: virtio
+          vlan: ${VLAN:=null}
 ---
 kind: KubeadmConfigTemplate
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1

--- a/templates/cluster-template-calico.yaml
+++ b/templates/cluster-template-calico.yaml
@@ -186,6 +186,7 @@ spec:
         default:
           bridge: ${BRIDGE}
           model: virtio
+          vlan: ${VLAN:=null}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -238,6 +239,7 @@ spec:
         default:
           bridge: ${BRIDGE}
           model: virtio
+          vlan: ${VLAN:=null}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-cilium-load-balancer.yaml
+++ b/templates/cluster-template-cilium-load-balancer.yaml
@@ -234,10 +234,12 @@ spec:
         default:
           bridge: ${BRIDGE}
           model: virtio
+          vlan: ${VLAN:=null}
         additionalDevices:
         - name: net1
           bridge: ${SECONDARY_BRIDGE}
           model: virtio
+          vlan: ${SECONDARY_VLAN:=null}
           ipv4PoolRef:
             apiGroup: ipam.cluster.x-k8s.io
             kind: GlobalInClusterIPPool
@@ -295,10 +297,12 @@ spec:
         default:
           bridge: ${BRIDGE}
           model: virtio
+          vlan: ${VLAN:=null}
         additionalDevices:
         - name: net1
           bridge: ${SECONDARY_BRIDGE}
           model: virtio
+          vlan: ${SECONDARY_VLAN:=null}
           ipv4PoolRef:
             apiGroup: ipam.cluster.x-k8s.io
             kind: GlobalInClusterIPPool
@@ -355,10 +359,12 @@ spec:
         default:
           bridge: ${BRIDGE}
           model: virtio
+          vlan: ${VLAN:=null}
         additionalDevices:
         - name: net1
           bridge: ${SECONDARY_BRIDGE}
           model: virtio
+          vlan: ${SECONDARY_VLAN:=null}
           ipv4PoolRef:
             apiGroup: ipam.cluster.x-k8s.io
             kind: GlobalInClusterIPPool
@@ -367,6 +373,7 @@ spec:
         - name: net2
           bridge: ${EXT_SERVICE_BRIDGE}
           model: virtio
+          vlan: ${EXT_SERVICE_VLAN:=null}
           ipv4PoolRef:
             apiGroup: ipam.cluster.x-k8s.io
             kind: GlobalInClusterIPPool

--- a/templates/cluster-template-cilium.yaml
+++ b/templates/cluster-template-cilium.yaml
@@ -179,6 +179,7 @@ spec:
         default:
           bridge: ${BRIDGE}
           model: virtio
+          vlan: ${VLAN:=null}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -224,6 +225,7 @@ spec:
         default:
           bridge: ${BRIDGE}
           model: virtio
+          vlan: ${VLAN:=null}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-dual-stack.yaml
+++ b/templates/cluster-template-dual-stack.yaml
@@ -194,6 +194,7 @@ spec:
         default:
           bridge: ${BRIDGE}
           model: virtio
+          vlan: ${VLAN:=null}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -243,6 +244,7 @@ spec:
         default:
           bridge: ${BRIDGE}
           model: virtio
+          vlan: ${VLAN:=null}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-external-creds.yaml
+++ b/templates/cluster-template-external-creds.yaml
@@ -197,6 +197,7 @@ spec:
         default:
           bridge: ${BRIDGE}
           model: virtio
+          vlan: ${VLAN:=null}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -246,6 +247,7 @@ spec:
         default:
           bridge: ${BRIDGE}
           model: virtio
+          vlan: ${VLAN:=null}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/templates/cluster-template-multiple-vlans.yaml
+++ b/templates/cluster-template-multiple-vlans.yaml
@@ -193,10 +193,12 @@ spec:
         default:
           bridge: ${BRIDGE}
           model: virtio
+          vlan: ${VLAN:=null}
         additionalDevices:
         - name: net1
           bridge: ${SECONDARY_BRIDGE}
           model: virtio
+          vlan: ${SECONDARY_VLAN:=null}
           ipv4PoolRef:
             apiGroup: ipam.cluster.x-k8s.io
             kind: GlobalInClusterIPPool
@@ -251,10 +253,12 @@ spec:
         default:
           bridge: ${BRIDGE}
           model: virtio
+          vlan: ${VLAN:=null}
         additionalDevices:
         - name: net1
           bridge: ${SECONDARY_BRIDGE}
           model: virtio
+          vlan: ${SECONDARY_VLAN:=null}
           ipv4PoolRef:
             apiGroup: ipam.cluster.x-k8s.io
             kind: GlobalInClusterIPPool

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -184,6 +184,7 @@ spec:
         default:
           bridge: ${BRIDGE}
           model: virtio
+          vlan: ${VLAN:=null}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -233,6 +234,7 @@ spec:
         default:
           bridge: ${BRIDGE}
           model: virtio
+          vlan: ${VLAN:=null}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate


### PR DESCRIPTION
*Issue #, if available:* #303

*Description of changes:*

- Add `VLAN`, `SECONDARY_VLAN` and `EXT_SERVICE_VLAN` variables to the template to configure VLAN on the network devices

*Testing performed:*

- Tested generation of template with and without `VLAN` set: Expected behavior, without ENV-var a `kubectl describe` shows no configured `vlan`, with `VLAN` set to `2` it shows `vlan: 2`.
