### PR TITLE
Add securityContext.seccompProfile.type: RuntimeDefault to manager deployment to meet restricted Pod security profile

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -39,6 +39,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - args:
         - --leader-elect


### PR DESCRIPTION
*Description of changes:*

The current `securityContext` of the `manager` deployment doesn't meet the Pod Security Profile "restricted", which makes it impossible to run in "restricted" namespaces.

The `cluster-api` deployments also set this value, for example [here](https://github.com/kubernetes-sigs/cluster-api/blob/2a7d61df5924f714f4271caa677e4a0a9f529da6/config/manager/manager.yaml#L76) 

*Testing performed:*

With this change implemented, a deployment to a 'restricted' namespace will be successful. It shouldn't change the current behaviour for non-restricted namespaces.