### PR TITLE
Enable logging for e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,6 +40,14 @@ jobs:
       - name: Run e2e tests
         run: "make test-e2e GINKGO_SKIP=${{ env.SKIP_E2E }}"
 
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: logs
+          path: _artifacts
+          retention-days: 7
+
       - name: Cleanup kind clusters
         uses: gacts/run-and-post-run@v1
         with:

--- a/test/e2e/capmox_test.go
+++ b/test/e2e/capmox_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Workload cluster creation", func() {
 		result = new(clusterctl.ApplyClusterTemplateAndWaitResult)
 
 		// We need to override clusterctl apply log folder to avoid getting our credentials exposed.
-		clusterctlLogFolder = filepath.Join(os.TempDir(), "clusters", bootstrapClusterProxy.GetName())
+		clusterctlLogFolder = filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName())
 	})
 
 	AfterEach(func() {

--- a/test/e2e/data/infrastructure-proxmox/cluster-template-ci.yaml
+++ b/test/e2e/data/infrastructure-proxmox/cluster-template-ci.yaml
@@ -153,6 +153,7 @@ spec:
         owner: root:root
         permissions: "0700"
     preKubeadmCommands:
+      - echo "127.0.0.1   localhost kubernetes {{ ds.meta_data.hostname }}" >>/etc/hosts
       - /etc/kube-vip-prepare.sh
     initConfiguration:
       nodeRegistration:

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -192,6 +192,10 @@ var _ = SynchronizedAfterSuite(func() {
 	// After each ParallelNode.
 }, func() {
 	// After all ParallelNodes.
+	By("Dumping logs from the bootstrap cluster")
+	if err := dumpBootstrapClusterLogs(); err != nil {
+		GinkgoWriter.Printf("Failed to dump bootstrap cluster logs: %v", err)
+	}
 
 	By("Tearing down the management cluster")
 	if !skipCleanup {


### PR DESCRIPTION
This PR enable logging for the e2e tests so we can check what's happening.