### PR TITLE
Harden and improve GitHub Actions workflows

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -2,6 +2,9 @@
 name: Codespell
 on: [ pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   codespell:
     runs-on: ubuntu-latest

--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 permissions:
-  contents: write
+  contents: read
   packages: write
 
 jobs:

--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -2,17 +2,10 @@ name: container-image
 
 on:
   push:
-    branches:
-      - main
-      - release-*
-    # Sequence of patterns matched against refs/tags
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
   pull_request:
-    branches:
-      - main
-      - release-*
 
 permissions:
   contents: write

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,9 @@ jobs:
     if: ${{ ! contains( github.event.pull_request.labels.*.name, 'e2e/none') }}
     runs-on: capmox-e2e
     environment: e2e
+    concurrency:
+      group: e2e-${{ github.event.pull_request.number || github.sha }}
+      cancel-in-progress: true
     env:
       PROXMOX_URL: ${{ secrets.PROXMOX_URL }}
       PROXMOX_TOKEN: ${{ secrets.PROXMOX_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,7 +43,7 @@ jobs:
         run: echo 'SKIP_E2E=""' >> "$GITHUB_ENV"
 
       - name: Run e2e tests
-        run: "make test-e2e GINKGO_SKIP=${{ env.SKIP_E2E }}"
+        run: make test-e2e "GINKGO_SKIP=$SKIP_E2E"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,9 @@ on:
   pull_request_target:
     types: ["opened", "synchronize", "reopened", "labeled", "unlabeled"]
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     if: ${{ ! contains( github.event.pull_request.labels.*.name, 'e2e/none') }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,6 @@ on:
     branches: ["main"]
   pull_request_target:
     types: ["opened", "synchronize", "reopened", "labeled", "unlabeled"]
-    branches: ["main"]
 
 jobs:
   e2e:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           go-version-file: go.mod
       - name: generate release artifacts
         run: |
-          make release-manifests RELEASE_VERSION=${{ env.RELEASE_TAG }}
+          make release-manifests "RELEASE_VERSION=$RELEASE_TAG"
       - name: generate release templates
         run: |
           make release-templates

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
     branches: ["main"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,12 +30,10 @@ jobs:
            -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
            -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: SonarQube
         if: github.event_name == 'push'
         uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
 
 jobs:
   test:


### PR DESCRIPTION
*Description of changes:*

A few simple tweaks to improve resilience and ergonomics of our actions.

Hardening:
- **Least-privilege permissions**: Downgrade permissions add explicit permissions (resolves CodeQL alerts 34, 30, 19)
- **Expression injection hardening**: Replace `${{ env.* }}` interpolation with quoted shell variable expansion (interpolation happens before the expression is passed to shell, potentially allowing command injection)
- **Drop GITHUB_TOKEN from test**: SonarQube doesn't need it

Ergonomics:
- **Run CI on all branches**: Remove branch filters from PR triggers in test and e2e so CI runs on PRs targeting other PRs/branches; keep push limited to main.
- **Container image triggers**: Only push images to GHCR on releases; PRs still build for validation
- **e2e concurrency control**: Add job-level concurrency group so superseded runs for the same PR are cancelled after the new run is approved

*Testing performed:*

actionlint + CodeQL analyze actions
Tested triggers, e2e labels, concurrency