### PR TITLE
fix: add tag validation to MatchTags

### DIFF
--- a/api/v1alpha1/proxmoxmachine_types.go
+++ b/api/v1alpha1/proxmoxmachine_types.go
@@ -229,6 +229,8 @@ type TemplateSelector struct {
 	// Passed tags must be an exact 1:1 match with the tags on the template you want to use.
 	// If multiple VM templates with the same set of tags are found, provisioning will fail.
 	//
+	// +listType=set
+	// +kubebuilder:validation:items:Pattern=`^(?i)[a-z0-9_][a-z0-9_\-\+\.]*$`
 	// +kubebuilder:validation:MinItems=1
 	MatchTags []string `json:"matchTags"`
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclusters.yaml
@@ -569,9 +569,11 @@ spec:
                                 Passed tags must be an exact 1:1 match with the tags on the template you want to use.
                                 If multiple VM templates with the same set of tags are found, provisioning will fail.
                               items:
+                                pattern: ^(?i)[a-z0-9_][a-z0-9_\-\+\.]*$
                                 type: string
                               minItems: 1
                               type: array
+                              x-kubernetes-list-type: set
                           required:
                           - matchTags
                           type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclustertemplates.yaml
@@ -610,9 +610,11 @@ spec:
                                         Passed tags must be an exact 1:1 match with the tags on the template you want to use.
                                         If multiple VM templates with the same set of tags are found, provisioning will fail.
                                       items:
+                                        pattern: ^(?i)[a-z0-9_][a-z0-9_\-\+\.]*$
                                         type: string
                                       minItems: 1
                                       type: array
+                                      x-kubernetes-list-type: set
                                   required:
                                   - matchTags
                                   type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachines.yaml
@@ -537,9 +537,11 @@ spec:
                       Passed tags must be an exact 1:1 match with the tags on the template you want to use.
                       If multiple VM templates with the same set of tags are found, provisioning will fail.
                     items:
+                      pattern: ^(?i)[a-z0-9_][a-z0-9_\-\+\.]*$
                       type: string
                     minItems: 1
                     type: array
+                    x-kubernetes-list-type: set
                 required:
                 - matchTags
                 type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachinetemplates.yaml
@@ -569,9 +569,11 @@ spec:
                               Passed tags must be an exact 1:1 match with the tags on the template you want to use.
                               If multiple VM templates with the same set of tags are found, provisioning will fail.
                             items:
+                              pattern: ^(?i)[a-z0-9_][a-z0-9_\-\+\.]*$
                               type: string
                             minItems: 1
                             type: array
+                            x-kubernetes-list-type: set
                         required:
                         - matchTags
                         type: object


### PR DESCRIPTION
this fixes a small oversight in #343 and actually validates the individual tags against what is accepted by the API

https://github.com/proxmox/pve-common/blob/master/src/PVE/JSONSchema.pm#L706

```
our $PVE_TAG_RE = qr/[a-z0-9_][a-z0-9_\-\+\.]*/i;
```
