### PR TITLE
Fix: Schedule vms evenly across nodes when memory allows

### DIFF
--- a/internal/service/scheduler/vmscheduler.go
+++ b/internal/service/scheduler/vmscheduler.go
@@ -109,9 +109,12 @@ func selectNode(
 	sort.Sort(byReplicas)
 
 	decision := byMemory[0].Name
-	if requestedMemory < byReplicas[0].AvailableMemory {
+	for _, info := range byReplicas {
 		// distribute round-robin when memory allows it
-		decision = byReplicas[0].Name
+		if requestedMemory < info.AvailableMemory {
+			decision = info.Name
+			break
+		}
 	}
 
 	if logger := logr.FromContextOrDiscard(ctx); logger.V(4).Enabled() {


### PR DESCRIPTION
*Issue #, if available:*
No issue raised

*Description of changes:*
This PR fixes a scheduling imbalance in the VM scheduler logic. Previously, when one node had fewer replicas than others but lacked sufficient available memory, the scheduler would always select the node with the most free memory. This behavior caused an uneven distribution of replicas across nodes.

The updated logic ensures that replicas are spread more evenly across nodes, provided memory constraints are satisfied.

See the affected logic below, where the scheduler performs round-robin scheduling only if the node with the fewest replicas has sufficient available memory:
https://github.com/ionos-cloud/cluster-api-provider-proxmox/blob/92ac7a597d57a5a56c0024b02f389c33f423c3fc/internal/service/scheduler/vmscheduler.go#L111C1-L115C3

*Testing performed:*
- Added a unit test verifying that VMs are distributed evenly across nodes when memory allows.
- The new test fails on the current master branch but passes with this fix applied.
