### PR TITLE
v1alpha2: port PR 665

### DIFF
--- a/internal/controller/proxmoxcluster_controller.go
+++ b/internal/controller/proxmoxcluster_controller.go
@@ -20,6 +20,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -201,7 +202,7 @@ func (r *ProxmoxClusterReconciler) reconcileNormal(ctx context.Context, clusterS
 				Message: "The ProxmoxCluster is missing or waiting for a ControlPlaneEndpoint",
 			})
 
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{RequeueAfter: 200 * time.Millisecond}, nil
 		}
 	}
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/ionos-cloud/cluster-api-provider-proxmox/issues/652

*Description of changes:*
PR is rebase of 
https://github.com/ionos-cloud/cluster-api-provider-proxmox/pull/665
against v1alpha2.

*Testing performed:*
Cluster succesfully deployed.