### PR TITLE
fix: sort IP addresses by pool offset to prevent flaky ordering

### DIFF
--- a/internal/service/vmservice/ip.go
+++ b/internal/service/vmservice/ip.go
@@ -72,6 +72,11 @@ func reconcileIPAddresses(ctx context.Context, machineScope *scope.MachineScope)
 	machineScope.Logger.V(4).Info("updating ProxmoxMachine.status.ipAddresses.")
 	for net, pools := range netPoolAddresses {
 		addresses := slices.Concat(slices.Collect(maps.Values(pools))...)
+		slices.SortFunc(addresses, func(a, b ipamv1.IPAddress) int {
+			aOffset, _ := strconv.Atoi(a.GetAnnotations()[infrav1.ProxmoxPoolOffsetAnnotation])
+			bOffset, _ := strconv.Atoi(b.GetAnnotations()[infrav1.ProxmoxPoolOffsetAnnotation])
+			return aOffset - bOffset
+		})
 		ipSpec := infrav1.IPAddressesSpec{
 			NetName: net,
 		}


### PR DESCRIPTION
## Summary
- `maps.Values()` iterates in non-deterministic order, causing `reconcileIPAddresses` to produce randomly ordered IP address lists when multiple pools exist for the same network device
- Sort collected addresses by `ProxmoxPoolOffsetAnnotation` to preserve the ordering defined in the `NetworkSpec` (default pools first, then extra pools in spec order)
- Fixes flaky `TestReconcileIPAddresses_MachineIPPoolRef` test

## Test plan
- [ ] Run `go test -v -race -count=10 -run TestReconcileIPAddresses_MachineIPPoolRef ./internal/service/...` and verify it passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)