### PR TITLE
feat: Add fail-fast behavior to Ginkgo in test-e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,7 @@ test-e2e: $(ENVSUBST) $(KUBECTL) $(GINKGO) e2e-image ## Run the end-to-end tests
 	$(ENVSUBST) < $(E2E_CONF_FILE) > $(E2E_CONF_FILE_ENVSUBST) && \
 	time $(GINKGO) -v --trace -poll-progress-after=$(GINKGO_POLL_PROGRESS_AFTER) -poll-progress-interval=$(GINKGO_POLL_PROGRESS_INTERVAL) \
 	--tags=e2e --focus="$(GINKGO_FOCUS)" -skip="$(GINKGO_SKIP)" --nodes=$(GINKGO_NODES) --no-color=$(GINKGO_NOCOLOR) \
-	--timeout=$(GINKGO_TIMEOUT) --output-dir="$(ARTIFACTS)" --junit-report="junit.e2e_suite.1.xml" $(GINKGO_ARGS) ./test/e2e -- \
+	--timeout=$(GINKGO_TIMEOUT) --output-dir="$(ARTIFACTS)" --junit-report="junit.e2e_suite.1.xml" --fail-fast  $(GINKGO_ARGS) ./test/e2e -- \
 		-e2e.artifacts-folder="$(ARTIFACTS)" \
 		-e2e.config="$(E2E_CONF_FILE_ENVSUBST)" \
 		-e2e.skip-resource-cleanup=$(SKIP_CLEANUP) \


### PR DESCRIPTION

in regards to the follwing issue:
[https://github.com/ionos-cloud/cluster-api-provider-proxmox/issues/194](url)

What was changed: Describe the specific change:

    Added --fail-fast to the Ginkgo command in the test-e2e target of the Makefile.
    Ensures the e2e test suite halts immediately upon encountering a failure.

Why the change was made:

    Saves compute resources and time by stopping further tests when a failure is detected.



Further information about the --fail-fast flag can be found here: [https://onsi.github.io/ginkgo/](url)
