### PR TITLE
fix: move controlPlane validation from CRD to webhook

### DIFF
--- a/api/v1alpha1/proxmoxcluster_types.go
+++ b/api/v1alpha1/proxmoxcluster_types.go
@@ -90,7 +90,6 @@ type ProxmoxClusterSpec struct {
 // ProxmoxClusterCloneSpec is the configuration pertaining to all items configurable
 // in the configuration and cloning of a proxmox VM.
 type ProxmoxClusterCloneSpec struct {
-	// +kubebuilder:validation:XValidation:rule="has(self.controlPlane)",message="Cowardly refusing to deploy cluster without control plane"
 	ProxmoxMachineSpec map[string]ProxmoxMachineSpec `json:"machineSpec"`
 
 	// SshAuthorizedKeys contains the authorized keys deployed to the PROXMOX VMs.

--- a/api/v1alpha2/proxmoxcluster_types.go
+++ b/api/v1alpha2/proxmoxcluster_types.go
@@ -142,7 +142,6 @@ type ProxmoxClusterClassSpec struct {
 // in the configuration and cloning of a proxmox VM.
 type ProxmoxClusterCloneSpec struct {
 	// machineSpec is the map of machine specs.
-	// +kubebuilder:validation:XValidation:rule="self.exists_one(x, x.machineType == \"controlPlane\")",message="Cowardly refusing to deploy cluster without control plane"
 	// +listType=map
 	// +listMapKey=machineType
 	// +optional

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclusters.yaml
@@ -697,10 +697,6 @@ spec:
                       - message: Must set full=true when specifying storage
                         rule: self.full || !has(self.storage)
                     type: object
-                    x-kubernetes-validations:
-                    - message: Cowardly refusing to deploy cluster without control
-                        plane
-                      rule: has(self.controlPlane)
                   sshAuthorizedKeys:
                     description: SshAuthorizedKeys contains the authorized keys deployed
                       to the PROXMOX VMs.
@@ -1612,10 +1608,6 @@ spec:
                     x-kubernetes-list-map-keys:
                     - machineType
                     x-kubernetes-list-type: map
-                    x-kubernetes-validations:
-                    - message: Cowardly refusing to deploy cluster without control
-                        plane
-                      rule: self.exists_one(x, x.machineType == "controlPlane")
                   sshAuthorizedKeys:
                     description: sshAuthorizedKeys contains the authorized keys deployed
                       to the PROXMOX VMs.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxclustertemplates.yaml
@@ -738,10 +738,6 @@ spec:
                               - message: Must set full=true when specifying storage
                                 rule: self.full || !has(self.storage)
                             type: object
-                            x-kubernetes-validations:
-                            - message: Cowardly refusing to deploy cluster without
-                                control plane
-                              rule: has(self.controlPlane)
                           sshAuthorizedKeys:
                             description: SshAuthorizedKeys contains the authorized
                               keys deployed to the PROXMOX VMs.
@@ -1512,10 +1508,6 @@ spec:
                             x-kubernetes-list-map-keys:
                             - machineType
                             x-kubernetes-list-type: map
-                            x-kubernetes-validations:
-                            - message: Cowardly refusing to deploy cluster without
-                                control plane
-                              rule: self.exists_one(x, x.machineType == "controlPlane")
                           sshAuthorizedKeys:
                             description: sshAuthorizedKeys contains the authorized
                               keys deployed to the PROXMOX VMs.


### PR DESCRIPTION
## Summary
- Remove controlPlane XValidation rule from v1alpha1 and v1alpha2 CRDs
- Add equivalent validation in ProxmoxCluster webhook using `slices.IndexFunc`

## Problem
CRD validation on `cloneSpec.machineSpec` fails when v1alpha2 objects are accessed via v1alpha1 API. The converted objects fail v1alpha1 validation even when valid in v1alpha2, breaking ClusterClass template patching.

## Solution
Move validation to webhook which:
- Only validates `ProxmoxCluster` (not `ProxmoxClusterTemplate`)
- Avoids conversion-related validation issues
- Allows templates to have empty/partial machineSpec for ClusterClass

🤖 Generated with [Claude Code](https://claude.ai/code)