### PR TITLE
Add support for linked clones

### DIFF
--- a/api/v1alpha1/proxmoxmachine_types.go
+++ b/api/v1alpha1/proxmoxmachine_types.go
@@ -204,6 +204,8 @@ type TemplateSource struct {
 }
 
 // VirtualMachineCloneSpec is information used to clone a virtual machine.
+// +kubebuilder:validation:XValidation:rule="self.full || !has(self.format)",message="Must set full=true when specifying format"
+// +kubebuilder:validation:XValidation:rule="self.full || !has(self.storage)",message="Must set full=true when specifying storage"
 type VirtualMachineCloneSpec struct {
 	TemplateSource `json:",inline"`
 
@@ -578,8 +580,6 @@ type ProxmoxMachine struct {
 
 	// +kubebuilder:validation:XValidation:rule="[has(self.sourceNode), has(self.templateSelector)].exists_one(c, c)",message="must define either SourceNode with TemplateID, OR TemplateSelector"
 	// +kubebuilder:validation:XValidation:rule="[has(self.templateID), has(self.templateSelector)].exists_one(c, c)",message="must define either SourceNode with TemplateID, OR TemplateSelector."
-	// +kubebuilder:validation:XValidation:rule="self.full || !has(self.format)",message="Must set full=true when specifying format"
-	// +kubebuilder:validation:XValidation:rule="self.full || !has(self.storage)",message="Must set full=true when specifying storage"
 	Spec   ProxmoxMachineSpec   `json:"spec,omitempty"`
 	Status ProxmoxMachineStatus `json:"status,omitempty"`
 }

--- a/api/v1alpha1/proxmoxmachine_types.go
+++ b/api/v1alpha1/proxmoxmachine_types.go
@@ -578,7 +578,8 @@ type ProxmoxMachine struct {
 
 	// +kubebuilder:validation:XValidation:rule="[has(self.sourceNode), has(self.templateSelector)].exists_one(c, c)",message="must define either SourceNode with TemplateID, OR TemplateSelector"
 	// +kubebuilder:validation:XValidation:rule="[has(self.templateID), has(self.templateSelector)].exists_one(c, c)",message="must define either SourceNode with TemplateID, OR TemplateSelector."
-	// +kubebuilder:validation:XValidation:rule="self.full && self.format != ''",message="Must set full=true when specifying format"
+	// +kubebuilder:validation:XValidation:rule="self.full || !has(self.format)",message="Must set full=true when specifying format"
+	// +kubebuilder:validation:XValidation:rule="self.full || !has(self.storage)",message="Must set full=true when specifying storage"
 	Spec   ProxmoxMachineSpec   `json:"spec,omitempty"`
 	Status ProxmoxMachineStatus `json:"status,omitempty"`
 }

--- a/api/v1alpha1/proxmoxmachine_types.go
+++ b/api/v1alpha1/proxmoxmachine_types.go
@@ -215,7 +215,6 @@ type VirtualMachineCloneSpec struct {
 
 	// Format for file storage. Only valid for full clone.
 	// +kubebuilder:validation:Enum=raw;qcow2;vmdk
-	// +kubebuilder:default=raw
 	// +optional
 	Format *TargetFileStorageFormat `json:"format,omitempty"`
 

--- a/api/v1alpha1/proxmoxmachine_types_test.go
+++ b/api/v1alpha1/proxmoxmachine_types_test.go
@@ -76,6 +76,15 @@ var _ = Describe("ProxmoxMachine Test", func() {
 			Expect(k8sClient.Create(context.Background(), dm)).Should(MatchError(ContainSubstring("Must set full=true when specifying storage")))
 		})
 
+		It("Should allow disabling full clone in absence of format and storage", func() {
+			dm := defaultMachine()
+			dm.Spec.Format = nil
+			dm.Spec.Storage = nil
+			dm.Spec.Full = ptr.To(false)
+
+			Expect(k8sClient.Create(context.Background(), dm)).Should(Succeed())
+		})
+
 		It("Should disallow absence of SourceNode, TemplateID and TemplateSelector", func() {
 			dm := defaultMachine()
 			dm.Spec.TemplateSource.SourceNode = ""

--- a/api/v1alpha1/proxmoxmachine_types_test.go
+++ b/api/v1alpha1/proxmoxmachine_types_test.go
@@ -62,9 +62,18 @@ var _ = Describe("ProxmoxMachine Test", func() {
 	Context("VirtualMachineCloneSpec", func() {
 		It("Should not allow specifying format if full clone is disabled", func() {
 			dm := defaultMachine()
+			dm.Spec.Format = ptr.To(TargetStorageFormatRaw)
 			dm.Spec.Full = ptr.To(false)
 
 			Expect(k8sClient.Create(context.Background(), dm)).Should(MatchError(ContainSubstring("Must set full=true when specifying format")))
+		})
+
+		It("Should not allow specifying storage if full clone is disabled", func() {
+			dm := defaultMachine()
+			dm.Spec.Storage = ptr.To("local")
+			dm.Spec.Full = ptr.To(false)
+
+			Expect(k8sClient.Create(context.Background(), dm)).Should(MatchError(ContainSubstring("Must set full=true when specifying storage")))
 		})
 
 		It("Should disallow absence of SourceNode, TemplateID and TemplateSelector", func() {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclusters.yaml
@@ -700,6 +700,11 @@ spec:
                           - message: end should be greater than or equal to start
                             rule: self.end >= self.start
                       type: object
+                      x-kubernetes-validations:
+                      - message: Must set full=true when specifying format
+                        rule: self.full || !has(self.format)
+                      - message: Must set full=true when specifying storage
+                        rule: self.full || !has(self.storage)
                     type: object
                     x-kubernetes-validations:
                     - message: Cowardly refusing to deploy cluster without control

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclusters.yaml
@@ -135,7 +135,6 @@ spec:
                                 rule: self == oldSelf
                           type: object
                         format:
-                          default: raw
                           description: Format for file storage. Only valid for full
                             clone.
                           enum:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclustertemplates.yaml
@@ -159,7 +159,6 @@ spec:
                                         rule: self == oldSelf
                                   type: object
                                 format:
-                                  default: raw
                                   description: Format for file storage. Only valid
                                     for full clone.
                                   enum:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclustertemplates.yaml
@@ -742,6 +742,11 @@ spec:
                                       start
                                     rule: self.end >= self.start
                               type: object
+                              x-kubernetes-validations:
+                              - message: Must set full=true when specifying format
+                                rule: self.full || !has(self.format)
+                              - message: Must set full=true when specifying storage
+                                rule: self.full || !has(self.storage)
                             type: object
                             x-kubernetes-validations:
                             - message: Cowardly refusing to deploy cluster without

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachines.yaml
@@ -127,7 +127,6 @@ spec:
                       rule: self == oldSelf
                 type: object
               format:
-                default: raw
                 description: Format for file storage. Only valid for full clone.
                 enum:
                 - raw

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachines.yaml
@@ -664,7 +664,9 @@ spec:
               rule: '[has(self.templateID), has(self.templateSelector)].exists_one(c,
                 c)'
             - message: Must set full=true when specifying format
-              rule: self.full && self.format != ''
+              rule: self.full || !has(self.format)
+            - message: Must set full=true when specifying storage
+              rule: self.full || !has(self.storage)
           status:
             description: ProxmoxMachineStatus defines the observed state of a ProxmoxMachine.
             properties:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachinetemplates.yaml
@@ -139,7 +139,6 @@ spec:
                               rule: self == oldSelf
                         type: object
                       format:
-                        default: raw
                         description: Format for file storage. Only valid for full
                           clone.
                         enum:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachinetemplates.yaml
@@ -697,6 +697,11 @@ spec:
                         - message: end should be greater than or equal to start
                           rule: self.end >= self.start
                     type: object
+                    x-kubernetes-validations:
+                    - message: Must set full=true when specifying format
+                      rule: self.full || !has(self.format)
+                    - message: Must set full=true when specifying storage
+                      rule: self.full || !has(self.storage)
                 required:
                 - spec
                 type: object


### PR DESCRIPTION
*Issue #, if available:*
#174

*Description of changes:*
* Fix `ProxmoxMachineSpec` validation rules
    * Previous rule required `full` to be always set to `true` and did not validate for `storage` being set
* Move validation rules from `ProxmoxMachine` to `VirtualMachineCloneSpec`
    * Moving validation rules to `VirtualMachineCloneSpec` also adds them to other resources where it is embedded that users interact with directly
* Remove default value from `VirtualMachineCloneSpec.Format`
    * Having `format` default to `raw` prevents making linked clones on storages that support it

*Testing performed:*
* `make test`
* Manually deploying multiple clusters with and without linked clones enabled