### PR TITLE
MINOR: Remove duplicate rules to avoid validation warning when applying

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclusters.yaml
@@ -264,9 +264,6 @@ spec:
                                     - message: invalid MTU value
                                       rule: self == 1 || ( self >= 576 && self <=
                                         65520)
-                                    - message: invalid MTU value
-                                      rule: self == 1 || ( self >= 576 && self <=
-                                        65520)
                                   model:
                                     default: virtio
                                     description: Model is the network device model.
@@ -282,9 +279,6 @@ spec:
                                       When set to 1, virtio devices inherit the MTU value from the underlying bridge.
                                     type: integer
                                     x-kubernetes-validations:
-                                    - message: invalid MTU value
-                                      rule: self == 1 || ( self >= 576 && self <=
-                                        65520)
                                     - message: invalid MTU value
                                       rule: self == 1 || ( self >= 576 && self <=
                                         65520)
@@ -476,8 +470,6 @@ spec:
                                     When set to 1, virtio devices inherit the MTU value from the underlying bridge.
                                   type: integer
                                   x-kubernetes-validations:
-                                  - message: invalid MTU value
-                                    rule: self == 1 || ( self >= 576 && self <= 65520)
                                   - message: invalid MTU value
                                     rule: self == 1 || ( self >= 576 && self <= 65520)
                                 vlan:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclustertemplates.yaml
@@ -288,9 +288,6 @@ spec:
                                             - message: invalid MTU value
                                               rule: self == 1 || ( self >= 576 &&
                                                 self <= 65520)
-                                            - message: invalid MTU value
-                                              rule: self == 1 || ( self >= 576 &&
-                                                self <= 65520)
                                           model:
                                             default: virtio
                                             description: Model is the network device
@@ -307,9 +304,6 @@ spec:
                                               When set to 1, virtio devices inherit the MTU value from the underlying bridge.
                                             type: integer
                                             x-kubernetes-validations:
-                                            - message: invalid MTU value
-                                              rule: self == 1 || ( self >= 576 &&
-                                                self <= 65520)
                                             - message: invalid MTU value
                                               rule: self == 1 || ( self >= 576 &&
                                                 self <= 65520)
@@ -507,9 +501,6 @@ spec:
                                             When set to 1, virtio devices inherit the MTU value from the underlying bridge.
                                           type: integer
                                           x-kubernetes-validations:
-                                          - message: invalid MTU value
-                                            rule: self == 1 || ( self >= 576 && self
-                                              <= 65520)
                                           - message: invalid MTU value
                                             rule: self == 1 || ( self >= 576 && self
                                               <= 65520)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachines.yaml
@@ -246,8 +246,6 @@ spec:
                           x-kubernetes-validations:
                           - message: invalid MTU value
                             rule: self == 1 || ( self >= 576 && self <= 65520)
-                          - message: invalid MTU value
-                            rule: self == 1 || ( self >= 576 && self <= 65520)
                         model:
                           default: virtio
                           description: Model is the network device model.
@@ -263,8 +261,6 @@ spec:
                             When set to 1, virtio devices inherit the MTU value from the underlying bridge.
                           type: integer
                           x-kubernetes-validations:
-                          - message: invalid MTU value
-                            rule: self == 1 || ( self >= 576 && self <= 65520)
                           - message: invalid MTU value
                             rule: self == 1 || ( self >= 576 && self <= 65520)
                         name:
@@ -439,8 +435,6 @@ spec:
                           When set to 1, virtio devices inherit the MTU value from the underlying bridge.
                         type: integer
                         x-kubernetes-validations:
-                        - message: invalid MTU value
-                          rule: self == 1 || ( self >= 576 && self <= 65520)
                         - message: invalid MTU value
                           rule: self == 1 || ( self >= 576 && self <= 65520)
                       vlan:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachinetemplates.yaml
@@ -267,8 +267,6 @@ spec:
                                   x-kubernetes-validations:
                                   - message: invalid MTU value
                                     rule: self == 1 || ( self >= 576 && self <= 65520)
-                                  - message: invalid MTU value
-                                    rule: self == 1 || ( self >= 576 && self <= 65520)
                                 model:
                                   default: virtio
                                   description: Model is the network device model.
@@ -284,8 +282,6 @@ spec:
                                     When set to 1, virtio devices inherit the MTU value from the underlying bridge.
                                   type: integer
                                   x-kubernetes-validations:
-                                  - message: invalid MTU value
-                                    rule: self == 1 || ( self >= 576 && self <= 65520)
                                   - message: invalid MTU value
                                     rule: self == 1 || ( self >= 576 && self <= 65520)
                                 name:
@@ -474,8 +470,6 @@ spec:
                                   When set to 1, virtio devices inherit the MTU value from the underlying bridge.
                                 type: integer
                                 x-kubernetes-validations:
-                                - message: invalid MTU value
-                                  rule: self == 1 || ( self >= 576 && self <= 65520)
                                 - message: invalid MTU value
                                   rule: self == 1 || ( self >= 576 && self <= 65520)
                               vlan:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing performed:*

Validation errors given when applying version v0.7.4

E1002 12:53:54.844489       1 status.go:71] "Unhandled Error" err="apiserver received an error that is not an metav1.Status: &errors.errorString{s:\"failed to create typed patch object (/proxmoxmachinetemplates.infrastructure.cluster.x-k8s.io; apiextensions.k8s.io/v1, Kind=CustomResourceDefinition): .spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.network.properties.default.properties.mtu.x-kubernetes-validations: duplicate entries for key [rule=\\\"self == 1 || ( self >= 576 && self <= 65520)\\\"]\"}: failed to create typed patch object (/proxmoxmachinetemplates.infrastructure.cluster.x-k8s.io; apiextensions.k8s.io/v1, Kind=CustomResourceDefinition): .spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.template.properties.spec.properties.network.properties.default.properties.mtu.x-kubernetes-validations: duplicate entries for key [rule=\"self == 1 || ( self >= 576 && self <= 65520)\"]" logger="UnhandledError"