### PR TITLE
v1alpha2: turn infrav2.NetName back into a string

### DIFF
--- a/api/v1alpha1/conversion.go
+++ b/api/v1alpha1/conversion.go
@@ -74,16 +74,13 @@ func convert_v1alpha2_AdditionalNetworkDevices_To_v1alpha1_AdditionalNetworkDevi
 		out.AdditionalDevices = make([]AdditionalNetworkDevice, 0, len(in.NetworkDevices))
 
 		for i, net := range in.NetworkDevices {
-			if net.Name != nil && *net.Name == DefaultNetworkDevice {
+			if string(net.Name) == DefaultNetworkDevice {
 				// skip default device, already handled
 				continue
 			}
 
 			nd := AdditionalNetworkDevice{}
-
-			if net.Name != nil {
-				nd.Name = *net.Name
-			}
+			nd.Name = string(net.Name)
 
 			err := Convert_v1alpha2_NetworkDevice_To_v1alpha1_NetworkDevice(&in.NetworkDevices[i], &nd.NetworkDevice, s)
 			if err != nil {
@@ -246,7 +243,7 @@ func Convert_v1alpha2_ProxmoxMachineStatus_To_v1alpha1_ProxmoxMachineStatus(in *
 				ip.IPV6 = v.IPv6[0]
 			}
 
-			out.IPAddresses[v.NetName] = ip
+			out.IPAddresses[string(v.NetName)] = ip
 		}
 	}
 
@@ -332,7 +329,7 @@ func Convert_v1alpha1_NetworkSpec_To_v1alpha2_NetworkSpec(in *NetworkSpec, out *
 
 	if in.Default != nil {
 		net0 := capmoxv2.NetworkDevice{
-			Name:        ptr.To(DefaultNetworkDevice),
+			Name:        capmoxv2.NetName(DefaultNetworkDevice),
 			DefaultIPv4: ptr.To(true),
 			DefaultIPv6: ptr.To(true),
 			InterfaceConfig: capmoxv2.InterfaceConfig{
@@ -351,7 +348,7 @@ func Convert_v1alpha1_NetworkSpec_To_v1alpha2_NetworkSpec(in *NetworkSpec, out *
 	// additional devices
 	for _, device := range in.AdditionalDevices {
 		net := capmoxv2.NetworkDevice{
-			Name: ptr.To(device.Name),
+			Name: capmoxv2.NetName(device.Name),
 			InterfaceConfig: capmoxv2.InterfaceConfig{
 				IPPoolRef: make([]corev1.TypedLocalObjectReference, 0),
 			},
@@ -507,12 +504,12 @@ func Convert_v1beta1_ObjectMeta_To_v1beta2_ObjectMeta(in *clusterv1beta1.ObjectM
 // //
 
 func Convert_v1alpha2_NetName_To_string(in *capmoxv2.NetName, out *string, s conversion.Scope) error {
-	*out = ptr.Deref(*in, "")
+	*out = string(*in)
 	return nil
 }
 
 func Convert_string_To_v1alpha2_NetName(in *string, out *capmoxv2.NetName, s conversion.Scope) error {
-	*out = in
+	*out = capmoxv2.NetName(*in)
 	return nil
 }
 
@@ -552,7 +549,7 @@ func Convert_Slice_string_To_Slice_v1alpha2_NetName(in *[]string, out *[]capmoxv
 
 func getNetByName(nets []capmoxv2.NetworkDevice, name string) int {
 	for i, net := range nets {
-		if net.Name != nil && *net.Name == name {
+		if string(net.Name) == name {
 			return i
 		}
 	}
@@ -572,20 +569,6 @@ func getIPPoolRefByIPFamily(poolRefs []corev1.TypedLocalObjectReference, ipFamil
 func Convert_string_To_Pointer_string(in string, hasRestored bool, restoredIn *string, out **string) {
 	// If the value is "", convert to *"" only if the value was *"" before (we know it was intentionally set to "").
 	// In all the other cases we do not know if the value was intentionally set to "", so convert to nil.
-	if in == "" {
-		if hasRestored && restoredIn != nil && *restoredIn == "" {
-			*out = ptr.To("")
-			return
-		}
-		*out = nil
-		return
-	}
-
-	// Otherwise, if the value is not "", convert to *value.
-	*out = ptr.To(in)
-}
-
-func Convert_string_To_NetName(in string, hasRestored bool, restoredIn capmoxv2.NetName, out *capmoxv2.NetName) {
 	if in == "" {
 		if hasRestored && restoredIn != nil && *restoredIn == "" {
 			*out = ptr.To("")

--- a/api/v1alpha1/conversion_test.go
+++ b/api/v1alpha1/conversion_test.go
@@ -142,11 +142,11 @@ func hubProxmoxMachineSpec(in *v1alpha2.ProxmoxMachineSpec, c randfill.Continue)
 			if len(in.Network.VRFs[i].Interfaces) == 0 {
 				in.Network.VRFs[i].Interfaces = nil
 			} else {
-				// Filter out nil elements and empty string NetNames
+				// Filter out empty string NetNames
 				filtered := make([]v1alpha2.NetName, 0, len(in.Network.VRFs[i].Interfaces))
 				for j := range in.Network.VRFs[i].Interfaces {
-					// Skip nil or empty string elements
-					if in.Network.VRFs[i].Interfaces[j] == nil || *in.Network.VRFs[i].Interfaces[j] == "" {
+					// Skip empty string elements
+					if len(in.Network.VRFs[i].Interfaces[j]) == 0 {
 						continue
 					}
 					filtered = append(filtered, in.Network.VRFs[i].Interfaces[j])
@@ -191,7 +191,7 @@ func hubProxmoxMachineSpec(in *v1alpha2.ProxmoxMachineSpec, c randfill.Continue)
 	if in.Network == nil {
 		in.Network = &v1alpha2.NetworkSpec{
 			NetworkDevices: []v1alpha2.NetworkDevice{{
-				Name: ptr.To(DefaultNetworkDevice),
+				Name: v1alpha2.DefaultNetworkDevice,
 				InterfaceConfig: v1alpha2.InterfaceConfig{
 					IPPoolRef: []corev1.TypedLocalObjectReference{},
 				},
@@ -263,8 +263,8 @@ func hubProxmoxMachineStatus(in *v1alpha2.ProxmoxMachineStatus, c randfill.Conti
 		if in.Network[i].Connected == nil {
 			in.Network[i].Connected = ptr.To(false)
 		}
-		if in.Network[i].NetworkName == nil {
-			in.Network[i].NetworkName = ptr.To("net0")
+		if len(in.Network[i].NetworkName) == 0 {
+			in.Network[i].NetworkName = v1alpha2.DefaultNetworkDevice
 		}
 	}
 }

--- a/api/v1alpha1/proxmoxmachine_conversion.go
+++ b/api/v1alpha1/proxmoxmachine_conversion.go
@@ -104,9 +104,9 @@ func restoreProxmoxMachineSpec(src *ProxmoxMachineSpec, dst *infrav1.ProxmoxMach
 
 	if dst.Network != nil && restored.Network != nil {
 		for i := range restored.Network.NetworkDevices {
-			device := getNetDeviceByName(src.Network.AdditionalDevices, *dst.Network.NetworkDevices[i].Name)
+			device := getNetDeviceByName(src.Network.AdditionalDevices, string(dst.Network.NetworkDevices[i].Name))
 			var name, model, bridge string
-			if dst.Network.NetworkDevices[i].Name != nil && *dst.Network.NetworkDevices[i].Name == DefaultNetworkDevice {
+			if dst.Network.NetworkDevices[i].Name == DefaultNetworkDevice {
 				name = DefaultNetworkDevice
 				model = ptr.Deref(src.Network.Default.Model, "")
 				bridge = src.Network.Default.Bridge
@@ -120,7 +120,7 @@ func restoreProxmoxMachineSpec(src *ProxmoxMachineSpec, dst *infrav1.ProxmoxMach
 
 			Convert_string_To_Pointer_string(model, ok, restored.Network.NetworkDevices[i].Model, &dst.Network.NetworkDevices[i].Model)
 			Convert_string_To_Pointer_string(bridge, ok, restored.Network.NetworkDevices[i].Bridge, &dst.Network.NetworkDevices[i].Bridge)
-			Convert_string_To_NetName(name, ok, restored.Network.NetworkDevices[i].Name, &dst.Network.NetworkDevices[i].Name)
+			dst.Network.NetworkDevices[i].Name = infrav1.NetName(name)
 
 			if dst.Network.NetworkDevices[i].Routing.Routes != nil {
 				for j := range dst.Network.NetworkDevices[i].Routing.Routes {
@@ -153,7 +153,7 @@ func restoreProxmoxMachineSpec(src *ProxmoxMachineSpec, dst *infrav1.ProxmoxMach
 	if dst.Network == nil {
 		dst.Network = &infrav1.NetworkSpec{
 			NetworkDevices: []infrav1.NetworkDevice{{
-				Name:        ptr.To(DefaultNetworkDevice),
+				Name:        infrav1.DefaultNetworkDevice,
 				DefaultIPv4: ptr.To(true),
 				DefaultIPv6: ptr.To(true),
 				Bridge:      ptr.To("vmbr0"),

--- a/api/v1alpha2/proxmoxmachine_types.go
+++ b/api/v1alpha2/proxmoxmachine_types.go
@@ -39,7 +39,7 @@ const (
 	DefaultReconcilerRequeue = 10 * time.Second
 
 	// DefaultNetworkDevice is the default network device name.
-	DefaultNetworkDevice = "net0"
+	DefaultNetworkDevice = NetName("net0")
 
 	// DefaultSuffix is the default suffix for the network device.
 	DefaultSuffix = "inet"
@@ -514,8 +514,8 @@ type ProxmoxMachineInitializationStatus struct {
 // IPAddressesSpec stores the IP addresses of a network interface. Used for status.
 type IPAddressesSpec struct {
 	// net is the proxmox network name these ipaddresses are attached to.
+	// +kubebuilder:validation:MinLength=4
 	// +kubebuilder:validation:Pattern=`^(net[0-9]+|default)$`
-	// +kubebuilder:validation:MinLength=1
 	// +required
 	NetName string `json:"net,omitempty"`
 
@@ -604,10 +604,10 @@ func (r *ProxmoxMachine) GetIPAddresses() []IPAddressesSpec {
 }
 
 // GetIPAddressesNet returns the ipaddresses status for a network or nil.
-func (r *ProxmoxMachine) GetIPAddressesNet(name string) *IPAddressesSpec {
+func (r *ProxmoxMachine) GetIPAddressesNet(name NetName) *IPAddressesSpec {
 	addresses := r.GetIPAddresses()
 	index := slices.IndexFunc(addresses, func(s IPAddressesSpec) bool {
-		return name == s.NetName
+		return string(name) == s.NetName
 	})
 
 	if index < 0 {

--- a/api/v1alpha2/proxmoxmachine_types_test.go
+++ b/api/v1alpha2/proxmoxmachine_types_test.go
@@ -53,7 +53,7 @@ func defaultMachine() *ProxmoxMachine {
 			},
 			Network: &NetworkSpec{
 				NetworkDevices: []NetworkDevice{{
-					Name: ptr.To("net0"),
+					Name: DefaultNetworkDevice,
 				}},
 			},
 		},
@@ -220,7 +220,7 @@ var _ = Describe("ProxmoxMachine Test", func() {
 			dm := defaultMachine()
 			dm.Spec.Network = &NetworkSpec{
 				NetworkDevices: []NetworkDevice{{
-					Name:   ptr.To("asdf"),
+					Name:   "asdf",
 					Bridge: ptr.To("vmbr0"),
 				}},
 			}
@@ -234,7 +234,7 @@ var _ = Describe("ProxmoxMachine Test", func() {
 				NetworkDevices: []NetworkDevice{{
 					Bridge: ptr.To("vmbr0"),
 				}, {
-					Name: ptr.To("net0"),
+					Name: DefaultNetworkDevice,
 					InterfaceConfig: InterfaceConfig{
 						IPPoolRef: []corev1.TypedLocalObjectReference{{
 							APIGroup: ptr.To("ipam.cluster.x-k8s.io"),
@@ -253,7 +253,7 @@ var _ = Describe("ProxmoxMachine Test", func() {
 			dm.Spec.Network = &NetworkSpec{
 				NetworkDevices: []NetworkDevice{{
 					Bridge: ptr.To("vmbr0"),
-					Name:   ptr.To("net1"),
+					Name:   "net1",
 					InterfaceConfig: InterfaceConfig{
 						IPPoolRef: []corev1.TypedLocalObjectReference{{
 							APIGroup: ptr.To("apps"),
@@ -270,7 +270,7 @@ var _ = Describe("ProxmoxMachine Test", func() {
 			dm.Spec.Network = &NetworkSpec{
 				NetworkDevices: []NetworkDevice{{
 					Bridge: ptr.To("vmbr0"),
-					Name:   ptr.To("net1"),
+					Name:   "net1",
 					InterfaceConfig: InterfaceConfig{
 						IPPoolRef: []corev1.TypedLocalObjectReference{{
 							APIGroup: ptr.To("ipam.cluster.x-k8s.io"),

--- a/api/v1alpha2/types.go
+++ b/api/v1alpha2/types.go
@@ -106,8 +106,9 @@ type NetworkStatus struct {
 }
 
 // NetName is a formally verified Proxmox network name string.
+// +kubebuilder:validation:MinLength=4
 // +kubebuilder:validation:Pattern=`^net[0-9]+$`
-type NetName *string
+type NetName string
 
 // Zone is a formally verified Proxmox network zone name. Needs to adhere to Label rules.
 // +kubebuilder:validation:Pattern=`^[a-z0-9A-Z](?:[a-z0-9A-Z-_.]{0,61}[a-z0-9A-Z])?$`

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -207,11 +207,6 @@ func (in *NetworkDevice) DeepCopyInto(out *NetworkDevice) {
 		*out = new(int32)
 		**out = **in
 	}
-	if in.Name != nil {
-		in, out := &in.Name, &out.Name
-		*out = new(string)
-		**out = **in
-	}
 	in.InterfaceConfig.DeepCopyInto(&out.InterfaceConfig)
 }
 
@@ -265,11 +260,6 @@ func (in *NetworkStatus) DeepCopyInto(out *NetworkStatus) {
 		in, out := &in.IPAddrs, &out.IPAddrs
 		*out = make([]string, len(*in))
 		copy(*out, *in)
-	}
-	if in.NetworkName != nil {
-		in, out := &in.NetworkName, &out.NetworkName
-		*out = new(string)
-		**out = **in
 	}
 }
 
@@ -1159,13 +1149,7 @@ func (in *VRFDevice) DeepCopyInto(out *VRFDevice) {
 	if in.Interfaces != nil {
 		in, out := &in.Interfaces, &out.Interfaces
 		*out = make([]NetName, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(string)
-				**out = **in
-			}
-		}
+		copy(*out, *in)
 	}
 	in.Routing.DeepCopyInto(&out.Routing)
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachines.yaml
@@ -1096,6 +1096,7 @@ spec:
                         name:
                           default: net0
                           description: name is the network device name.
+                          minLength: 4
                           pattern: ^net[0-9]+$
                           type: string
                         routes:
@@ -1177,6 +1178,7 @@ spec:
                           items:
                             description: NetName is a formally verified Proxmox network
                               name string.
+                            minLength: 4
                             pattern: ^net[0-9]+$
                             type: string
                           type: array
@@ -1528,7 +1530,7 @@ spec:
                     net:
                       description: net is the proxmox network name these ipaddresses
                         are attached to.
-                      minLength: 1
+                      minLength: 4
                       pattern: ^(net[0-9]+|default)$
                       type: string
                   required:
@@ -1566,6 +1568,7 @@ spec:
                       type: string
                     networkName:
                       description: networkName is the name of the network.
+                      minLength: 4
                       pattern: ^net[0-9]+$
                       type: string
                   required:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachinetemplates.yaml
@@ -962,6 +962,7 @@ spec:
                                 name:
                                   default: net0
                                   description: name is the network device name.
+                                  minLength: 4
                                   pattern: ^net[0-9]+$
                                   type: string
                                 routes:
@@ -1048,6 +1049,7 @@ spec:
                                   items:
                                     description: NetName is a formally verified Proxmox
                                       network name string.
+                                    minLength: 4
                                     pattern: ^net[0-9]+$
                                     type: string
                                   type: array

--- a/internal/service/vmservice/bootstrap.go
+++ b/internal/service/vmservice/bootstrap.go
@@ -216,17 +216,15 @@ func getNetworkConfigData(ctx context.Context, machineScope *scope.MachineScope)
 	return networkConfigData, nil
 }
 
-func getNetworkConfigDataForDevice(ctx context.Context, machineScope *scope.MachineScope, device string, ipPoolRefs map[corev1.TypedLocalObjectReference][]ipamv1.IPAddress) (*types.NetworkConfigData, error) {
+func getNetworkConfigDataForDevice(ctx context.Context, machineScope *scope.MachineScope, device infrav1.NetName, ipPoolRefs map[corev1.TypedLocalObjectReference][]ipamv1.IPAddress) (*types.NetworkConfigData, error) {
 	if device == "" {
 		// this should never happen outwith tests
 		return nil, errors.New("empty device name")
 	}
 
 	nets := machineScope.VirtualMachine.VirtualMachineConfig.MergeNets()
-	// For nics supporting multiple IP addresses, we need to cut the '-inet' or '-inet6' part,
-	// to retrieve the correct MAC address.
-	formattedDevice, _, _ := strings.Cut(device, "-")
-	macAddress := extractMACAddress(nets[formattedDevice])
+
+	macAddress := extractMACAddress(nets[string(device)])
 	if len(macAddress) == 0 {
 		machineScope.Logger.Error(errors.New("unable to extract mac address"), "device has no mac address", "device", device)
 		return nil, errors.New("unable to extract mac address")
@@ -286,7 +284,7 @@ func getCommonInterfaceConfig(_ context.Context, _ *scope.MachineScope, ciconfig
 
 func getNetworkDevices(ctx context.Context, machineScope *scope.MachineScope, network infrav1.NetworkSpec) ([]types.NetworkConfigData, error) {
 	networkConfigData := make([]types.NetworkConfigData, 0, len(network.NetworkDevices))
-	ipAddressMap := make(map[string]map[corev1.TypedLocalObjectReference][]ipamv1.IPAddress)
+	ipAddressMap := make(map[infrav1.NetName]map[corev1.TypedLocalObjectReference][]ipamv1.IPAddress)
 
 	requeue, err := handleDevices(ctx, machineScope, ipAddressMap)
 	if requeue || err != nil {
@@ -298,12 +296,11 @@ func getNetworkDevices(ctx context.Context, machineScope *scope.MachineScope, ne
 	for i, nic := range network.NetworkDevices {
 		var config = ptr.To(types.NetworkConfigData{})
 
-		// TODO: Default device IPPool api change
-		ipPoolRefs := ipAddressMap[*nic.Name]
+		ipPoolRefs := ipAddressMap[nic.Name]
 
-		conf, err := getNetworkConfigDataForDevice(ctx, machineScope, *nic.Name, ipPoolRefs)
+		conf, err := getNetworkConfigDataForDevice(ctx, machineScope, nic.Name, ipPoolRefs)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to get network config data for device=%s", *nic.Name)
+			return nil, errors.Wrapf(err, "unable to get network config data for device=%s", nic.Name)
 		}
 		if len(nic.DNSServers) != 0 {
 			config.DNSServers = nic.DNSServers
@@ -316,9 +313,8 @@ func getNetworkDevices(ctx context.Context, machineScope *scope.MachineScope, ne
 		config.Type = "ethernet"
 		config.ProxName = nic.Name
 
-		// TODO: Figure device names for eth0
 		if i == 0 {
-			config.ProxName = ptr.To("net0")
+			config.ProxName = infrav1.DefaultNetworkDevice
 		}
 
 		if len(config.MacAddress) > 0 {
@@ -339,12 +335,12 @@ func getVirtualNetworkDevices(_ context.Context, _ *scope.MachineScope, network 
 
 		for i, child := range device.Interfaces {
 			for _, net := range data {
-				if (net.Name == *child) || (ptr.Deref(net.ProxName, "") == *child) {
+				if net.Name == string(child) || net.ProxName == child {
 					config.Interfaces = append(config.Interfaces, net.Name)
 				}
 			}
 			if len(config.Interfaces)-1 < i {
-				return nil, errors.Errorf("unable to find vrf interface=%s child interface %s", config.Name, *child)
+				return nil, errors.Errorf("unable to find vrf interface=%s child interface %s", config.Name, child)
 			}
 		}
 

--- a/internal/service/vmservice/bootstrap_test.go
+++ b/internal/service/vmservice/bootstrap_test.go
@@ -49,7 +49,7 @@ const (
 var defaultNic = infrav1.NetworkDevice{
 	Bridge: ptr.To("vmbr0"),
 	Model:  ptr.To("virtio"),
-	Name:   ptr.To(infrav1.DefaultNetworkDevice),
+	Name:   infrav1.DefaultNetworkDevice,
 }
 
 func setupFakeIsoInjector(t *testing.T) *[]byte {
@@ -93,7 +93,7 @@ func addDefaultIPPool(machineScope *scope.MachineScope, offset ...int) corev1.Ty
 		offset = append(offset, 0)
 	}
 	// call to add defaultNic
-	addIPPool(machineScope, defaultPool, ptr.To(fmt.Sprintf("net%d", offset[0])))
+	addIPPool(machineScope, defaultPool, infrav1.NetName(fmt.Sprintf("net%d", offset[0])))
 	machineScope.ProxmoxMachine.Spec.Network.NetworkDevices[offset[0]].DefaultIPv4 = ptr.To(true)
 
 	setInClusterIPPoolStatus(machineScope, "test-v4-icip", infrav1.IPv4Type, nil)
@@ -110,7 +110,7 @@ func addDefaultIPPoolV6(machineScope *scope.MachineScope, offset ...int) corev1.
 		offset = append(offset, 0)
 	}
 	// call to add defaultNic
-	addIPPool(machineScope, defaultPoolV6, ptr.To(fmt.Sprintf("net%d", offset[0])))
+	addIPPool(machineScope, defaultPoolV6, infrav1.NetName(fmt.Sprintf("net%d", offset[0])))
 	machineScope.ProxmoxMachine.Spec.Network.NetworkDevices[offset[0]].DefaultIPv6 = ptr.To(true)
 
 	setInClusterIPPoolStatus(machineScope, "test-v6-icip", infrav1.IPv6Type, nil)
@@ -200,7 +200,7 @@ func TestReconcileBootstrapData_NoNetworkConfig_UpdateStatus(t *testing.T) {
 	require.Equal(t, "10.10.10.10"+"/24", networkConfigData[0].IPConfigs[0].IPAddress.String())
 	require.Equal(t, "A6:23:64:4D:84:CB", networkConfigData[0].MacAddress)
 	require.Equal(t, "eth0", networkConfigData[0].Name)
-	require.Equal(t, "net0", *networkConfigData[0].ProxName)
+	require.Equal(t, infrav1.DefaultNetworkDevice, networkConfigData[0].ProxName)
 	require.Equal(t, "ethernet", networkConfigData[0].Type)
 
 	require.Equal(t, infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForVMPowerUpReason, conditions.GetReason(machineScope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition))
@@ -216,7 +216,7 @@ func TestReconcileBootstrapData_UpdateStatus(t *testing.T) {
 
 	// NetworkSetup
 	defaultPool := addDefaultIPPool(machineScope)
-	extraPool0 := addGlobalInClusterIPPool(machineScope, "extraPool0", ptr.To("net1"))
+	extraPool0 := addGlobalInClusterIPPool(machineScope, "extraPool0", "net1")
 
 	createIPPools(t, kubeClient, machineScope)
 
@@ -243,13 +243,13 @@ func TestReconcileBootstrapData_UpdateStatus(t *testing.T) {
 	require.Equal(t, "10.10.10.10"+"/24", networkConfigData[0].IPConfigs[0].IPAddress.String())
 	require.Equal(t, "A6:23:64:4D:84:CB", networkConfigData[0].MacAddress)
 	require.Equal(t, "eth0", networkConfigData[0].Name)
-	require.Equal(t, "net0", *networkConfigData[0].ProxName)
+	require.Equal(t, infrav1.DefaultNetworkDevice, networkConfigData[0].ProxName)
 	require.Equal(t, "ethernet", networkConfigData[0].Type)
 	require.Equal(t, "10.100.10.10"+"/16", networkConfigData[1].IPConfigs[0].IPAddress.String())
 	require.Equal(t, "10.100.10.1", networkConfigData[1].IPConfigs[0].Gateway)
 	require.Equal(t, "AA:23:64:4D:84:CD", networkConfigData[1].MacAddress)
 	require.Equal(t, "eth1", networkConfigData[1].Name)
-	require.Equal(t, "net1", *networkConfigData[1].ProxName)
+	require.Equal(t, infrav1.NetName("net1"), networkConfigData[1].ProxName)
 	require.Equal(t, "ethernet", networkConfigData[1].Type)
 
 	require.Equal(t, infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForVMPowerUpReason, conditions.GetReason(machineScope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition))
@@ -360,7 +360,7 @@ func TestGetCommonInterfaceConfig_MissingIPPool(t *testing.T) {
 			{
 				Bridge: ptr.To("vmbr1"),
 				Model:  ptr.To("virtio"),
-				Name:   ptr.To("net1"),
+				Name:   "net1",
 				InterfaceConfig: infrav1.InterfaceConfig{
 					IPPoolRef: []corev1.TypedLocalObjectReference{{
 						APIGroup: ptr.To("ipam.cluster.x-k8s.io"),
@@ -387,7 +387,7 @@ func TestGetCommonInterfaceConfig(t *testing.T) {
 			{
 				Bridge: ptr.To("vmbr1"),
 				Model:  ptr.To("virtio"),
-				Name:   ptr.To("net1"),
+				Name:   "net1",
 				InterfaceConfig: infrav1.InterfaceConfig{
 					DNSServers: []string{"1.2.3.4"},
 					LinkMTU:    &MTU,
@@ -424,7 +424,7 @@ func TestGetVirtualNetworkDevices_VRFDevice_MissingInterface(t *testing.T) {
 			VRFs: []infrav1.VRFDevice{{
 				Name:       "vrf-blue",
 				Table:      500,
-				Interfaces: []infrav1.NetName{ptr.To("net1")},
+				Interfaces: []infrav1.NetName{"net1"},
 			}},
 		},
 	}
@@ -520,8 +520,8 @@ func TestReconcileBootstrapData_DualStack_AdditionalDevices(t *testing.T) {
 	addDefaultIPPoolV6(machineScope)
 
 	// NetworkSetup for extra pools.
-	addGlobalInClusterIPPool(machineScope, "extraPool0", ptr.To("net1"))
-	addGlobalInClusterIPPool(machineScope, "extraPool1", ptr.To("net1"))
+	addGlobalInClusterIPPool(machineScope, "extraPool0", "net1")
+	addGlobalInClusterIPPool(machineScope, "extraPool1", "net1")
 
 	// Create missing ip addresses and pools.
 	createNetworkSpecForMachine(t, kubeClient, machineScope, "10.10.10.10", "2001:db8::2", "10.0.0.10", "2001:db8::9")
@@ -615,7 +615,7 @@ func TestReconcileBootstrapData_VirtualDevices_VRF(t *testing.T) {
 	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
 		VirtualNetworkDevices: infrav1.VirtualNetworkDevices{
 			VRFs: []infrav1.VRFDevice{{
-				Interfaces: []infrav1.NetName{ptr.To("net1")},
+				Interfaces: []infrav1.NetName{"net1"},
 				Name:       "vrf-blue",
 				Table:      500,
 			}},
@@ -626,8 +626,8 @@ func TestReconcileBootstrapData_VirtualDevices_VRF(t *testing.T) {
 	addDefaultIPPool(machineScope)
 
 	// NetworkSetup for extra pools.
-	addGlobalInClusterIPPool(machineScope, "extraPool0", ptr.To("net0"))
-	addGlobalInClusterIPPool(machineScope, "extraPool1", ptr.To("net1"))
+	addGlobalInClusterIPPool(machineScope, "extraPool0", "net0")
+	addGlobalInClusterIPPool(machineScope, "extraPool1", "net1")
 
 	createNetworkSpecForMachine(t, kubeClient, machineScope, "10.10.10.10", "10.20.10.10/23", "10.100.10.10/22")
 
@@ -765,7 +765,7 @@ func TestReconcileBootstrapData_DefaultDeviceIPPoolRef(t *testing.T) {
 	addDefaultIPPool(machineScope)
 
 	// NetworkSetup for extra pools.
-	addGlobalInClusterIPPool(machineScope, "extraPool0", ptr.To("net0"))
+	addGlobalInClusterIPPool(machineScope, "extraPool0", "net0")
 
 	createNetworkSpecForMachine(t, kubeClient, machineScope, "10.10.10.10", "10.5.10.10/23")
 

--- a/internal/service/vmservice/helpers_test.go
+++ b/internal/service/vmservice/helpers_test.go
@@ -298,7 +298,7 @@ func createIPAddressResource(t *testing.T, c client.Client, name string, machine
 // If one objectRefs is passed then it's used as a pool (intended for most tests, typically pass 0 for offset).
 // If two objectRefs are passed then the first pool is used for the IP address name and the second for creating
 // the IP address resource (intended for createNetworkSpecForMachine, pass your poolRef index for offset).
-func createIPAddress(t *testing.T, c client.Client, machineScope *scope.MachineScope, device, ip string, offset int, pool ...*corev1.TypedLocalObjectReference) {
+func createIPAddress(t *testing.T, c client.Client, machineScope *scope.MachineScope, device infrav1.NetName, ip string, offset int, pool ...*corev1.TypedLocalObjectReference) {
 	ipPrefix, err := netip.ParsePrefix(ip)
 	if err != nil {
 		ipAddr, err := netip.ParseAddr(ip)
@@ -318,7 +318,7 @@ func createIPAddress(t *testing.T, c client.Client, machineScope *scope.MachineS
 	}
 
 	poolName := ptr.Deref(pools[0], corev1.TypedLocalObjectReference{Name: "dummy"}).Name
-	ipName := ipam.IPAddressFormat(machineScope.Name(), &poolName, offset, device)
+	ipName := ipam.IPAddressFormat(machineScope.Name(), device, offset, poolName)
 	createIPAddressResource(t, c, ipName, machineScope, ipPrefix, offset, pools[1])
 }
 
@@ -345,7 +345,7 @@ func createNetworkSpecForMachine(t *testing.T, c client.Client, machineScope *sc
 		}
 
 		for offset, poolRef := range ipPoolRefs {
-			createIPAddress(t, c, machineScope, infrav1.DefaultSuffix, ipPrefixes[i], offset, &corev1.TypedLocalObjectReference{Name: *device.Name}, &poolRef)
+			createIPAddress(t, c, machineScope, infrav1.DefaultSuffix, ipPrefixes[i], offset, &corev1.TypedLocalObjectReference{Name: string(device.Name)}, &poolRef)
 			i++
 		}
 	}

--- a/internal/service/vmservice/ip.go
+++ b/internal/service/vmservice/ip.go
@@ -47,7 +47,7 @@ func reconcileIPAddresses(ctx context.Context, machineScope *scope.MachineScope)
 	pm := machineScope.ProxmoxMachine
 
 	// TODO: This datastructure is less bad, but still bad
-	netPoolAddresses := make(map[string]map[corev1.TypedLocalObjectReference][]ipamv1.IPAddress)
+	netPoolAddresses := make(map[infrav1.NetName]map[corev1.TypedLocalObjectReference][]ipamv1.IPAddress)
 
 	if pm.Spec.Network != nil {
 		if requeue, err = handleDevices(ctx, machineScope, netPoolAddresses); err != nil || requeue {
@@ -77,7 +77,7 @@ func reconcileIPAddresses(ctx context.Context, machineScope *scope.MachineScope)
 			return aOffset - bOffset
 		})
 		ipSpec := infrav1.IPAddressesSpec{
-			NetName: net,
+			NetName: string(net),
 		}
 		for _, address := range addresses {
 			if isIPv4(address.Spec.Address) {
@@ -153,7 +153,7 @@ func findIPAddressGatewayMetric(ctx context.Context, machineScope *scope.Machine
 }
 
 func handleIPAddresses(ctx context.Context, machineScope *scope.MachineScope, ipClaimDef ipam.IPClaimDef) ([]ipamv1.IPAddress, error) {
-	device := ptr.Deref(ipClaimDef.Device, infrav1.DefaultNetworkDevice)
+	device := ipClaimDef.Device
 
 	ipAddresses, err := findIPAddress(ctx, ipClaimDef.PoolRef, machineScope)
 	if err != nil {
@@ -183,7 +183,7 @@ func handleIPAddresses(ctx context.Context, machineScope *scope.MachineScope, ip
 	return ipAddresses, nil
 }
 
-func handleDevices(ctx context.Context, machineScope *scope.MachineScope, addresses map[string]map[corev1.TypedLocalObjectReference][]ipamv1.IPAddress) (bool, error) {
+func handleDevices(ctx context.Context, machineScope *scope.MachineScope, addresses map[infrav1.NetName]map[corev1.TypedLocalObjectReference][]ipamv1.IPAddress) (bool, error) {
 	// paranoidly handle callers handing us an empty map
 	if addresses == nil {
 		return false, errors.New("handleDevices called without a map")
@@ -238,13 +238,13 @@ func handleDevices(ctx context.Context, machineScope *scope.MachineScope, addres
 				continue
 			}
 
-			poolMap := addresses[*net.Name]
+			poolMap := addresses[net.Name]
 			if poolMap == nil {
 				poolMap = make(map[corev1.TypedLocalObjectReference][]ipamv1.IPAddress)
 			}
 
 			poolMap[ipPool] = ipAddresses
-			addresses[*net.Name] = poolMap
+			addresses[net.Name] = poolMap
 
 			// append default pool addresses to map
 			if _, exists := defaultPoolMap[ipPool]; exists && ptr.Deref(net.DefaultIPv4, false) || ptr.Deref(net.DefaultIPv6, false) {

--- a/internal/service/vmservice/ip_test.go
+++ b/internal/service/vmservice/ip_test.go
@@ -40,7 +40,7 @@ func TestReconcileIPAddresses_CreateDefaultClaim(t *testing.T) {
 	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
 		NetworkDevices: []infrav1.NetworkDevice{
 			{
-				Name:        ptr.To("net0"),
+				Name:        infrav1.DefaultNetworkDevice,
 				DefaultIPv4: ptr.To(true),
 			},
 		},
@@ -75,9 +75,9 @@ func TestReconcileIPAddresses_CreateAdditionalClaim(t *testing.T) {
 
 	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
 		NetworkDevices: []infrav1.NetworkDevice{
-			{Name: ptr.To("net0")},
+			{Name: infrav1.DefaultNetworkDevice},
 			{
-				Name: ptr.To("net1"),
+				Name: "net1",
 				InterfaceConfig: infrav1.InterfaceConfig{
 					IPPoolRef: []corev1.TypedLocalObjectReference{extraPool0},
 				},
@@ -122,7 +122,7 @@ func TestReconcileIPAddresses_AddIPTag(t *testing.T) {
 	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
 		NetworkDevices: []infrav1.NetworkDevice{
 			{
-				Name:        ptr.To("net0"),
+				Name:        infrav1.DefaultNetworkDevice,
 				DefaultIPv4: ptr.To(true),
 			},
 		},
@@ -167,11 +167,11 @@ func TestReconcileIPAddresses_SetIPAddresses(t *testing.T) {
 	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
 		NetworkDevices: []infrav1.NetworkDevice{
 			{
-				Name:        ptr.To("net0"),
+				Name:        infrav1.DefaultNetworkDevice,
 				DefaultIPv4: ptr.To(true),
 			},
 			{
-				Name: ptr.To("net1"),
+				Name: "net1",
 				InterfaceConfig: infrav1.InterfaceConfig{
 					IPPoolRef: []corev1.TypedLocalObjectReference{extraPool0},
 				},
@@ -194,7 +194,7 @@ func TestReconcileIPAddresses_SetIPAddresses(t *testing.T) {
 	require.NotNil(t, machineScope.ProxmoxMachine.GetIPAddressesNet("net0"))
 	require.Equal(
 		t,
-		infrav1.IPAddressesSpec{NetName: infrav1.DefaultNetworkDevice, IPv4: []string{"10.10.10.10"}, IPv6: nil},
+		infrav1.IPAddressesSpec{NetName: string(infrav1.DefaultNetworkDevice), IPv4: []string{"10.10.10.10"}, IPv6: nil},
 		*machineScope.ProxmoxMachine.GetIPAddressesNet(infrav1.DefaultNetworkDevice),
 	)
 	require.NotNil(t, machineScope.ProxmoxMachine.GetIPAddressesNet("net1"))
@@ -232,16 +232,16 @@ func TestReconcileIPAddresses_MultipleDevices(t *testing.T) {
 	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
 		NetworkDevices: []infrav1.NetworkDevice{
 			{
-				Name:            ptr.To(infrav1.DefaultNetworkDevice),
+				Name:            infrav1.DefaultNetworkDevice,
 				DefaultIPv4:     ptr.To(true),
 				InterfaceConfig: infrav1.InterfaceConfig{IPPoolRef: []corev1.TypedLocalObjectReference{ipv4pool0}},
 			},
 			{
-				Name:            ptr.To("net1"),
+				Name:            "net1",
 				InterfaceConfig: infrav1.InterfaceConfig{IPPoolRef: []corev1.TypedLocalObjectReference{ipv4pool1}},
 			},
 			{
-				Name:            ptr.To("net2"),
+				Name:            "net2",
 				InterfaceConfig: infrav1.InterfaceConfig{IPPoolRef: []corev1.TypedLocalObjectReference{ipv6pool}},
 			},
 		},
@@ -332,12 +332,12 @@ func TestReconcileIPAddresses_IPv6(t *testing.T) {
 	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
 		NetworkDevices: []infrav1.NetworkDevice{
 			{
-				Name:        ptr.To("net0"),
+				Name:        infrav1.DefaultNetworkDevice,
 				DefaultIPv4: ptr.To(true),
 				DefaultIPv6: ptr.To(true),
 			},
 			{
-				Name:            ptr.To("net1"),
+				Name:            "net1",
 				InterfaceConfig: infrav1.InterfaceConfig{IPPoolRef: []corev1.TypedLocalObjectReference{extraPool0}},
 			},
 		},
@@ -362,7 +362,7 @@ func TestReconcileIPAddresses_IPv6(t *testing.T) {
 
 	require.NotNil(t, machineScope.ProxmoxMachine.GetIPAddressesNet("net0"))
 	require.Equal(t,
-		infrav1.IPAddressesSpec{NetName: infrav1.DefaultNetworkDevice, IPv4: []string{"10.10.10.10"}, IPv6: []string{"fe80::1"}},
+		infrav1.IPAddressesSpec{NetName: string(infrav1.DefaultNetworkDevice), IPv4: []string{"10.10.10.10"}, IPv6: []string{"fe80::1"}},
 		*machineScope.ProxmoxMachine.GetIPAddressesNet("net0"),
 	)
 	require.NotNil(t, machineScope.ProxmoxMachine.GetIPAddressesNet("net1"))
@@ -399,12 +399,12 @@ func TestReconcileIPAddresses_MachineIPPoolRef(t *testing.T) {
 	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
 		NetworkDevices: []infrav1.NetworkDevice{
 			{
-				Name:            ptr.To("net0"),
+				Name:            "net0",
 				DefaultIPv4:     ptr.To(true),
 				InterfaceConfig: infrav1.InterfaceConfig{IPPoolRef: []corev1.TypedLocalObjectReference{extraPool0, extraPool0}},
 			},
 			{
-				Name:            ptr.To("net1"),
+				Name:            "net1",
 				InterfaceConfig: infrav1.InterfaceConfig{IPPoolRef: []corev1.TypedLocalObjectReference{extraPool1, extraPool2, extraPool1, extraPool2}},
 			},
 		},

--- a/internal/service/vmservice/power_test.go
+++ b/internal/service/vmservice/power_test.go
@@ -29,7 +29,7 @@ func TestReconcilePowerState_SetTaskRef(t *testing.T) {
 	ctx := context.TODO()
 	machineScope, proxmoxClient, _ := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForVMPowerUpReason)
 	machineScope.ProxmoxMachine.Status.IPAddresses = []infrav1.IPAddressesSpec{{
-		NetName: infrav1.DefaultNetworkDevice,
+		NetName: string(infrav1.DefaultNetworkDevice),
 		IPv4:    []string{"10.10.10.10"},
 	}, {
 		NetName: "default",

--- a/internal/service/vmservice/utils.go
+++ b/internal/service/vmservice/utils.go
@@ -18,7 +18,6 @@ package vmservice
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -148,7 +147,11 @@ func shouldUpdateNetworkDevices(machineScope *scope.MachineScope) bool {
 
 	devices := machineScope.ProxmoxMachine.Spec.Network.NetworkDevices
 	for _, v := range devices {
-		net := nets[ptr.Deref(v.Name, infrav1.DefaultNetworkDevice)]
+		name := v.Name
+		if len(name) == 0 {
+			name = infrav1.DefaultNetworkDevice
+		}
+		net := nets[string(name)]
 		// device is empty.
 		if len(net) == 0 {
 			return true
@@ -210,13 +213,9 @@ func extractMACAddress(input string) string {
 
 // NetNameToOffset converts a proxmox network name to a NetworkDevice offset.
 func NetNameToOffset(name infrav1.NetName) (int, error) {
-	if name == nil {
-		return -1, errors.New("called without input")
-	}
-
-	offset, found := strings.CutPrefix(*name, "net")
+	offset, found := strings.CutPrefix(string(name), "net")
 	if !found {
-		return -1, fmt.Errorf("invalid proxmox network name: %s", *name)
+		return -1, fmt.Errorf("invalid proxmox network name: %s", name)
 	}
 
 	return strconv.Atoi(offset)
@@ -224,5 +223,5 @@ func NetNameToOffset(name infrav1.NetName) (int, error) {
 
 // OffsetToNetName converts an integer to a proxmox network name.
 func OffsetToNetName(offset uint8) infrav1.NetName {
-	return ptr.To(fmt.Sprintf("net%d", offset))
+	return infrav1.NetName(fmt.Sprintf("net%d", offset))
 }

--- a/internal/service/vmservice/utils_test.go
+++ b/internal/service/vmservice/utils_test.go
@@ -187,7 +187,11 @@ func TestShouldUpdateNetworkDevices_MissingAdditionalDeviceOnVM(t *testing.T) {
 	machineScope, _, _ := setupReconcilerTest(t)
 	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
 		NetworkDevices: []infrav1.NetworkDevice{
-			{Name: ptr.To("net1"), Bridge: ptr.To("vmbr1"), Model: ptr.To("virtio")},
+			{
+				Name:   "net1",
+				Bridge: ptr.To("vmbr1"),
+				Model:  ptr.To("virtio"),
+			},
 		},
 	}
 	machineScope.SetVirtualMachine(newVMWithNets("virtio=A6:23:64:4D:84:CB,bridge=vmbr0"))
@@ -199,7 +203,11 @@ func TestShouldUpdateNetworkDevices_AdditionalDeviceNeedsUpdate(t *testing.T) {
 	machineScope, _, _ := setupReconcilerTest(t)
 	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
 		NetworkDevices: []infrav1.NetworkDevice{
-			{Name: ptr.To("net1"), Bridge: ptr.To("vmbr1"), Model: ptr.To("virtio")},
+			{
+				Name:   "net1",
+				Bridge: ptr.To("vmbr1"),
+				Model:  ptr.To("virtio"),
+			},
 		},
 	}
 	machineScope.SetVirtualMachine(newVMWithNets("", "virtio=A6:23:64:4D:84:CB,bridge=vmbr0"))
@@ -211,8 +219,17 @@ func TestShouldUpdateNetworkDevices_NoUpdate(t *testing.T) {
 	machineScope, _, _ := setupReconcilerTest(t)
 	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
 		NetworkDevices: []infrav1.NetworkDevice{
-			{Bridge: ptr.To("vmbr0"), Model: ptr.To("virtio"), MTU: ptr.To(int32(1500))},
-			{Name: ptr.To("net1"), Bridge: ptr.To("vmbr1"), Model: ptr.To("virtio"), MTU: ptr.To(int32(1500))},
+			{
+				Bridge: ptr.To("vmbr0"),
+				Model:  ptr.To("virtio"),
+				MTU:    ptr.To[int32](1500),
+			},
+			{
+				Name:   "net1",
+				Bridge: ptr.To("vmbr1"),
+				Model:  ptr.To("virtio"),
+				MTU:    ptr.To[int32](1500),
+			},
 		},
 	}
 	machineScope.SetVirtualMachine(newVMWithNets("virtio=A6:23:64:4D:84:CD,bridge=vmbr0,mtu=1500", "virtio=A6:23:64:4D:84:CD,bridge=vmbr1,mtu=1500"))

--- a/internal/service/vmservice/vm.go
+++ b/internal/service/vmservice/vm.go
@@ -19,7 +19,6 @@ package vmservice
 
 import (
 	"context"
-	"fmt"
 	"slices"
 	"strings"
 
@@ -318,11 +317,10 @@ func reconcileVirtualMachineConfig(ctx context.Context, machineScope *scope.Mach
 
 	// Network vmbrs.
 	if machineScope.ProxmoxMachine.Spec.Network != nil && shouldUpdateNetworkDevices(machineScope) {
-		// handing additional network devices.
 		devices := machineScope.ProxmoxMachine.Spec.Network.NetworkDevices
-		for i, v := range devices {
+		for _, v := range devices {
 			vmOptions = append(vmOptions, proxmox.VirtualMachineOption{
-				Name:  ptr.Deref(v.Name, fmt.Sprintf("net%d", i)),
+				Name:  string(v.Name),
 				Value: formatNetworkDevice(ptr.Deref(v.Model, "virtio"), ptr.Deref(v.Bridge, ""), v.MTU, v.VLAN),
 			})
 		}

--- a/internal/service/vmservice/vm_test.go
+++ b/internal/service/vmservice/vm_test.go
@@ -425,8 +425,8 @@ func TestReconcileVirtualMachineConfig_ApplyConfig(t *testing.T) {
 	machineScope.ProxmoxMachine.Spec.MemoryMiB = ptr.To(int32(16 * 1024))
 	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
 		NetworkDevices: []infrav1.NetworkDevice{
-			{Name: ptr.To("net0"), Bridge: ptr.To("vmbr0"), Model: ptr.To("virtio"), MTU: ptr.To(int32(1500))},
-			{Name: ptr.To("net1"), Bridge: ptr.To("vmbr1"), Model: ptr.To("virtio"), MTU: ptr.To(int32(1500))},
+			{Name: "net0", Bridge: ptr.To("vmbr0"), Model: ptr.To("virtio"), MTU: ptr.To[int32](1500)},
+			{Name: "net1", Bridge: ptr.To("vmbr1"), Model: ptr.To("virtio"), MTU: ptr.To[int32](1500)},
 		},
 	}
 
@@ -438,8 +438,8 @@ func TestReconcileVirtualMachineConfig_ApplyConfig(t *testing.T) {
 		proxmox.VirtualMachineOption{Name: optionCores, Value: *machineScope.ProxmoxMachine.Spec.NumCores},
 		proxmox.VirtualMachineOption{Name: optionMemory, Value: *machineScope.ProxmoxMachine.Spec.MemoryMiB},
 		proxmox.VirtualMachineOption{Name: optionDescription, Value: machineScope.ProxmoxMachine.Spec.Description},
-		proxmox.VirtualMachineOption{Name: "net0", Value: formatNetworkDevice("virtio", "vmbr0", ptr.To(int32(1500)), nil)},
-		proxmox.VirtualMachineOption{Name: "net1", Value: formatNetworkDevice("virtio", "vmbr1", ptr.To(int32(1500)), nil)},
+		proxmox.VirtualMachineOption{Name: "net0", Value: formatNetworkDevice("virtio", "vmbr0", ptr.To[int32](1500), nil)},
+		proxmox.VirtualMachineOption{Name: "net1", Value: formatNetworkDevice("virtio", "vmbr1", ptr.To[int32](1500), nil)},
 	}
 
 	proxmoxClient.EXPECT().ConfigureVM(context.Background(), vm, expectedOptions...).Return(task, nil).Once()
@@ -527,7 +527,7 @@ func TestReconcileMachineAddresses_IPv4(t *testing.T) {
 	machineScope.SetVirtualMachine(vm)
 	machineScope.SetVirtualMachineID(int64(vm.VMID))
 	machineScope.ProxmoxMachine.Status.IPAddresses = []infrav1.IPAddressesSpec{{
-		NetName: infrav1.DefaultNetworkDevice,
+		NetName: string(infrav1.DefaultNetworkDevice),
 		IPv4:    []string{"10.10.10.10"},
 	}, {
 		NetName: "default",
@@ -553,7 +553,7 @@ func TestReconcileMachineAddresses_IPv6(t *testing.T) {
 	machineScope.SetVirtualMachine(vm)
 	machineScope.SetVirtualMachineID(int64(vm.VMID))
 	machineScope.ProxmoxMachine.Status.IPAddresses = []infrav1.IPAddressesSpec{{
-		NetName: infrav1.DefaultNetworkDevice,
+		NetName: string(infrav1.DefaultNetworkDevice),
 		IPv6:    []string{"2001:db8::2"},
 	}, {
 		NetName: "default",
@@ -578,7 +578,7 @@ func TestReconcileMachineAddresses_DualStack(t *testing.T) {
 	machineScope.SetVirtualMachine(vm)
 	machineScope.SetVirtualMachineID(int64(vm.VMID))
 	machineScope.ProxmoxMachine.Status.IPAddresses = []infrav1.IPAddressesSpec{{
-		NetName: infrav1.DefaultNetworkDevice,
+		NetName: string(infrav1.DefaultNetworkDevice),
 		IPv4:    []string{"10.10.10.10"},
 		IPv6:    []string{"2001:db8::2"},
 	}, {
@@ -601,8 +601,8 @@ func TestReconcileVirtualMachineConfigVLAN(t *testing.T) {
 	machineScope.ProxmoxMachine.Spec.MemoryMiB = ptr.To(int32(16 * 1024))
 	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
 		NetworkDevices: []infrav1.NetworkDevice{
-			{Name: ptr.To("net0"), Bridge: ptr.To("vmbr0"), Model: ptr.To("virtio"), VLAN: ptr.To(int32(100))},
-			{Name: ptr.To("net1"), Bridge: ptr.To("vmbr1"), Model: ptr.To("virtio"), VLAN: ptr.To(int32(100))},
+			{Name: infrav1.NetName("net0"), Bridge: ptr.To("vmbr0"), Model: ptr.To("virtio"), VLAN: ptr.To(int32(100))},
+			{Name: infrav1.NetName("net1"), Bridge: ptr.To("vmbr1"), Model: ptr.To("virtio"), VLAN: ptr.To(int32(100))},
 		},
 	}
 
@@ -642,7 +642,7 @@ func TestReconcileVM_CloudInitFailed(t *testing.T) {
 	vm := newRunningVM()
 	machineScope.SetVirtualMachineID(int64(vm.VMID))
 	machineScope.ProxmoxMachine.Status.IPAddresses = []infrav1.IPAddressesSpec{{
-		NetName: infrav1.DefaultNetworkDevice,
+		NetName: string(infrav1.DefaultNetworkDevice),
 		IPv4:    []string{"10.10.10.10"},
 	}, {
 		NetName: "default",
@@ -668,7 +668,7 @@ func TestReconcileVM_CloudInitRunning(t *testing.T) {
 	vm := newRunningVM()
 	machineScope.SetVirtualMachineID(int64(vm.VMID))
 	machineScope.ProxmoxMachine.Status.IPAddresses = []infrav1.IPAddressesSpec{{
-		NetName: infrav1.DefaultNetworkDevice,
+		NetName: string(infrav1.DefaultNetworkDevice),
 		IPv4:    []string{"10.10.10.10"},
 	}, {
 		NetName: "default",

--- a/internal/webhook/proxmoxmachine_webhook.go
+++ b/internal/webhook/proxmoxmachine_webhook.go
@@ -117,7 +117,7 @@ func validateNetworks(machine *infrav1.ProxmoxMachine) error {
 
 	sortedNetworks := machine.Spec.Network.NetworkDevices
 	slices.SortFunc(sortedNetworks, func(nd1, nd2 infrav1.NetworkDevice) int {
-		return strings.Compare(*nd1.Name, *nd2.Name)
+		return strings.Compare(string(nd1.Name), string(nd2.Name))
 	})
 
 	defaultIPv4Count := 0
@@ -289,7 +289,7 @@ func (p *ProxmoxMachine) Default(_ context.Context, obj runtime.Object) error {
 	}
 
 	// We guarantee that DefaultNetworkDevice is a valid proxmox network device.
-	offset, _ := vmservice.NetNameToOffset(ptr.To(infrav1.DefaultNetworkDevice))
+	offset, _ := vmservice.NetNameToOffset(infrav1.DefaultNetworkDevice)
 	if defaultIPv4Count == 0 {
 		machine.Spec.Network.NetworkDevices[offset].DefaultIPv4 = ptr.To(true)
 	}

--- a/internal/webhook/proxmoxmachine_webhook_test.go
+++ b/internal/webhook/proxmoxmachine_webhook_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Controller Test", func() {
 
 		It("should disallow having two devices named net0", func() {
 			machine := validProxmoxMachine("net-additional-name-net0")
-			machine.Spec.Network.NetworkDevices[1].Name = ptr.To("net0")
+			machine.Spec.Network.NetworkDevices[1].Name = "net0"
 			g.Expect(k8sClient.Create(testEnv.GetContext(), &machine)).To(MatchError(ContainSubstring("Duplicate value")))
 		})
 
@@ -162,7 +162,7 @@ var _ = Describe("Controller Test", func() {
 
 		It("should not allow non consecutive network interface names ", func() {
 			machine := validProxmoxMachine("non-consecutive-netname")
-			machine.Spec.Network.NetworkDevices[1].Name = ptr.To("net2")
+			machine.Spec.Network.NetworkDevices[1].Name = "net2"
 			g.Expect(k8sClient.Create(testEnv.GetContext(), &machine)).To(MatchError(ContainSubstring("consecutive")))
 		})
 	})
@@ -223,13 +223,13 @@ func validProxmoxMachine(name string) infrav1.ProxmoxMachine {
 			},
 			Network: &infrav1.NetworkSpec{
 				NetworkDevices: []infrav1.NetworkDevice{{
-					Name:   ptr.To("net0"),
+					Name:   infrav1.NetName("net0"),
 					Bridge: ptr.To("vmbr1"),
 					Model:  ptr.To("virtio"),
 					MTU:    ptr.To(int32(1500)),
 					VLAN:   ptr.To(int32(100)),
 				}, {
-					Name:   ptr.To("net1"),
+					Name:   infrav1.NetName("net1"),
 					Bridge: ptr.To("vmbr2"),
 					Model:  ptr.To("virtio"),
 					MTU:    ptr.To(int32(1500)),
@@ -266,10 +266,10 @@ func validProxmoxMachine(name string) infrav1.ProxmoxMachine {
 func invalidMTUProxmoxMachine(name string) infrav1.ProxmoxMachine {
 	machine := validProxmoxMachine(name)
 	machine.Spec.Network.NetworkDevices = []infrav1.NetworkDevice{{
-		Name:   ptr.To("net0"),
+		Name:   infrav1.DefaultNetworkDevice,
 		Bridge: ptr.To("vmbr1"),
 		Model:  ptr.To("virtio"),
-		MTU:    ptr.To(int32(50)),
+		MTU:    ptr.To[int32](50),
 	}}
 	return machine
 }
@@ -277,10 +277,10 @@ func invalidMTUProxmoxMachine(name string) infrav1.ProxmoxMachine {
 func invalidVLANProxmoxMachine(name string) infrav1.ProxmoxMachine {
 	machine := validProxmoxMachine(name)
 	machine.Spec.Network.NetworkDevices = []infrav1.NetworkDevice{{
-		Name:   ptr.To("net0"),
+		Name:   infrav1.DefaultNetworkDevice,
 		Bridge: ptr.To("vmbr1"),
 		Model:  ptr.To("virtio"),
-		VLAN:   ptr.To(int32(0)),
+		VLAN:   ptr.To[int32](0),
 	}}
 	return machine
 }

--- a/pkg/ignition/network_test.go
+++ b/pkg/ignition/network_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 
+	infrav1 "github.com/ionos-cloud/cluster-api-provider-proxmox/api/v1alpha2"
 	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/types"
 )
 
@@ -142,7 +143,7 @@ func TestRenderNetworkConfigData(t *testing.T) {
 							{IPAddress: netip.MustParsePrefix("10.0.0.98/25"), Gateway: "10.0.0.1", Metric: ptr.To(int32(100))},
 							{IPAddress: netip.MustParsePrefix("2001:db8:1::10/64"), Gateway: "2001:db8:1::1", Metric: ptr.To(int32(100))},
 						},
-						ProxName:   ptr.To("net0"),
+						ProxName:   infrav1.DefaultNetworkDevice,
 						DNSServers: []string{"10.0.1.1"},
 					},
 					{
@@ -152,7 +153,7 @@ func TestRenderNetworkConfigData(t *testing.T) {
 						IPConfigs: []types.IPConfig{
 							{IPAddress: netip.MustParsePrefix("10.0.1.84/25"), Gateway: "10.0.1.1", Metric: ptr.To(int32(200))},
 						},
-						ProxName:   ptr.To("net1"),
+						ProxName:   "net1",
 						DNSServers: []string{"10.0.1.1"},
 						FIBRules: []types.FIBRuleData{{
 							To:       ptr.To("8.7.6.5/32"),
@@ -180,7 +181,7 @@ func TestRenderNetworkConfigData(t *testing.T) {
 							{IPAddress: netip.MustParsePrefix("10.0.0.98/25"), Gateway: "10.0.0.1", Metric: ptr.To(int32(100))},
 							{IPAddress: netip.MustParsePrefix("2001:db8:1::10/64"), Gateway: "2001:db8:1::1", Metric: ptr.To(int32(100))},
 						},
-						ProxName:   ptr.To("net0"),
+						ProxName:   infrav1.DefaultNetworkDevice,
 						DNSServers: []string{"10.0.1.1"},
 					},
 					{
@@ -190,13 +191,13 @@ func TestRenderNetworkConfigData(t *testing.T) {
 						IPConfigs: []types.IPConfig{
 							{IPAddress: netip.MustParsePrefix("10.0.1.84/25"), Gateway: "10.0.1.1", Metric: ptr.To(int32(200))},
 						},
-						ProxName:   ptr.To("net1"),
+						ProxName:   "net1",
 						DNSServers: []string{"10.0.1.1"},
 					},
 					{
 						Type:       "vrf",
 						Name:       "vrf0",
-						ProxName:   ptr.To("net1"),
+						ProxName:   "net1",
 						Table:      644,
 						Interfaces: []string{"eth1"},
 						Routes: []types.RoutingData{{

--- a/pkg/kubernetes/ipam/ipam.go
+++ b/pkg/kubernetes/ipam/ipam.go
@@ -72,7 +72,7 @@ func InClusterPoolFormat(cluster *infrav1.ProxmoxCluster, zone infrav1.Zone, for
 
 // IPAddressFormat returns an ipaddress name.
 func IPAddressFormat(machineName string, proxDeviceName infrav1.NetName, offset int, suffix string) string {
-	return fmt.Sprintf("%s-%s-%02d-%s", machineName, ptr.Deref(proxDeviceName, ""), offset, suffix)
+	return fmt.Sprintf("%s-%s-%02d-%s", machineName, proxDeviceName, offset, suffix)
 }
 
 func isIPv4(ip string) (bool, error) {

--- a/pkg/kubernetes/ipam/ipam_test.go
+++ b/pkg/kubernetes/ipam/ipam_test.go
@@ -267,7 +267,7 @@ func (s *IPAMTestSuite) Test_GetIPPoolAnnotations() {
 	}, &pool))
 
 	ipClaimDef := IPClaimDef{
-		Device: ptr.To(infrav1.DefaultNetworkDevice),
+		Device: infrav1.DefaultNetworkDevice,
 		PoolRef: corev1.TypedLocalObjectReference{
 			Name:     "test-cluster-v4-icip",
 			APIGroup: GetIPAMInClusterAPIGroup(),
@@ -315,7 +315,7 @@ func (s *IPAMTestSuite) Test_GetIPPoolAnnotations() {
 	}, &globalPool))
 
 	ipClaimDef = IPClaimDef{
-		Device: ptr.To(infrav1.DefaultNetworkDevice),
+		Device: infrav1.DefaultNetworkDevice,
 		PoolRef: corev1.TypedLocalObjectReference{
 			Name:     "test-ippool-annotations",
 			APIGroup: GetIPAMInClusterAPIGroup(),
@@ -371,7 +371,7 @@ func (s *IPAMTestSuite) Test_CreateIPAddressClaimv2() {
 		Name:      "test-cluster-v4-icip",
 	}, &pool))
 
-	device := ptr.To(infrav1.DefaultNetworkDevice)
+	device := infrav1.DefaultNetworkDevice
 
 	ipClaimDef := IPClaimDef{
 		Device: device,
@@ -416,10 +416,8 @@ func (s *IPAMTestSuite) Test_CreateIPAddressClaimv2() {
 		Name:      "test-additional-cluster-icip",
 	}, &additionalPool))
 
-	additionalDevice := ptr.To("net1")
-
 	ipClaimDef = IPClaimDef{
-		Device: additionalDevice,
+		Device: "net1",
 		PoolRef: corev1.TypedLocalObjectReference{
 			Name:     "test-cluster-v4-icip",
 			APIGroup: GetIPAMInClusterAPIGroup(),
@@ -451,7 +449,7 @@ func (s *IPAMTestSuite) Test_CreateIPAddressClaimv2() {
 	}, &globalPool))
 
 	ipClaimDef = IPClaimDef{
-		Device: ptr.To("net2"),
+		Device: "net2",
 		PoolRef: corev1.TypedLocalObjectReference{
 			Name:     "test-global-cluster-icip",
 			APIGroup: GetIPAMInClusterAPIGroup(),
@@ -505,7 +503,7 @@ func (s *IPAMTestSuite) Test_GetIPAddress() {
 	}, &pool))
 
 	ipClaimDef := IPClaimDef{
-		Device: ptr.To(infrav1.DefaultNetworkDevice),
+		Device: infrav1.DefaultNetworkDevice,
 		PoolRef: corev1.TypedLocalObjectReference{
 			Name:     "test-cluster-v4-icip",
 			APIGroup: GetIPAMInClusterAPIGroup(),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
v1alpha2.NetName was a pointer in my prototype, and when Mohamed made the conversion hook, he requested no pointer changes because of rebasing.

I'm slipping this one in at the last moment, because it really shouldn't be a pointer. Name is a required field in NetworkDevices and can never be nil.

*Testing performed:*
Deployed a ClusterClass with it. Make test finishes. Linting performed.