### PR TITLE
.github/workflows/{e2e,test}: check out sha instead of ref

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           fetch-depth: 0 # for SonarQube
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: checkout
         if: github.event_name == 'push'


### PR DESCRIPTION
`ref` can be raced between approval and checkout by pushing a commit between approval and checkout. `sha` always refers to the triggering commit, which is safe.

*Issue #, if available:*
https://github.com/ionos-cloud/cluster-api-provider-proxmox/security/advisories/GHSA-qhwh-qr65-jwm3

