### PR TITLE
Feature/clusterclass template update

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -333,13 +333,50 @@ to be set in your capi controller and in the environment of clusterctl.
 
 We provide the following ClusterClasses:
 
-| Flavor         | Template File                                   | CRS File                      | Example Cluster Manifest     |
-|----------------| ----------------------------------------------- |-------------------------------|-------------------------------
-| cilium         | templates/cluster-class-cilium.yaml             | templates/crs/cni/cilium.yaml | examples/cluster-cilium.yaml |
-| calico         | templates/cluster-class-calico.yaml             | templates/crs/cni/calico.yaml | examples/cluster-calico.yaml |
-| default        | templates/cluster-class.yaml                    | -                             | examples/cluster.yaml        |
+| Flavor         | Template File                          | Example Cluster Manifest     |
+|----------------|---------------------------------------|-----------------------------|
+| cilium         | templates/cluster-class-cilium.yaml    | examples/cluster-cilium.yaml|
+| calico         | templates/cluster-class-calico.yaml    | examples/cluster-calico.yaml|
+| default        | templates/cluster-class.yaml           | examples/cluster.yaml       |
+
+> **Note:**  
+> The provided templates and example manifests assume that clusters are created in the `default` namespace.  
+> If you wish to create clusters in a different namespace, you must update the template to change the `namespace` field of the `ClusterResourceSet` and ensure that the CNI manifests (ConfigMaps) are created in the same namespace.
+
+> **Note:**  
+> To use Cilium or Calico with ClusterResourceSet, you need to generate and apply a ConfigMap for the CNI manifest.
+
+<details>
+<summary><strong>Cilium</strong></summary>
+
+Generate and apply a ConfigMap for **Cilium**:
+
+```bash
+helm template cilium cilium/cilium --version 1.17.6 --namespace kube-system > cilium.yaml
+kubectl create configmap cilium --from-file=cilium.yaml="cilium.yaml" --dry-run=client -o yaml > cilium-configmap.yaml
+kubectl apply -f cilium-configmap.yaml
+```
+
+</details>
+
+<details>
+<summary><strong>Calico</strong></summary>
+
+Generate and apply a ConfigMap for **Calico**:
+
+```bash
+curl -fsSL "https://raw.githubusercontent.com/projectcalico/calico/v3.30.2/manifests/calico.yaml" -o calico.yaml
+kubectl create configmap calico --from-file=calico.yaml=calico.yaml --dry-run=client -o yaml > calico-configmap.yaml
+kubectl apply -f calico-configmap.yaml
+```
+
+</details>
+
 
 ### Creating a cluster from a ClusterClass
+
+
+
 1. Choose a ClusterClass
 All ClusterClasses provide the same features except for the CNI they refer to. The base ClusterClass
 also does not provide MachineHealthChecks as those can not be successful until a CNI is deployed.

--- a/examples/cluster-calico.yaml
+++ b/examples/cluster-calico.yaml
@@ -66,6 +66,10 @@ spec:
 #           numSockets: 1
 #           numCores: 4
 #           memoryMiB: 4096
+#           disks:
+#            bootVolume:
+#              disk: scsi0
+#              sizeGb: 20
             sourceNode: pve1
             templateID: 100
           workerNode:
@@ -87,6 +91,10 @@ spec:
 #           numSockets: 1
 #           numCores: 4
 #           memoryMiB: 4096
+#           disks:
+#            bootVolume:
+#              disk: scsi0
+#              sizeGb: 20
             sourceNode: pve1
             templateID: 100
           loadBalancer:
@@ -115,6 +123,10 @@ spec:
 #           numSockets: 1
 #           numCores: 2
 #           memoryMiB: 2048
+#           disks:
+#            bootVolume:
+#              disk: scsi0
+#              sizeGb: 20
             sourceNode: pve1
             templateID: 100
         sshAuthorizedKeys:

--- a/examples/cluster-cilium.yaml
+++ b/examples/cluster-cilium.yaml
@@ -66,6 +66,10 @@ spec:
 #           numSockets: 1
 #           numCores: 4
 #           memoryMiB: 4096
+#           disks:
+#            bootVolume:
+#              disk: scsi0
+#              sizeGb: 20
             sourceNode: pve1
             templateID: 100
           workerNode:
@@ -87,6 +91,10 @@ spec:
 #           numSockets: 1
 #           numCores: 4
 #           memoryMiB: 4096
+#           disks:
+#            bootVolume:
+#              disk: scsi0
+#              sizeGb: 20
             sourceNode: pve1
             templateID: 100
           loadBalancer:
@@ -115,6 +123,10 @@ spec:
 #           numSockets: 1
 #           numCores: 2
 #           memoryMiB: 2048
+#           disks:
+#            bootVolume:
+#              disk: scsi0
+#              sizeGb: 20
             sourceNode: pve1
             templateID: 100
         sshAuthorizedKeys:

--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -63,6 +63,10 @@ spec:
 #           numSockets: 1
 #           numCores: 4
 #           memoryMiB: 4096
+#           disks:
+#            bootVolume:
+#              disk: scsi0
+#              sizeGb: 20
             sourceNode: pve1
             templateID: 100
           workerNode:
@@ -84,6 +88,10 @@ spec:
 #           numSockets: 1
 #           numCores: 4
 #           memoryMiB: 4096
+#           disks:
+#            bootVolume:
+#              disk: scsi0
+#              sizeGb: 20
             sourceNode: pve1
             templateID: 100
           loadBalancer:
@@ -112,6 +120,10 @@ spec:
 #           numSockets: 1
 #           numCores: 2
 #           memoryMiB: 2048
+#           disks:
+#            bootVolume:
+#              disk: scsi0
+#              sizeGb: 20
             sourceNode: pve1
             templateID: 100
         sshAuthorizedKeys:

--- a/templates/cluster-class-calico.yaml
+++ b/templates/cluster-class-calico.yaml
@@ -198,13 +198,13 @@ spec:
                           properties:
                             disk:
                               type: string
-                        sizeGb:
-                          type: integer
-                          minimum: 5
-                          format: int32
-                      required:
-                      - disk
-                      - sizeGb
+                            sizeGb:
+                              type: integer
+                              minimum: 5
+                              format: int32
+                          required:
+                          - disk
+                          - sizeGb
                     format:
                       type: string
                       enum: [raw, qcow2, vmdk]
@@ -768,6 +768,54 @@ spec:
             path: /spec/template/spec/format
             valueFrom:
               variable: cloneSpec.machineSpec.loadBalancer.format
+  - name: ControlPlaneDiskSize
+    description: "Configure ControlPlane Disk Size"
+    enabledIf: "{{ if .cloneSpec.machineSpec.controlPlane.disks }}true{{ end }}"
+    definitions:
+      - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+          kind: ProxmoxMachineTemplate
+          matchResources:
+            controlPlane: true
+        jsonPatches:
+          - op: add
+            path: /spec/template/spec/disks
+            valueFrom:
+              variable: cloneSpec.machineSpec.controlPlane.disks
+  - name: WorkerNodeDiskSize
+    description: "Configure WorkerNode Disk Size"
+    enabledIf: "{{ if .cloneSpec.machineSpec.workerNode.disks }}true{{ end }}"
+    definitions:
+      - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+          kind: ProxmoxMachineTemplate
+          matchResources:
+            controlPlane: false
+            machineDeploymentClass:
+              names:
+              - proxmox-worker
+        jsonPatches:
+          - op: add
+            path: /spec/template/spec/disks
+            valueFrom:
+              variable: cloneSpec.machineSpec.workerNode.disks
+  - name: LoadBalancerDiskSize
+    description: "Configure LoadBalancer Disk Size"
+    enabledIf: "{{ if .cloneSpec.machineSpec.loadBalancer.disks }}true{{ end }}"
+    definitions:
+      - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+          kind: ProxmoxMachineTemplate
+          matchResources:
+            controlPlane: false
+            machineDeploymentClass:
+              names:
+              - proxmox-loadbalancer
+        jsonPatches:
+          - op: add
+            path: /spec/template/spec/disks
+            valueFrom:
+              variable: cloneSpec.machineSpec.loadBalancer.disks
   - name: ControlPlaneMem
     description: "Configure ControlPlane Memory"
     enabledIf: "{{ if .cloneSpec.machineSpec.workerNode.memoryMiB }}true{{ end }}"

--- a/templates/cluster-class-cilium.yaml
+++ b/templates/cluster-class-cilium.yaml
@@ -198,13 +198,13 @@ spec:
                           properties:
                             disk:
                               type: string
-                        sizeGb:
-                          type: integer
-                          minimum: 5
-                          format: int32
-                      required:
-                      - disk
-                      - sizeGb
+                            sizeGb:
+                              type: integer
+                              minimum: 5
+                              format: int32
+                          required:
+                          - disk
+                          - sizeGb
                     format:
                       type: string
                       enum: [raw, qcow2, vmdk]
@@ -768,6 +768,54 @@ spec:
             path: /spec/template/spec/format
             valueFrom:
               variable: cloneSpec.machineSpec.loadBalancer.format
+  - name: ControlPlaneDiskSize
+    description: "Configure ControlPlane Disk Size"
+    enabledIf: "{{ if .cloneSpec.machineSpec.controlPlane.disks }}true{{ end }}"
+    definitions:
+      - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+          kind: ProxmoxMachineTemplate
+          matchResources:
+            controlPlane: true
+        jsonPatches:
+          - op: add
+            path: /spec/template/spec/disks
+            valueFrom:
+              variable: cloneSpec.machineSpec.controlPlane.disks
+  - name: WorkerNodeDiskSize
+    description: "Configure WorkerNode Disk Size"
+    enabledIf: "{{ if .cloneSpec.machineSpec.workerNode.disks }}true{{ end }}"
+    definitions:
+      - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+          kind: ProxmoxMachineTemplate
+          matchResources:
+            controlPlane: false
+            machineDeploymentClass:
+              names:
+              - proxmox-worker
+        jsonPatches:
+          - op: add
+            path: /spec/template/spec/disks
+            valueFrom:
+              variable: cloneSpec.machineSpec.workerNode.disks
+  - name: LoadBalancerDiskSize
+    description: "Configure LoadBalancer Disk Size"
+    enabledIf: "{{ if .cloneSpec.machineSpec.loadBalancer.disks }}true{{ end }}"
+    definitions:
+      - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+          kind: ProxmoxMachineTemplate
+          matchResources:
+            controlPlane: false
+            machineDeploymentClass:
+              names:
+              - proxmox-loadbalancer
+        jsonPatches:
+          - op: add
+            path: /spec/template/spec/disks
+            valueFrom:
+              variable: cloneSpec.machineSpec.loadBalancer.disks
   - name: ControlPlaneMem
     description: "Configure ControlPlane Memory"
     enabledIf: "{{ if .cloneSpec.machineSpec.workerNode.memoryMiB }}true{{ end }}"

--- a/templates/cluster-class.yaml
+++ b/templates/cluster-class.yaml
@@ -168,13 +168,13 @@ spec:
                           properties:
                             disk:
                               type: string
-                        sizeGb:
-                          type: integer
-                          minimum: 5
-                          format: int32
-                      required:
-                      - disk
-                      - sizeGb
+                            sizeGb:
+                              type: integer
+                              minimum: 5
+                              format: int32
+                          required:
+                          - disk
+                          - sizeGb
                     format:
                       type: string
                       enum: [raw, qcow2, vmdk]
@@ -738,6 +738,54 @@ spec:
             path: /spec/template/spec/format
             valueFrom:
               variable: cloneSpec.machineSpec.loadBalancer.format
+  - name: ControlPlaneDiskSize
+    description: "Configure ControlPlane Disk Size"
+    enabledIf: "{{ if .cloneSpec.machineSpec.controlPlane.disks }}true{{ end }}"
+    definitions:
+      - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+          kind: ProxmoxMachineTemplate
+          matchResources:
+            controlPlane: true
+        jsonPatches:
+          - op: add
+            path: /spec/template/spec/disks
+            valueFrom:
+              variable: cloneSpec.machineSpec.controlPlane.disks
+  - name: WorkerNodeDiskSize
+    description: "Configure WorkerNode Disk Size"
+    enabledIf: "{{ if .cloneSpec.machineSpec.workerNode.disks }}true{{ end }}"
+    definitions:
+      - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+          kind: ProxmoxMachineTemplate
+          matchResources:
+            controlPlane: false
+            machineDeploymentClass:
+              names:
+              - proxmox-worker
+        jsonPatches:
+          - op: add
+            path: /spec/template/spec/disks
+            valueFrom:
+              variable: cloneSpec.machineSpec.workerNode.disks
+  - name: LoadBalancerDiskSize
+    description: "Configure LoadBalancer Disk Size"
+    enabledIf: "{{ if .cloneSpec.machineSpec.loadBalancer.disks }}true{{ end }}"
+    definitions:
+      - selector:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+          kind: ProxmoxMachineTemplate
+          matchResources:
+            controlPlane: false
+            machineDeploymentClass:
+              names:
+              - proxmox-loadbalancer
+        jsonPatches:
+          - op: add
+            path: /spec/template/spec/disks
+            valueFrom:
+              variable: cloneSpec.machineSpec.loadBalancer.disks
   - name: ControlPlaneMem
     description: "Configure ControlPlane Memory"
     enabledIf: "{{ if .cloneSpec.machineSpec.workerNode.memoryMiB }}true{{ end }}"


### PR DESCRIPTION
Description of changes:

Documentation (Usage.md):
Removed the "CRS File" column from the ClusterClass table because the files don't exist.
Added a note explaining that the provided templates and example manifests assume clusters are created in the default namespace.
Added example copyable code blocks for generating and applying CNI ConfigMaps for both Cilium and Calico.

Templates and Examples
Enabled all clusterclass templates (calico, cilium, and no cni) to allow resizing the boot disk of nodes.
Modified examples to include disk size (commented out).

Testing performed:
I created clusters using all three cluster classes with modified sizeGb for the bootDisk and verified that the clusters came up successfully with the proper disk size. 
