### PR TITLE
Fix typo: test-duacl-stack → test-dual-stack

### DIFF
--- a/docs/advanced-setups.md
+++ b/docs/advanced-setups.md
@@ -104,7 +104,7 @@ If you're using cilium, be aware that Cilium's helm chart requires `ipv6.enabled
 #### Generate a Cluster
 
 ```bash
-clusterctl generate cluster test-duacl-stack  \
+clusterctl generate cluster test-dual-stack  \
   --infrastructure proxmox \
   --kubernetes-version v1.31.6  \
   --control-plane-machine-count=1 \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixed typo in dual-stack cluster name example.
Changed "test-duacl-stack" to "test-dual-stack" for consistency with the --flavor=dual-stack parameter.

*Testing performed:*
