### PR TITLE
V1alpha2/memory mib pointer fix

### DIFF
--- a/api/v1alpha2/proxmoxmachine_types.go
+++ b/api/v1alpha2/proxmoxmachine_types.go
@@ -92,6 +92,7 @@ type ProxmoxMachineSpec struct {
 	// memoryMiB is the size of a virtual machine's memory, in MiB.
 	// Defaults to the property value in the template from which the virtual machine is cloned.
 	// +kubebuilder:validation:MultipleOf=8
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	MemoryMiB *int32 `json:"memoryMiB,omitempty"`
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachines.yaml
@@ -983,6 +983,7 @@ spec:
                   memoryMiB is the size of a virtual machine's memory, in MiB.
                   Defaults to the property value in the template from which the virtual machine is cloned.
                 format: int32
+                minimum: 0
                 multipleOf: 8
                 type: integer
               metadataSettings:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_proxmoxmachinetemplates.yaml
@@ -846,6 +846,7 @@ spec:
                           memoryMiB is the size of a virtual machine's memory, in MiB.
                           Defaults to the property value in the template from which the virtual machine is cloned.
                         format: int32
+                        minimum: 0
                         multipleOf: 8
                         type: integer
                       metadataSettings:

--- a/internal/service/scheduler/vmscheduler.go
+++ b/internal/service/scheduler/vmscheduler.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 
 	"github.com/go-logr/logr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api/util"
 
 	infrav1 "github.com/ionos-cloud/cluster-api-provider-proxmox/api/v1alpha2"
@@ -82,7 +83,7 @@ func selectNode(
 
 	sort.Sort(byMemory)
 
-	requestedMemory := uint64(*machine.Spec.MemoryMiB) * 1024 * 1024 // convert to bytes
+	requestedMemory := uint64(ptr.Deref(machine.Spec.MemoryMiB, 0)) * 1024 * 1024 // convert to bytes
 	if requestedMemory > byMemory[0].AvailableMemory {
 		// no more space on the node with the highest amount of available memory
 		return "", InsufficientMemoryError{


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since MemoryMiB can be nil, this needs to also ptr.Deref. We should think about changing the API here, but I hear defaulters with omitzero are being flagged by kubeapilinter.
*Testing performed:*
Rolled out cluster with nil MemoryMiB.
