### PR TITLE
e2e: port to v1alpha2

### DIFF
--- a/test/e2e/capmox_test.go
+++ b/test/e2e/capmox_test.go
@@ -2,7 +2,7 @@
 // +build e2e
 
 /*
-Copyright 2024-2025 IONOS Cloud.
+Copyright 2024-2026 IONOS Cloud.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/config/proxmox-ci.yaml
+++ b/test/e2e/config/proxmox-ci.yaml
@@ -14,11 +14,11 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v1.10.4
-        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.4/core-components.yaml
+      - name: v1.11.4
+        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.4/core-components.yaml
         type: url
         files:
-          - sourcePath: "../data/shared/v1beta1/metadata.yaml"
+          - sourcePath: "../data/shared/v1beta2/metadata.yaml"
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
@@ -27,11 +27,11 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-      - name: v1.10.4
-        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.4/bootstrap-components.yaml
+      - name: v1.11.4
+        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.4/bootstrap-components.yaml
         type: url
         files:
-          - sourcePath: "../data/shared/v1beta1/metadata.yaml"
+          - sourcePath: "../data/shared/v1beta2/metadata.yaml"
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
@@ -40,11 +40,11 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-      - name: v1.10.4
-        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.4/control-plane-components.yaml
+      - name: v1.11.4
+        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.4/control-plane-components.yaml
         type: url
         files:
-          - sourcePath: "../data/shared/v1beta1/metadata.yaml"
+          - sourcePath: "../data/shared/v1beta2/metadata.yaml"
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
@@ -53,8 +53,8 @@ providers:
   - name: in-cluster
     type: IPAMProvider
     versions:
-      - name: v1.0.2
-        value: https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster/releases/download/v1.0.2/ipam-components.yaml
+      - name: v1.1.0-rc.1
+        value: https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster/releases/download/v1.1.0-rc.1/ipam-components.yaml
         type: url
         files:
           - sourcePath: "../data/shared/ipam/metadata.yaml"
@@ -66,7 +66,7 @@ providers:
   - name: proxmox
     type: InfrastructureProvider
     versions:
-      - name: v0.7.99
+      - name: v0.8.99
         value: "${PWD}/config/default"
         replacements:
           - old: ghcr.io/ionos-cloud/cluster-api-provider-proxmox:dev

--- a/test/e2e/config/proxmox-dev.yaml
+++ b/test/e2e/config/proxmox-dev.yaml
@@ -14,11 +14,11 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v1.10.4
-        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.4/core-components.yaml
+      - name: v1.11.4
+        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.4/core-components.yaml
         type: url
         files:
-          - sourcePath: "../data/shared/v1beta1/metadata.yaml"
+          - sourcePath: "../data/shared/v1beta2/metadata.yaml"
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
@@ -27,11 +27,11 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-      - name: v1.10.4
-        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.4/bootstrap-components.yaml
+      - name: v1.11.4
+        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.4/bootstrap-components.yaml
         type: url
         files:
-          - sourcePath: "../data/shared/v1beta1/metadata.yaml"
+          - sourcePath: "../data/shared/v1beta2/metadata.yaml"
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
@@ -40,11 +40,11 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-      - name: v1.10.4
-        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.10.4/control-plane-components.yaml
+      - name: v1.11.4
+        value: https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.11.4/control-plane-components.yaml
         type: url
         files:
-          - sourcePath: "../data/shared/v1beta1/metadata.yaml"
+          - sourcePath: "../data/shared/v1beta2/metadata.yaml"
         replacements:
           - old: "imagePullPolicy: Always"
             new: "imagePullPolicy: IfNotPresent"
@@ -53,8 +53,8 @@ providers:
   - name: in-cluster
     type: IPAMProvider
     versions:
-      - name: v1.0.2
-        value: https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster/releases/download/v1.0.2/ipam-components.yaml
+      - name: v1.1.0-rc.1
+        value: https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster/releases/download/v1.1.0-rc.1/ipam-components.yaml
         type: url
         files:
           - sourcePath: "../data/shared/ipam/metadata.yaml"
@@ -66,7 +66,7 @@ providers:
   - name: proxmox
     type: InfrastructureProvider
     versions:
-      - name: v0.7.99
+      - name: v0.8.99
         value: "${PWD}/config/default"
         replacements:
           - old: ghcr.io/ionos-cloud/cluster-api-provider-proxmox:dev

--- a/test/e2e/conformance_test.go
+++ b/test/e2e/conformance_test.go
@@ -2,7 +2,7 @@
 // +build e2e
 
 /*
-Copyright 2024-2025 IONOS Cloud.
+Copyright 2024-2026 IONOS Cloud.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/data/infrastructure-proxmox/cluster-template-ci.yaml
+++ b/test/e2e/data/infrastructure-proxmox/cluster-template-ci.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: "${CLUSTER_NAME}"
@@ -10,15 +10,15 @@ spec:
     pods:
       cidrBlocks: ["192.168.0.0/16"]
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: ProxmoxCluster
     name: "${CLUSTER_NAME}"
   controlPlaneRef:
     kind: KubeadmControlPlane
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiGroup: controlplane.cluster.x-k8s.io
     name: "${CLUSTER_NAME}-control-plane"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: ProxmoxCluster
 metadata:
   name: "${CLUSTER_NAME}"
@@ -34,16 +34,17 @@ spec:
   allowedNodes: ${ALLOWED_NODES:=[]}
 ---
 kind: KubeadmControlPlane
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   machineTemplate:
-    infrastructureRef:
-      kind: ProxmoxMachineTemplate
-      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
-      name: "${CLUSTER_NAME}-control-plane"
+    spec:
+      infrastructureRef:
+        kind: ProxmoxMachineTemplate
+        apiGroup: infrastructure.cluster.x-k8s.io
+        name: "${CLUSTER_NAME}-control-plane"
   kubeadmConfigSpec:
     users:
       - name: root
@@ -157,15 +158,17 @@ spec:
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          provider-id: "proxmox://'{{ ds.meta_data.instance_id }}'"
+          - name: provider-id
+            value: "proxmox://'{{ ds.meta_data.instance_id }}'"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          provider-id: "proxmox://'{{ ds.meta_data.instance_id }}'"
+          - name: provider-id
+            value: "proxmox://'{{ ds.meta_data.instance_id }}'"
   version: "${KUBERNETES_VERSION}"
 ---
 kind: ProxmoxMachineTemplate
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
@@ -183,11 +186,12 @@ spec:
           disk: ${BOOT_VOLUME_DEVICE}
           sizeGb: ${BOOT_VOLUME_SIZE:=100}
       network:
-        default:
+        networkDevices:
+        - name: net0
           bridge: ${BRIDGE}
           model: virtio
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   name: "${CLUSTER_NAME}-workers"
@@ -206,14 +210,14 @@ spec:
       bootstrap:
         configRef:
           name: "${CLUSTER_NAME}-worker"
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: KubeadmConfigTemplate
       infrastructureRef:
         name: "${CLUSTER_NAME}-worker"
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: ProxmoxMachineTemplate
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: ProxmoxMachineTemplate
 metadata:
   name: "${CLUSTER_NAME}-worker"
@@ -232,11 +236,12 @@ spec:
           disk: ${BOOT_VOLUME_DEVICE}
           sizeGb: ${BOOT_VOLUME_SIZE:=100}
       network:
-        default:
+        networkDevices:
+        - name: net0
           bridge: ${BRIDGE}
           model: virtio
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
   name: "${CLUSTER_NAME}-worker"
@@ -249,7 +254,8 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            provider-id: "proxmox://'{{ ds.meta_data.instance_id }}'"
+            - name: provider-id
+              value: "proxmox://'{{ ds.meta_data.instance_id }}'"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -257,7 +263,7 @@ metadata:
   name: "${CLUSTER_NAME}-crs-cni"
 data: ${CNI_RESOURCES}
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: "${CLUSTER_NAME}-crs-cni"

--- a/test/e2e/data/infrastructure-proxmox/cluster-template-flatcar.yaml
+++ b/test/e2e/data/infrastructure-proxmox/cluster-template-flatcar.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: "${CLUSTER_NAME}"
@@ -10,15 +10,15 @@ spec:
     pods:
       cidrBlocks: ["192.168.0.0/16"]
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: ProxmoxCluster
     name: "${CLUSTER_NAME}"
   controlPlaneRef:
     kind: KubeadmControlPlane
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiGroup: controlplane.cluster.x-k8s.io
     name: "${CLUSTER_NAME}-control-plane"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: ProxmoxCluster
 metadata:
   name: "${CLUSTER_NAME}"
@@ -34,16 +34,17 @@ spec:
   allowedNodes: ${ALLOWED_NODES:=[]}
 ---
 kind: KubeadmControlPlane
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   machineTemplate:
-    infrastructureRef:
-      kind: ProxmoxMachineTemplate
-      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
-      name: "${CLUSTER_NAME}-control-plane"
+    spec:
+      infrastructureRef:
+        kind: ProxmoxMachineTemplate
+        apiGroup: infrastructure.cluster.x-k8s.io
+        name: "${CLUSTER_NAME}-control-plane"
   kubeadmConfigSpec:
     format: ignition
     ignition:
@@ -228,15 +229,17 @@ spec:
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          provider-id: proxmox://'$${COREOS_CUSTOM_INSTANCE_ID}'
+          - name: provider-id
+            value: proxmox://'$${COREOS_CUSTOM_INSTANCE_ID}'
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          provider-id: proxmox://'$${COREOS_CUSTOM_INSTANCE_ID}'
+          - name: provider-id
+            value: proxmox://'$${COREOS_CUSTOM_INSTANCE_ID}'
   version: "${KUBERNETES_VERSION}"
 ---
 kind: ProxmoxMachineTemplate
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
@@ -254,14 +257,15 @@ spec:
           disk: ${BOOT_VOLUME_DEVICE}
           sizeGb: ${BOOT_VOLUME_SIZE:=100}
       network:
-        default:
+        networkDevices:
+        - name: net0
           bridge: ${BRIDGE}
           model: virtio
       checks:
         skipQemuGuestAgent: false
         skipCloudInitStatus: true
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   name: "${CLUSTER_NAME}-workers"
@@ -280,14 +284,14 @@ spec:
       bootstrap:
         configRef:
           name: "${CLUSTER_NAME}-worker"
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: KubeadmConfigTemplate
       infrastructureRef:
         name: "${CLUSTER_NAME}-worker"
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: ProxmoxMachineTemplate
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: ProxmoxMachineTemplate
 metadata:
   name: "${CLUSTER_NAME}-worker"
@@ -306,14 +310,15 @@ spec:
           disk: ${BOOT_VOLUME_DEVICE}
           sizeGb: ${BOOT_VOLUME_SIZE:=100}
       network:
-        default:
+        networkDevices:
+        - name: net0
           bridge: ${BRIDGE}
           model: virtio
       checks:
         skipQemuGuestAgent: false
         skipCloudInitStatus: true
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
   name: "${CLUSTER_NAME}-worker"
@@ -393,7 +398,8 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            provider-id: proxmox://'$${COREOS_CUSTOM_INSTANCE_ID}'
+            - name: provider-id
+              value: proxmox://'$${COREOS_CUSTOM_INSTANCE_ID}'
       users:
         - name: core
           sshAuthorizedKeys: [${VM_SSH_KEYS}]
@@ -405,7 +411,7 @@ metadata:
   name: "${CLUSTER_NAME}-crs-cni"
 data: ${CNI_RESOURCES}
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: "${CLUSTER_NAME}-crs-cni"

--- a/test/e2e/data/infrastructure-proxmox/cluster-template-upgrades.yaml
+++ b/test/e2e/data/infrastructure-proxmox/cluster-template-upgrades.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: "${CLUSTER_NAME}"
@@ -10,15 +10,15 @@ spec:
     pods:
       cidrBlocks: ["192.168.0.0/16"]
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    apiGroup: infrastructure.cluster.x-k8s.io
     kind: ProxmoxCluster
     name: "${CLUSTER_NAME}"
   controlPlaneRef:
     kind: KubeadmControlPlane
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiGroup: controlplane.cluster.x-k8s.io
     name: "${CLUSTER_NAME}-control-plane"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: ProxmoxCluster
 metadata:
   name: "${CLUSTER_NAME}"
@@ -34,16 +34,17 @@ spec:
   allowedNodes: ${ALLOWED_NODES:=[]}
 ---
 kind: KubeadmControlPlane
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   machineTemplate:
-    infrastructureRef:
-      kind: ProxmoxMachineTemplate
-      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
-      name: "${CLUSTER_NAME}-control-plane"
+    spec:
+      infrastructureRef:
+        kind: ProxmoxMachineTemplate
+        apiGroup: infrastructure.cluster.x-k8s.io
+        name: "${CLUSTER_NAME}-control-plane"
   kubeadmConfigSpec:
     users:
       - name: root
@@ -157,15 +158,17 @@ spec:
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          provider-id: "proxmox://'{{ ds.meta_data.instance_id }}'"
+          - name: provider-id
+            value: "proxmox://'{{ ds.meta_data.instance_id }}'"
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          provider-id: "proxmox://'{{ ds.meta_data.instance_id }}'"
+          - name: provider-id
+            value: "proxmox://'{{ ds.meta_data.instance_id }}'"
   version: "${KUBERNETES_VERSION}"
 ---
 kind: ProxmoxMachineTemplate
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
@@ -183,11 +186,12 @@ spec:
           disk: ${BOOT_VOLUME_DEVICE}
           sizeGb: ${BOOT_VOLUME_SIZE:=100}
       network:
-        default:
+        networkDevices:
+        - name: net0
           bridge: ${BRIDGE}
           model: virtio
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   name: "${CLUSTER_NAME}-workers"
@@ -206,14 +210,14 @@ spec:
       bootstrap:
         configRef:
           name: "${CLUSTER_NAME}-worker"
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiGroup: bootstrap.cluster.x-k8s.io
           kind: KubeadmConfigTemplate
       infrastructureRef:
         name: "${CLUSTER_NAME}-worker"
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+        apiGroup: infrastructure.cluster.x-k8s.io
         kind: ProxmoxMachineTemplate
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: ProxmoxMachineTemplate
 metadata:
   name: "${CLUSTER_NAME}-worker"
@@ -232,11 +236,12 @@ spec:
           disk: ${BOOT_VOLUME_DEVICE}
           sizeGb: ${BOOT_VOLUME_SIZE:=100}
       network:
-        default:
+        networkDevices:
+        - name: net0
           bridge: ${BRIDGE}
           model: virtio
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
   name: "${CLUSTER_NAME}-worker"
@@ -249,7 +254,8 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            provider-id: "proxmox://'{{ ds.meta_data.instance_id }}'"
+            - name: provider-id
+              value: "proxmox://'{{ ds.meta_data.instance_id }}'"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -257,7 +263,7 @@ metadata:
   name: "${CLUSTER_NAME}-crs-cni"
 data: ${CNI_RESOURCES}
 ---
-apiVersion: addons.cluster.x-k8s.io/v1beta1
+apiVersion: addons.cluster.x-k8s.io/v1beta2
 kind: ClusterResourceSet
 metadata:
   name: "${CLUSTER_NAME}-crs-cni"
@@ -271,7 +277,7 @@ spec:
       kind: ConfigMap
 ---
 kind: ProxmoxMachineTemplate
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 metadata:
   name: cp-k8s-upgrade-and-conformance
 spec:
@@ -289,12 +295,13 @@ spec:
           disk: ${BOOT_VOLUME_DEVICE}
           sizeGb: ${BOOT_VOLUME_SIZE:=100}
       network:
-        default:
+        networkDevices:
+        - name: net0
           bridge: ${BRIDGE}
           model: virtio
 ---
 kind: ProxmoxMachineTemplate
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 metadata:
   name: worker-k8s-upgrade-and-conformance
 spec:
@@ -312,6 +319,7 @@ spec:
           disk: ${BOOT_VOLUME_DEVICE}
           sizeGb: ${BOOT_VOLUME_SIZE:=100}
       network:
-        default:
+        networkDevices:
+        - name: net0
           bridge: ${BRIDGE}
           model: virtio

--- a/test/e2e/data/shared/ipam/metadata.yaml
+++ b/test/e2e/data/shared/ipam/metadata.yaml
@@ -7,3 +7,6 @@ releaseSeries:
   - major: 1
     minor: 0
     contract: v1beta1
+  - major: 1
+    minor: 1
+    contract: v1beta2

--- a/test/e2e/data/shared/v1beta1/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1/metadata.yaml
@@ -7,6 +7,9 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
   - major: 1
+    minor: 11
+    contract: v1beta1
+  - major: 1
     minor: 10
     contract: v1beta1
   - major: 1

--- a/test/e2e/data/shared/v1beta2/metadata.yaml
+++ b/test/e2e/data/shared/v1beta2/metadata.yaml
@@ -1,0 +1,11 @@
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# update this file only when a new major or minor version is released
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+  - major: 1
+    minor: 11
+    contract: v1beta2

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -44,7 +44,7 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework/ginkgoextensions"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	infrav1 "github.com/ionos-cloud/cluster-api-provider-proxmox/api/v1alpha1"
+	infrav1 "github.com/ionos-cloud/cluster-api-provider-proxmox/api/v1alpha2"
 )
 
 const (


### PR DESCRIPTION
*Description of changes:*
- e2e/suite_test.go import changed to v1alpha2
- e2e configs changed to CAPI 1.11.4 and ipam-provider v1.1.0-rc.1 (the only version currently supporting v1beta2)
- templates updated accordingly.

*Testing performed:*
e2e

*Behind the scenes:*
We set up a new e2e runner, it's fast!