### PR TITLE
🌱  Refactoring: move NetworkConfigData out of cloudinit pkg

### DIFF
--- a/internal/inject/inject_test.go
+++ b/internal/inject/inject_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/cloudinit"
 	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/ignition"
 	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/proxmox/goproxmox"
+	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/types"
 )
 
 const (
@@ -92,7 +93,7 @@ func TestISOInjectorInjectCloudInit(t *testing.T) {
 		VirtualMachine: vm,
 		BootstrapData:  []byte(""),
 		MetaRenderer:   cloudinit.NewMetadata("xxx-xxxx", "my-custom-vm", "1.2.3", true),
-		NetworkRenderer: cloudinit.NewNetworkConfig([]cloudinit.NetworkConfigData{
+		NetworkRenderer: cloudinit.NewNetworkConfig([]types.NetworkConfigData{
 			{
 				Name:       "eth0",
 				IPAddress:  "10.1.1.6/24",
@@ -136,7 +137,7 @@ func TestISOInjectorInjectCloudInit_Errors(t *testing.T) {
 		VirtualMachine: vm,
 		BootstrapData:  []byte(""),
 		MetaRenderer:   cloudinit.NewMetadata("xxx-xxxx", "", "", true),
-		NetworkRenderer: cloudinit.NewNetworkConfig([]cloudinit.NetworkConfigData{
+		NetworkRenderer: cloudinit.NewNetworkConfig([]types.NetworkConfigData{
 			{
 				Name:       "eth0",
 				IPAddress:  "10.1.1.6/24",
@@ -187,7 +188,7 @@ func TestISOInjectorInjectIgnition(t *testing.T) {
 		Hostname:      "my-custom-vm",
 		InstanceID:    "xxxx-xxx",
 		ProviderID:    "proxmox://xxxx-xxx",
-		Network: []cloudinit.NetworkConfigData{
+		Network: []types.NetworkConfigData{
 			{
 				Name:       "eth0",
 				IPAddress:  "10.1.1.6/24",
@@ -239,7 +240,7 @@ func TestISOInjectorInjectIgnition_Errors(t *testing.T) {
 		Hostname:      "my-custom-vm",
 		InstanceID:    "xxxx-xxx",
 		ProviderID:    "proxmox://xxxx-xxx",
-		Network: []cloudinit.NetworkConfigData{
+		Network: []types.NetworkConfigData{
 			{
 				Name:       "eth0",
 				IPAddress:  "10.1.1.9/24",
@@ -293,7 +294,7 @@ func TestISOInjectorInject_Unsupported(t *testing.T) {
 		VirtualMachine: vm,
 		BootstrapData:  []byte(""),
 		MetaRenderer:   cloudinit.NewMetadata("xxx-xxxx", "", "1.2.3", false),
-		NetworkRenderer: cloudinit.NewNetworkConfig([]cloudinit.NetworkConfigData{
+		NetworkRenderer: cloudinit.NewNetworkConfig([]types.NetworkConfigData{
 			{
 				Name:       "eth0",
 				IPAddress:  "10.1.1.6/24",

--- a/internal/service/vmservice/bootstrap_test.go
+++ b/internal/service/vmservice/bootstrap_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/cloudinit"
 	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/ignition"
 	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/scope"
+	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/types"
 )
 
 const (
@@ -221,7 +222,7 @@ func TestGetCommonInterfaceConfig_MissingIPPool(t *testing.T) {
 		},
 	}
 
-	cfg := &cloudinit.NetworkConfigData{Name: "net1"}
+	cfg := &types.NetworkConfigData{Name: "net1"}
 	err := getCommonInterfaceConfig(context.Background(), machineScope, cfg, machineScope.ProxmoxMachine.Spec.Network.AdditionalDevices[0].InterfaceConfig)
 	require.Error(t, err)
 }
@@ -238,7 +239,7 @@ func TestGetCommonInterfaceConfig_NoIPAddresses(t *testing.T) {
 		},
 	}
 
-	cfg := &cloudinit.NetworkConfigData{Name: "net1"}
+	cfg := &types.NetworkConfigData{Name: "net1"}
 	err := getCommonInterfaceConfig(context.Background(), machineScope, cfg, machineScope.ProxmoxMachine.Spec.Network.AdditionalDevices[0].InterfaceConfig)
 	require.NoError(t, err)
 }
@@ -288,7 +289,7 @@ func TestGetCommonInterfaceConfig(t *testing.T) {
 	createIP4AddressResource(t, kubeClient, machineScope, "net1", "10.0.0.10")
 	createIP6AddressResource(t, kubeClient, machineScope, "net1", "2001:db8::9")
 
-	cfg := &cloudinit.NetworkConfigData{Name: "net1"}
+	cfg := &types.NetworkConfigData{Name: "net1"}
 	err := getCommonInterfaceConfig(context.Background(), machineScope, cfg, machineScope.ProxmoxMachine.Spec.Network.AdditionalDevices[0].InterfaceConfig)
 	require.Equal(t, "10.0.0.10/24", cfg.IPAddress)
 	require.Equal(t, "2001:db8::9/64", cfg.IPV6Address)
@@ -313,7 +314,7 @@ func TestGetVirtualNetworkDevices_VRFDevice_MissingInterface(t *testing.T) {
 			}},
 		},
 	}
-	networkConfigData := []cloudinit.NetworkConfigData{{}}
+	networkConfigData := []types.NetworkConfigData{{}}
 
 	cfg, err := getVirtualNetworkDevices(context.Background(), machineScope, networkSpec, networkConfigData)
 	require.Error(t, err)

--- a/pkg/cloudinit/network.go
+++ b/pkg/cloudinit/network.go
@@ -18,6 +18,8 @@ package cloudinit
 
 import (
 	"net/netip"
+
+	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/types"
 )
 
 const (
@@ -152,7 +154,7 @@ type NetworkConfig struct {
 }
 
 // NewNetworkConfig returns a new NetworkConfig object.
-func NewNetworkConfig(configs []NetworkConfigData) *NetworkConfig {
+func NewNetworkConfig(configs []types.NetworkConfigData) *NetworkConfig {
 	nc := new(NetworkConfig)
 	nc.data = BaseCloudInitData{
 		NetworkConfigData: configs,
@@ -249,7 +251,7 @@ func (r *NetworkConfig) validate() error {
 	return nil
 }
 
-func validRoutes(input []RoutingData) error {
+func validRoutes(input []types.RoutingData) error {
 	if len(input) == 0 {
 		return nil
 	}
@@ -273,7 +275,7 @@ func validRoutes(input []RoutingData) error {
 	return nil
 }
 
-func validFIBRules(input []FIBRuleData, isVrf bool) error {
+func validFIBRules(input []types.FIBRuleData, isVrf bool) error {
 	if len(input) == 0 {
 		return nil
 	}

--- a/pkg/cloudinit/network_test.go
+++ b/pkg/cloudinit/network_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
+
+	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/types"
 )
 
 const (
@@ -419,7 +421,7 @@ const (
 
 func TestNetworkConfig_Render(t *testing.T) {
 	type args struct {
-		nics []NetworkConfigData
+		nics []types.NetworkConfigData
 	}
 
 	type want struct {
@@ -435,7 +437,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"ValidStaticNetworkConfig": {
 			reason: "render valid network-config with static ip",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "ethernet",
 						Name:       "eth0",
@@ -455,7 +457,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"ValidStaticNetworkConfigWithLinkMTU": {
 			reason: "render valid network-config with static ip and mtu",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "ethernet",
 						Name:       "eth0",
@@ -476,7 +478,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"ValidStaticNetworkConfigWithDHCP": {
 			reason: "render valid network-config with ipv6 static ip and dhcp",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "ethernet",
 						Name:       "eth0",
@@ -497,7 +499,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"ValidStaticNetworkConfigIPWithDHCP": {
 			reason: "render valid network-config with ipv6 static ip and dhcp",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "ethernet",
 						Name:       "eth0",
@@ -518,7 +520,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"ValidStaticNetworkConfigWithRoutes": {
 			reason: "render valid network-config with ipv6 static ip and dhcp and routes",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "ethernet",
 						Name:       "eth0",
@@ -535,7 +537,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 						IPAddress:  "10.10.11.12/24",
 						Gateway:    "10.10.11.1",
 						Metric:     ptr.To(uint32(200)),
-						Routes: []RoutingData{{
+						Routes: []types.RoutingData{{
 							To:     "172.16.24.1/24",
 							Metric: 50,
 							Via:    "10.10.10.254",
@@ -555,7 +557,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"ValidStaticNetworkConfigWithFIBRules": {
 			reason: "render valid network-config with FIB rules/routing policy",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "ethernet",
 						Name:       "eth0",
@@ -572,7 +574,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Gateway:    "10.10.11.1",
 						Metric:     ptr.To(uint32(200)),
 						MacAddress: "92:60:a0:5b:22:c3",
-						FIBRules: []FIBRuleData{{
+						FIBRules: []types.FIBRuleData{{
 							To:       "0.0.0.0/0",
 							From:     "192.168.178.1/24",
 							Priority: 999,
@@ -590,7 +592,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"InvalidNetworkConfigIp": {
 			reason: "ip address is not set",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "ethernet",
 						Name:       "eth0",
@@ -609,7 +611,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"InvalidNetworkConfigMalformedIp": {
 			reason: "malformed ip address",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "ethernet",
 						Name:       "eth0",
@@ -629,7 +631,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"InvalidNetworkConfigMalformedIP": {
 			reason: "ip address malformed",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "ethernet",
 						Name:       "eth0",
@@ -649,7 +651,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"InvalidNetworkConfigGW": {
 			reason: "gw is not set",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "ethernet",
 						Name:       "eth0",
@@ -668,7 +670,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"InvalidNetworkConfigMacAddress": {
 			reason: "macaddress is not set",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "ethernet",
 						Name:       "eth0",
@@ -687,7 +689,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"InvalidNetworkConfigConflictingMetrics": {
 			reason: "metric already exists for default gateway",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "ethernet",
 						Name:       "eth0",
@@ -715,7 +717,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"ValidNetworkConfigWithoutDNS": {
 			reason: "valid config without dns",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "ethernet",
 						Name:       "eth0",
@@ -734,7 +736,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"ValidNetworkConfigMultipleNics": {
 			reason: "valid config multiple nics",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "ethernet",
 						Name:       "eth0",
@@ -763,7 +765,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"InvalidNetworkConfigData": {
 			reason: "invalid config missing network config data",
 			args: args{
-				nics: []NetworkConfigData{},
+				nics: []types.NetworkConfigData{},
 			},
 			want: want{
 				network: "",
@@ -773,7 +775,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"ValidNetworkConfigDualStack": {
 			reason: "render valid network-config",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:        "ethernet",
 						Name:        "eth0",
@@ -796,7 +798,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"ValidNetworkConfigIPV6": {
 			reason: "render valid ipv6 network-config",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:        "ethernet",
 						Name:        "eth0",
@@ -816,7 +818,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"ValidNetworkConfigDHCP": {
 			reason: "render valid network-config with dhcp",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "ethernet",
 						Name:       "eth0",
@@ -835,7 +837,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"ValidNetworkConfigDHCP4": {
 			reason: "render valid network-config with dhcp",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "ethernet",
 						Name:       "eth0",
@@ -854,7 +856,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"ValidNetworkConfigDHCP6": {
 			reason: "render valid network-config with dhcp",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "ethernet",
 						Name:       "eth0",
@@ -873,7 +875,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"ValidNetworkConfigMultipleNicsVRF": {
 			reason: "valid config multiple nics enslaved to VRF",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "ethernet",
 						Name:       "eth0",
@@ -897,7 +899,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Name:       "vrf-blue",
 						Table:      500,
 						Interfaces: []string{"eth0", "eth1"},
-						Routes: []RoutingData{{
+						Routes: []types.RoutingData{{
 							To:     "default",
 							Via:    "192.168.178.1",
 							Metric: 100,
@@ -907,7 +909,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 							Via:    "192.168.178.254",
 							Metric: 100,
 						}},
-						FIBRules: []FIBRuleData{{
+						FIBRules: []types.FIBRuleData{{
 							To:       "0.0.0.0/0",
 							From:     "192.168.178.1/24",
 							Priority: 999,
@@ -924,7 +926,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"ValidNetworkConfigMultipleNicsMultipleVRF": {
 			reason: "valid config multiple nics enslaved to multiple VRFs",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "ethernet",
 						Name:       "eth0",
@@ -948,7 +950,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Name:       "vrf-blue",
 						Table:      500,
 						Interfaces: []string{"eth0"},
-						Routes: []RoutingData{{
+						Routes: []types.RoutingData{{
 							To:     "default",
 							Via:    "192.168.178.1",
 							Metric: 100,
@@ -958,7 +960,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 							Via:    "192.168.178.254",
 							Metric: 100,
 						}},
-						FIBRules: []FIBRuleData{{
+						FIBRules: []types.FIBRuleData{{
 							To:       "0.0.0.0/0",
 							From:     "192.168.178.1/24",
 							Priority: 999,
@@ -970,7 +972,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Name:       "vrf-red",
 						Table:      501,
 						Interfaces: []string{"eth1"},
-						FIBRules: []FIBRuleData{{
+						FIBRules: []types.FIBRuleData{{
 							To:       "0.0.0.0/0",
 							From:     "192.168.100.0/24",
 							Priority: 999,
@@ -987,12 +989,12 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"ValidNetworkConfigValidFIBRule": {
 			reason: "valid config valid routing policy",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:  "vrf",
 						Name:  "vrf-blue",
 						Table: 500,
-						FIBRules: []FIBRuleData{{
+						FIBRules: []types.FIBRuleData{{
 							From: "10.10.0.0/16",
 						}},
 					},
@@ -1006,13 +1008,13 @@ func TestNetworkConfig_Render(t *testing.T) {
 		"InvalidNetworkConfigMalformedFIBRule": {
 			reason: "invalid config malformed routing policy",
 			args: args{
-				nics: []NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:       "vrf",
 						Name:       "vrf-blue",
 						Table:      500,
 						Interfaces: []string{"eth0", "eth1"},
-						Routes: []RoutingData{{
+						Routes: []types.RoutingData{{
 							Table: 100,
 						}},
 					},

--- a/pkg/cloudinit/types.go
+++ b/pkg/cloudinit/types.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package cloudinit
 
+import "github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/types"
+
 const (
 	// FormatCloudConfig is the format for cloud-config.
 	FormatCloudConfig = "cloud-config"
@@ -28,44 +30,5 @@ type BaseCloudInitData struct {
 	InstanceID          string
 	KubernetesVersion   string
 	ProviderIDInjection bool
-	NetworkConfigData   []NetworkConfigData
-}
-
-// NetworkConfigData is used to render network-config.
-type NetworkConfigData struct {
-	ProxName    string // Device name in Proxmox
-	MacAddress  string
-	DHCP4       bool
-	DHCP6       bool
-	IPAddress   string
-	IPV6Address string
-	Gateway     string
-	Metric      *uint32
-	Gateway6    string
-	Metric6     *uint32
-	DNSServers  []string
-	Type        string
-	Name        string
-	Interfaces  []string // Interfaces controlled by this one.
-	Table       uint32   // linux routing table number for VRF.
-	Routes      []RoutingData
-	FIBRules    []FIBRuleData // Forwarding information block for routing.
-	LinkMTU     *uint16       // linux network device MTU
-	VRF         string        // linux VRF name // only used in networkd config.
-}
-
-// RoutingData stores routing configuration.
-type RoutingData struct {
-	To     string
-	Via    string
-	Metric uint32
-	Table  uint32
-}
-
-// FIBRuleData stores forward information base rules (routing policies).
-type FIBRuleData struct {
-	To       string
-	From     string
-	Priority uint32
-	Table    uint32
+	NetworkConfigData   []types.NetworkConfigData
 }

--- a/pkg/ignition/enrich.go
+++ b/pkg/ignition/enrich.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
 
-	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/cloudinit"
+	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/types"
 )
 
 // Enricher is responsible for enriching the Ignition config with additional data.
@@ -36,7 +36,7 @@ type Enricher struct {
 	Hostname          string
 	InstanceID        string
 	ProviderID        string
-	Network           []cloudinit.NetworkConfigData
+	Network           []types.NetworkConfigData
 	KubernetesVersion string
 }
 
@@ -96,7 +96,7 @@ func (e *Enricher) getEnrichConfig() (*ignitionTypes.Config, error) {
 	}
 
 	// populate networkd units
-	nets, err := RenderNetworkConfigData(cloudinit.BaseCloudInitData{NetworkConfigData: e.Network})
+	nets, err := RenderNetworkConfigData(e.Network)
 	if err != nil {
 		return nil, errors.Wrap(err, "rendering networkd units")
 	}

--- a/pkg/ignition/enrich_test.go
+++ b/pkg/ignition/enrich_test.go
@@ -6,7 +6,7 @@ import (
 	ignition "github.com/flatcar/ignition/config/v2_3"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/cloudinit"
+	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/types"
 )
 
 func TestEnricher_Enrich(t *testing.T) {
@@ -58,7 +58,7 @@ func TestEnricher_Enrich(t *testing.T) {
 		Hostname:      "my-custom-vm",
 		InstanceID:    "xxxx-xxx",
 		ProviderID:    "proxmox://xxxx-xxx",
-		Network: []cloudinit.NetworkConfigData{
+		Network: []types.NetworkConfigData{
 			{
 				Name:        "eth0",
 				IPAddress:   "10.1.1.9/24",

--- a/pkg/ignition/network_test.go
+++ b/pkg/ignition/network_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 
-	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/cloudinit"
+	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/types"
 )
 
 var (
@@ -110,7 +110,7 @@ Table=644
 
 func TestRenderNetworkConfigData(t *testing.T) {
 	type args struct {
-		nics []cloudinit.NetworkConfigData
+		nics []types.NetworkConfigData
 	}
 
 	type want struct {
@@ -126,7 +126,7 @@ func TestRenderNetworkConfigData(t *testing.T) {
 		"ValidNetworkdConfig": {
 			reason: "render valid networkd with static ip",
 			args: args{
-				nics: []cloudinit.NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:        "ethernet",
 						Name:        "eth0",
@@ -148,7 +148,7 @@ func TestRenderNetworkConfigData(t *testing.T) {
 						ProxName:   "net1",
 						DNSServers: []string{"10.0.1.1"},
 						Metric:     ptr.To(uint32(200)),
-						FIBRules: []cloudinit.FIBRuleData{{
+						FIBRules: []types.FIBRuleData{{
 							To:       "8.7.6.5/32",
 							From:     "1.1.1.1/32",
 							Priority: 100,
@@ -165,7 +165,7 @@ func TestRenderNetworkConfigData(t *testing.T) {
 		"ValidNetworkdConfigWithVRFPolicies": {
 			reason: "render valid networkd with static ip and VRF and policies",
 			args: args{
-				nics: []cloudinit.NetworkConfigData{
+				nics: []types.NetworkConfigData{
 					{
 						Type:        "ethernet",
 						Name:        "eth0",
@@ -194,12 +194,12 @@ func TestRenderNetworkConfigData(t *testing.T) {
 						ProxName:   "net1",
 						Table:      644,
 						Interfaces: []string{"eth1"},
-						Routes: []cloudinit.RoutingData{{
+						Routes: []types.RoutingData{{
 							To:     "3.4.5.6",
 							Via:    "10.0.1.1",
 							Metric: 100,
 						}},
-						FIBRules: []cloudinit.FIBRuleData{{
+						FIBRules: []types.FIBRuleData{{
 							To:       "8.7.6.5/32",
 							From:     "1.1.1.1/32",
 							Priority: 100,
@@ -216,7 +216,7 @@ func TestRenderNetworkConfigData(t *testing.T) {
 
 	for n, tc := range cases {
 		t.Run(n, func(t *testing.T) {
-			units, err := RenderNetworkConfigData(cloudinit.BaseCloudInitData{NetworkConfigData: tc.args.nics})
+			units, err := RenderNetworkConfigData(tc.args.nics)
 			require.ErrorIs(t, err, tc.want.err)
 			for k := range units {
 				require.Equal(t, tc.want.units[k], units[k])

--- a/pkg/types/network.go
+++ b/pkg/types/network.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2024 IONOS Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package types provides common types used in cloudinit & ignition.
+package types
+
+// NetworkConfigData is used to render network-config.
+type NetworkConfigData struct {
+	ProxName    string // Device name in Proxmox
+	MacAddress  string
+	DHCP4       bool
+	DHCP6       bool
+	IPAddress   string
+	IPV6Address string
+	Gateway     string
+	Metric      *uint32
+	Gateway6    string
+	Metric6     *uint32
+	DNSServers  []string
+	Type        string
+	Name        string
+	Interfaces  []string // Interfaces controlled by this one.
+	Table       uint32   // linux routing table number for VRF.
+	Routes      []RoutingData
+	FIBRules    []FIBRuleData // Forwarding information block for routing.
+	LinkMTU     *uint16       // linux network device MTU
+	VRF         string        // linux VRF name // only used in networkd config.
+}
+
+// RoutingData stores routing configuration.
+type RoutingData struct {
+	To     string
+	Via    string
+	Metric uint32
+	Table  uint32
+}
+
+// FIBRuleData stores forward information base rules (routing policies).
+type FIBRuleData struct {
+	To       string
+	From     string
+	Priority uint32
+	Table    uint32
+}

--- a/pkg/types/network.go
+++ b/pkg/types/network.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 IONOS Cloud.
+Copyright 2025 IONOS Cloud.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR moves the struct `NetworkConfigData` out of the cloudinit pkg,
Since ignition also uses the struct to generate network configuration, `NetworkConfigData` becomes a common type and can be moved to a standard package.

Closes #341 