### PR TITLE
convert lint to commit hashes, replace curlbash with action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Install yamllint
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y yamllint
       - uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3.1.1
         with:
           format: github


### PR DESCRIPTION
*Description of changes:*

We should really start converting `@version` with `@commithash #version` in action. This PR does the lint action.
While I was at it, I replaced the actionlint curlbash with a proper action.

*Testing performed:*
run the actions