### PR TITLE
Improve docker build workflow in forks

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Generate downcase repository name
         run: |
-          echo "REPO=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
+          echo "REPO=${GITHUB_REPOSITORY,,}" >> "${GITHUB_ENV}"
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -25,11 +25,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
 
+      - name: Generate downcase repository name
+        run: |
+          echo "REPO=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/ionos-cloud/cluster-api-provider-proxmox
+          images: ghcr.io/${{ env.REPO }}
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
 
-      - name: Generate downcase repository name
+      - name: Generate lowercase repository name
         run: |
           echo "REPO=${GITHUB_REPOSITORY,,}" >> "${GITHUB_ENV}"
 


### PR DESCRIPTION
*Description of changes:*
When forking the repository for development purposes, the github action workflow inside the fork will try upload the built image to ghcr.io/**ionos-cloud**/cluster-api-provider-proxmox, which results in a permission error: `ERROR: denied: permission_denied: The requested installation does not exist.`

This can be avoided by instead of having a hardcoded image name in the workflow, one dynamically takes the GITHUB_REPOSITORY variable and converts it into lowercase (for those who have Github usernames with one or more capital letters). Consequentially, every fork will push to its own registry without permission issues, while the main repository keeps working just like before.

*Testing performed:*
Verified workflow in my fork. It manages to publish ghcr images to my fork/registry.
