### PR TITLE
Add CloudInitNetworkConfigFormat to ProxmoxCluster spec

### DIFF
--- a/api/v1alpha1/proxmoxcluster_types.go
+++ b/api/v1alpha1/proxmoxcluster_types.go
@@ -35,6 +35,24 @@ const (
 	SecretFinalizer = "proxmoxcluster.infrastructure.cluster.x-k8s.io/secret" //nolint:gosec
 )
 
+// CloudInitNetworkConfigFormat specifies the format for cloud-init network-config.
+// +kubebuilder:validation:Enum=netplan;nocloud
+type CloudInitNetworkConfigFormat string
+
+const (
+	// CloudInitNetworkConfigFormatNetplan generates network-config in netplan format
+	// with a top-level "network:" key. This is the default format and works with
+	// distributions that support netplan (Ubuntu, Debian with netplan).
+	CloudInitNetworkConfigFormatNetplan CloudInitNetworkConfigFormat = "netplan"
+
+	// CloudInitNetworkConfigFormatNoCloud generates network-config in nocloud format
+	// without the top-level "network:" key. This is the correct format for the
+	// cloud-init nocloud datasource's network-config file, which expects version: at
+	// the root level. Systems like Talos Linux that use the nocloud datasource require
+	// this format.
+	CloudInitNetworkConfigFormatNoCloud CloudInitNetworkConfigFormat = "nocloud"
+)
+
 // ProxmoxClusterSpec defines the desired state of a ProxmoxCluster.
 type ProxmoxClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
@@ -85,6 +103,15 @@ type ProxmoxClusterSpec struct {
 	// if no namespace is provided, the namespace of the ProxmoxCluster will be used.
 	// +optional
 	CredentialsRef *corev1.SecretReference `json:"credentialsRef,omitempty"`
+
+	// CloudInitNetworkConfigFormat specifies the format for cloud-init network-config.
+	// Defaults to "netplan" which generates configuration with a top-level "network:" key
+	// suitable for netplan-based distributions (Ubuntu, Debian).
+	// Set to "nocloud" when using the cloud-init nocloud datasource, which expects the
+	// network-config file to have version: at the root level without a "network:" wrapper.
+	// +optional
+	// +kubebuilder:default=netplan
+	CloudInitNetworkConfigFormat CloudInitNetworkConfigFormat `json:"cloudInitNetworkConfigFormat,omitempty"`
 }
 
 // ProxmoxClusterCloneSpec is the configuration pertaining to all items configurable

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclusters.yaml
@@ -714,6 +714,18 @@ spec:
                 required:
                 - machineSpec
                 type: object
+              cloudInitNetworkConfigFormat:
+                default: netplan
+                description: |-
+                  CloudInitNetworkConfigFormat specifies the format for cloud-init network-config.
+                  Defaults to "netplan" which generates configuration with a top-level "network:" key
+                  suitable for netplan-based distributions (Ubuntu, Debian).
+                  Set to "nocloud" when using the cloud-init nocloud datasource, which expects the
+                  network-config file to have version: at the root level without a "network:" wrapper.
+                enum:
+                - netplan
+                - nocloud
+                type: string
               controlPlaneEndpoint:
                 description: ControlPlaneEndpoint represents the endpoint used to
                   communicate with the control plane.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclustertemplates.yaml
@@ -755,6 +755,18 @@ spec:
                         required:
                         - machineSpec
                         type: object
+                      cloudInitNetworkConfigFormat:
+                        default: netplan
+                        description: |-
+                          CloudInitNetworkConfigFormat specifies the format for cloud-init network-config.
+                          Defaults to "netplan" which generates configuration with a top-level "network:" key
+                          suitable for netplan-based distributions (Ubuntu, Debian).
+                          Set to "nocloud" when using the cloud-init nocloud datasource, which expects the
+                          network-config file to have version: at the root level without a "network:" wrapper.
+                        enum:
+                        - netplan
+                        - nocloud
+                        type: string
                       controlPlaneEndpoint:
                         description: ControlPlaneEndpoint represents the endpoint
                           used to communicate with the control plane.

--- a/internal/inject/inject_test.go
+++ b/internal/inject/inject_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/luthermonson/go-proxmox"
 	"github.com/stretchr/testify/require"
 
+	infrav1alpha1 "github.com/ionos-cloud/cluster-api-provider-proxmox/api/v1alpha1"
 	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/cloudinit"
 	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/ignition"
 	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/proxmox/goproxmox"
@@ -100,7 +101,7 @@ func TestISOInjectorInjectCloudInit(t *testing.T) {
 				Gateway:    "10.1.1.1",
 				DNSServers: []string{"8.8.8.8", "8.8.4.4"},
 			},
-		}),
+		}, infrav1alpha1.CloudInitNetworkConfigFormatNetplan),
 	}
 
 	httpmock.RegisterResponder(http.MethodGet, fmt.Sprintf(`=~/nodes/%s/storage`, "pve"),
@@ -144,7 +145,7 @@ func TestISOInjectorInjectCloudInit_Errors(t *testing.T) {
 				Gateway:    "10.1.1.1",
 				DNSServers: []string{"8.8.8.8", "8.8.4.4"},
 			},
-		}),
+		}, infrav1alpha1.CloudInitNetworkConfigFormatNetplan),
 	}
 
 	// missing hostname
@@ -153,7 +154,7 @@ func TestISOInjectorInjectCloudInit_Errors(t *testing.T) {
 
 	// missing network
 	injector.MetaRenderer = cloudinit.NewMetadata("xxx-xxxx", "my-custom-vm", "1.2.3", false)
-	injector.NetworkRenderer = cloudinit.NewNetworkConfig(nil)
+	injector.NetworkRenderer = cloudinit.NewNetworkConfig(nil, infrav1alpha1.CloudInitNetworkConfigFormatNetplan)
 	err = injector.Inject(context.Background(), "cloudinit")
 	require.Error(t, err)
 }
@@ -301,7 +302,7 @@ func TestISOInjectorInject_Unsupported(t *testing.T) {
 				Gateway:    "10.1.1.1",
 				DNSServers: []string{"8.8.8.8", "8.8.4.4"},
 			},
-		}),
+		}, infrav1alpha1.CloudInitNetworkConfigFormatNetplan),
 	}
 
 	// unsupported format

--- a/internal/service/vmservice/bootstrap.go
+++ b/internal/service/vmservice/bootstrap.go
@@ -93,8 +93,11 @@ func reconcileBootstrapData(ctx context.Context, machineScope *scope.MachineScop
 }
 
 func injectCloudInit(ctx context.Context, machineScope *scope.MachineScope, bootstrapData []byte, biosUUID string, nicData []types.NetworkConfigData, kubernetesVersion string) error {
+	// Get the cloud-init network config format from the cluster spec
+	networkConfigFormat := machineScope.InfraCluster.ProxmoxCluster.Spec.CloudInitNetworkConfigFormat
+
 	// create network renderer
-	network := cloudinit.NewNetworkConfig(nicData)
+	network := cloudinit.NewNetworkConfig(nicData, networkConfigFormat)
 
 	// create metadata renderer
 	metadata := cloudinit.NewMetadata(biosUUID, machineScope.Name(), kubernetesVersion, ptr.Deref(machineScope.ProxmoxMachine.Spec.MetadataSettings, infrav1alpha1.MetadataSettings{ProviderIDInjection: false}).ProviderIDInjection)

--- a/internal/service/vmservice/bootstrap_test.go
+++ b/internal/service/vmservice/bootstrap_test.go
@@ -557,7 +557,7 @@ func TestReconcileBootstrapData_Format_Ignition(t *testing.T) {
 }
 
 func TestDefaultISOInjector(t *testing.T) {
-	injector := defaultISOInjector(newRunningVM(), []byte("data"), cloudinit.NewMetadata(biosUUID, "test", "1.2.3", true), cloudinit.NewNetworkConfig(nil))
+	injector := defaultISOInjector(newRunningVM(), []byte("data"), cloudinit.NewMetadata(biosUUID, "test", "1.2.3", true), cloudinit.NewNetworkConfig(nil, infrav1alpha1.CloudInitNetworkConfigFormatNetplan))
 
 	require.NotEmpty(t, injector)
 	require.Equal(t, []byte("data"), injector.(*inject.ISOInjector).BootstrapData)

--- a/pkg/cloudinit/errors.go
+++ b/pkg/cloudinit/errors.go
@@ -51,4 +51,8 @@ var (
 
 	// ErrMalformedFIBRule is returned if a FIB rule can not be assembled by netplan.
 	ErrMalformedFIBRule = errors.New("routing policy is malformed")
+
+	// ErrNoCloudUnsupportedFeature is returned when nocloud format is used with
+	// features only supported by netplan (VRFs, routing-policy).
+	ErrNoCloudUnsupportedFeature = errors.New("nocloud format does not support VRFs or routing-policy; use netplan format or remove these features")
 )


### PR DESCRIPTION
*Issue #, if available:* Fixes #94, #51

*Description of changes:*

Add a new field to ProxmoxCluster spec that controls the format of cloud-init network-config generation. Supports two formats:

- netplan (default): Generates config with top-level "network:" key, suitable for netplan-based distributions like Ubuntu and Debian.
- nocloud: Generates config without the "network:" wrapper, required for cloud-init nocloud datasource consumers like Talos Linux.

Explicit fails on two CAPMOX supported features that cannot be articulated in a pure nocloud cloud-init network-config, that otherwise rely on netplan passthrough. There would be a maintenance burden to this, as mentioned in #94.

I appreciate your time and effort maintaining this repo and considering this change. I'm happy to make any requested changes to the extent of my knowledge and ability.

*Testing performed:*

In tree tests (fmt, lint, vet, test), using an iso with the new generated network-config with a Talos Linux VM. 
