### PR TITLE
Add kubernetes-version/injectKubernetesVersion to Metadata

### DIFF
--- a/internal/inject/inject_test.go
+++ b/internal/inject/inject_test.go
@@ -91,7 +91,7 @@ func TestISOInjectorInjectCloudInit(t *testing.T) {
 	injector := &ISOInjector{
 		VirtualMachine: vm,
 		BootstrapData:  []byte(""),
-		MetaRenderer:   cloudinit.NewMetadata("xxx-xxxx", "my-custom-vm", true),
+		MetaRenderer:   cloudinit.NewMetadata("xxx-xxxx", "my-custom-vm", "1.2.3", true),
 		NetworkRenderer: cloudinit.NewNetworkConfig([]cloudinit.NetworkConfigData{
 			{
 				Name:       "eth0",
@@ -135,7 +135,7 @@ func TestISOInjectorInjectCloudInit_Errors(t *testing.T) {
 	injector := &ISOInjector{
 		VirtualMachine: vm,
 		BootstrapData:  []byte(""),
-		MetaRenderer:   cloudinit.NewMetadata("xxx-xxxx", "", true),
+		MetaRenderer:   cloudinit.NewMetadata("xxx-xxxx", "", "", true),
 		NetworkRenderer: cloudinit.NewNetworkConfig([]cloudinit.NetworkConfigData{
 			{
 				Name:       "eth0",
@@ -151,7 +151,7 @@ func TestISOInjectorInjectCloudInit_Errors(t *testing.T) {
 	require.Error(t, err)
 
 	// missing network
-	injector.MetaRenderer = cloudinit.NewMetadata("xxx-xxxx", "my-custom-vm", false)
+	injector.MetaRenderer = cloudinit.NewMetadata("xxx-xxxx", "my-custom-vm", "1.2.3", false)
 	injector.NetworkRenderer = cloudinit.NewNetworkConfig(nil)
 	err = injector.Inject(context.Background(), "cloudinit")
 	require.Error(t, err)
@@ -200,7 +200,7 @@ func TestISOInjectorInjectIgnition(t *testing.T) {
 	injector := &ISOInjector{
 		VirtualMachine:   vm,
 		BootstrapData:    []byte(bootstrapData),
-		MetaRenderer:     cloudinit.NewMetadata("xxx-xxxx", "my-custom-vm", false),
+		MetaRenderer:     cloudinit.NewMetadata("xxx-xxxx", "my-custom-vm", "1.2.3", false),
 		IgnitionEnricher: enricher,
 	}
 
@@ -260,14 +260,14 @@ func TestISOInjectorInjectIgnition_Errors(t *testing.T) {
 	require.Error(t, err)
 
 	// missing hostname
-	injector.MetaRenderer = cloudinit.NewMetadata("xxxx-xxxxx", "", false)
+	injector.MetaRenderer = cloudinit.NewMetadata("xxxx-xxxxx", "", "1.2.3", false)
 	e.BootstrapData = []byte(bootstrapData)
 	err = injector.Inject(context.Background(), "ignition")
 	require.Error(t, err)
 
 	// no bootstrapdata
 	e.BootstrapData = nil
-	injector.MetaRenderer = cloudinit.NewMetadata("xxxx-xxxxx", "my-custom-vm", true)
+	injector.MetaRenderer = cloudinit.NewMetadata("xxxx-xxxxx", "my-custom-vm", "1.2.3", true)
 	injector.BootstrapData = []byte("invalid")
 	err = injector.Inject(context.Background(), "ignition")
 	require.Error(t, err)
@@ -292,7 +292,7 @@ func TestISOInjectorInject_Unsupported(t *testing.T) {
 	injector := &ISOInjector{
 		VirtualMachine: vm,
 		BootstrapData:  []byte(""),
-		MetaRenderer:   cloudinit.NewMetadata("xxx-xxxx", "", false),
+		MetaRenderer:   cloudinit.NewMetadata("xxx-xxxx", "", "1.2.3", false),
 		NetworkRenderer: cloudinit.NewNetworkConfig([]cloudinit.NetworkConfigData{
 			{
 				Name:       "eth0",

--- a/internal/service/vmservice/bootstrap.go
+++ b/internal/service/vmservice/bootstrap.go
@@ -119,7 +119,7 @@ func injectIgnition(ctx context.Context, machineScope *scope.MachineScope, boots
 		Network:       nicData,
 	}
 
-	injector := ignitionISOInjector(machineScope.VirtualMachine, metadata, enricher)
+	injector := getIgnitionISOInjector(machineScope.VirtualMachine, metadata, enricher)
 	if err := injector.Inject(ctx, inject.IgnitionFormat); err != nil {
 		conditions.MarkFalse(machineScope.ProxmoxMachine, infrav1alpha1.VMProvisionedCondition, infrav1alpha1.VMProvisionFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
 		return errors.Wrap(err, "ignition iso inject failed")
@@ -140,7 +140,7 @@ func defaultISOInjector(vm *proxmox.VirtualMachine, bootStrapData []byte, metada
 	}
 }
 
-func ignitionISOInjector(vm *proxmox.VirtualMachine, metadata cloudinit.Renderer, enricher *ignition.Enricher) isoInjector {
+func defaultIgnitionISOInjector(vm *proxmox.VirtualMachine, metadata cloudinit.Renderer, enricher *ignition.Enricher) isoInjector {
 	return &inject.ISOInjector{
 		VirtualMachine:   vm,
 		IgnitionEnricher: enricher,
@@ -148,7 +148,10 @@ func ignitionISOInjector(vm *proxmox.VirtualMachine, metadata cloudinit.Renderer
 	}
 }
 
-var getISOInjector = defaultISOInjector
+var (
+	getISOInjector         = defaultISOInjector
+	getIgnitionISOInjector = defaultIgnitionISOInjector
+)
 
 // getBootstrapData obtains a machine's bootstrap data from the relevant K8s secret and returns the data.
 // TODO: Add format return if ignition will be supported.

--- a/internal/service/vmservice/bootstrap_test.go
+++ b/internal/service/vmservice/bootstrap_test.go
@@ -500,14 +500,14 @@ func TestReconcileBootstrapDataMissingNetworkConfig(t *testing.T) {
 }
 
 func TestDefaultISOInjector(t *testing.T) {
-	injector := defaultISOInjector(newRunningVM(), []byte("data"), cloudinit.NewMetadata(biosUUID, "test", true), cloudinit.NewNetworkConfig(nil))
+	injector := defaultISOInjector(newRunningVM(), []byte("data"), cloudinit.NewMetadata(biosUUID, "test", "1.2.3", true), cloudinit.NewNetworkConfig(nil))
 
 	require.NotEmpty(t, injector)
 	require.Equal(t, []byte("data"), injector.(*inject.ISOInjector).BootstrapData)
 }
 
 func TestIgnitionISOInjector(t *testing.T) {
-	injector := ignitionISOInjector(newRunningVM(), cloudinit.NewMetadata(biosUUID, "test", true), &ignition.Enricher{
+	injector := ignitionISOInjector(newRunningVM(), cloudinit.NewMetadata(biosUUID, "test", "1.2.3", true), &ignition.Enricher{
 		BootstrapData: []byte("data"),
 		Hostname:      "test",
 	})

--- a/internal/service/vmservice/bootstrap_test.go
+++ b/internal/service/vmservice/bootstrap_test.go
@@ -540,7 +540,7 @@ func TestDefaultISOInjector(t *testing.T) {
 }
 
 func TestIgnitionISOInjector(t *testing.T) {
-	injector := ignitionISOInjector(newRunningVM(), cloudinit.NewMetadata(biosUUID, "test", "1.2.3", true), &ignition.Enricher{
+	injector := defaultIgnitionISOInjector(newRunningVM(), cloudinit.NewMetadata(biosUUID, "test", "1.2.3", true), &ignition.Enricher{
 		BootstrapData: []byte("data"),
 		Hostname:      "test",
 	})

--- a/pkg/cloudinit/metadata.go
+++ b/pkg/cloudinit/metadata.go
@@ -23,6 +23,9 @@ hostname: {{ .Hostname }}
 {{- if .ProviderIDInjection }}
 provider-id: proxmox://{{ .InstanceID }}
 {{- end }}
+{{- if .KubernetesVersion }}
+kubernetes-version: {{ .KubernetesVersion }}
+{{- end }}
 `
 )
 
@@ -32,11 +35,12 @@ type Metadata struct {
 }
 
 // NewMetadata returns a new Metadata object.
-func NewMetadata(instanceID, hostname string, injectProviderID bool) *Metadata {
+func NewMetadata(instanceID, hostname string, kubernetesVersion string, injectProviderID bool) *Metadata {
 	ci := new(Metadata)
 	ci.data = BaseCloudInitData{
 		Hostname:            hostname,
 		InstanceID:          instanceID,
+		KubernetesVersion:   kubernetesVersion,
 		ProviderIDInjection: injectProviderID,
 	}
 	return ci

--- a/pkg/cloudinit/metadata_test.go
+++ b/pkg/cloudinit/metadata_test.go
@@ -27,18 +27,26 @@ const (
 local-hostname: proxmox-control-plane
 hostname: proxmox-control-plane
 provider-id: proxmox://9a82e2ca-4294-11ee-be56-0242ac120002
+kubernetes-version: 1.2.3
 `
 	expectedValidMetadataWithoutProviderID = `instance-id: 9a82e2ca-4294-11ee-be56-0242ac120002
 local-hostname: proxmox-control-plane
 hostname: proxmox-control-plane
+kubernetes-version: 1.2.3
+`
+	expectedValidMetadataWithoutKubernetesVersion = `instance-id: 9a82e2ca-4294-11ee-be56-0242ac120002
+local-hostname: proxmox-control-plane
+hostname: proxmox-control-plane
+provider-id: proxmox://9a82e2ca-4294-11ee-be56-0242ac120002
 `
 )
 
 func TestMetadata_Render(t *testing.T) {
 	type args struct {
-		instanceID       string
-		hostname         string
-		injectProviderID bool
+		instanceID        string
+		hostname          string
+		kubernetesVersion string
+		injectProviderID  bool
 	}
 
 	type want struct {
@@ -54,9 +62,10 @@ func TestMetadata_Render(t *testing.T) {
 		"ValidCloudinit": {
 			reason: "rendering metadata",
 			args: args{
-				instanceID:       "9a82e2ca-4294-11ee-be56-0242ac120002",
-				hostname:         "proxmox-control-plane",
-				injectProviderID: true,
+				instanceID:        "9a82e2ca-4294-11ee-be56-0242ac120002",
+				hostname:          "proxmox-control-plane",
+				kubernetesVersion: "1.2.3",
+				injectProviderID:  true,
 			},
 			want: want{
 				metadata: expectedValidMetadata,
@@ -84,12 +93,26 @@ func TestMetadata_Render(t *testing.T) {
 		"ValidCloudinitwithoutProviderID": {
 			reason: "rendering metadata if providerID is not injected",
 			args: args{
-				instanceID:       "9a82e2ca-4294-11ee-be56-0242ac120002",
-				hostname:         "proxmox-control-plane",
-				injectProviderID: false,
+				instanceID:        "9a82e2ca-4294-11ee-be56-0242ac120002",
+				hostname:          "proxmox-control-plane",
+				kubernetesVersion: "1.2.3",
+				injectProviderID:  false,
 			},
 			want: want{
 				metadata: expectedValidMetadataWithoutProviderID,
+				err:      nil,
+			},
+		},
+		"ValidCloudinitwithoutKubernetesVersion": {
+			reason: "rendering metadata if kubernetesVersion is not provided",
+			args: args{
+				instanceID:        "9a82e2ca-4294-11ee-be56-0242ac120002",
+				hostname:          "proxmox-control-plane",
+				kubernetesVersion: "",
+				injectProviderID:  true,
+			},
+			want: want{
+				metadata: expectedValidMetadataWithoutKubernetesVersion,
 				err:      nil,
 			},
 		},
@@ -97,7 +120,7 @@ func TestMetadata_Render(t *testing.T) {
 
 	for n, tc := range cases {
 		t.Run(n, func(t *testing.T) {
-			ci := NewMetadata(tc.args.instanceID, tc.args.hostname, tc.args.injectProviderID)
+			ci := NewMetadata(tc.args.instanceID, tc.args.hostname, tc.args.kubernetesVersion, tc.args.injectProviderID)
 			metadata, err := ci.Render()
 			require.ErrorIs(t, err, tc.want.err)
 			require.Equal(t, tc.want.metadata, string(metadata))

--- a/pkg/cloudinit/types.go
+++ b/pkg/cloudinit/types.go
@@ -26,6 +26,7 @@ const (
 type BaseCloudInitData struct {
 	Hostname            string
 	InstanceID          string
+	KubernetesVersion   string
 	ProviderIDInjection bool
 	NetworkConfigData   []NetworkConfigData
 }

--- a/pkg/ignition/enrich.go
+++ b/pkg/ignition/enrich.go
@@ -32,11 +32,12 @@ import (
 
 // Enricher is responsible for enriching the Ignition config with additional data.
 type Enricher struct {
-	BootstrapData []byte
-	Hostname      string
-	InstanceID    string
-	ProviderID    string
-	Network       []cloudinit.NetworkConfigData
+	BootstrapData     []byte
+	Hostname          string
+	InstanceID        string
+	ProviderID        string
+	Network           []cloudinit.NetworkConfigData
+	KubernetesVersion string
 }
 
 // Enrich enriches the Ignition config with additional data.


### PR DESCRIPTION
*Description of changes:*

It would be very helpful to have access to the Kubernetes version specified in a machine's `spec.version` in the cloud-init/ignition metadata. With this information, it is possible to install Kubernetes version specific resources in cloud-init/ignition.

I used [this PR](https://github.com/ionos-cloud/cluster-api-provider-proxmox/pull/347) as a template, but I'm not sure if the way to control the injection is particularly elegant.
I would suggest injecting the field without a flag in the default or always passing the value of `MetadataSettings` completely to `cloudinit.NewMetadata` so that you don't have to add another argument for each flag.
I would be very happy to receive feedback from the maintainers on this suggestion and would then also carry out the desired implementation.

*Testing performed:*

We have tested this with the following `preKubeadmCommands`:

```yaml
      - MINOR_KUBERNETES_VERSION=$(echo {{ '{{ ds.meta_data.kubernetes_version }}' }} | cut -d. -f1-2 )
      - curl -fsSL https://pkgs.k8s.io/core:/stable:/${MINOR_KUBERNETES_VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
      - echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${MINOR_KUBERNETES_VERSION}/deb/ /" > /etc/apt/sources.list.d/kubernetes.list
      - apt-get update -y
      - TRIMMED_KUBERNETES_VERSION=$(echo {{ '{{ ds.meta_data.kubernetes_version }}' }} | sed 's/\./\\\\./g' | sed 's/^v//')
      - RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
      - apt-get install -y kubelet=${RESOLVED_KUBERNETES_VERSION} kubeadm=${RESOLVED_KUBERNETES_VERSION} kubectl=${RESOLVED_KUBERNETES_VERSION}
      - apt-mark hold kubelet kubeadm kubectl
```