### PR TITLE
Redesign e2e workflow with reusable workflow pattern

### DIFF
--- a/.github/workflows/e2e-external.yml
+++ b/.github/workflows/e2e-external.yml
@@ -1,0 +1,13 @@
+name: "e2e (external PR)"
+
+on:
+  pull_request_target:
+    types: ["opened", "synchronize", "reopened", "labeled", "unlabeled"]
+
+jobs:
+  e2e:
+    if: >-
+      github.event.pull_request.head.repo.fork &&
+      !contains(github.event.pull_request.labels.*.name, 'e2e/none')
+    uses: ./.github/workflows/e2e.yml
+    secrets: inherit

--- a/.github/workflows/e2e-external.yml
+++ b/.github/workflows/e2e-external.yml
@@ -10,7 +10,8 @@ permissions:
 jobs:
   e2e:
     if: >-
-      github.event.pull_request.head.repo.fork &&
+      (github.event.pull_request.head.repo.fork ||
+       github.event.pull_request.user.login == 'dependabot[bot]') &&
       !contains(github.event.pull_request.labels.*.name, 'e2e/none')
     uses: ./.github/workflows/e2e.yml
     secrets: inherit

--- a/.github/workflows/e2e-external.yml
+++ b/.github/workflows/e2e-external.yml
@@ -14,4 +14,6 @@ jobs:
        github.event.pull_request.user.login == 'dependabot[bot]') &&
       !contains(github.event.pull_request.labels.*.name, 'e2e/none')
     uses: ./.github/workflows/e2e.yml
+    with:
+      event-name: ${{ github.event_name }}
     secrets: inherit

--- a/.github/workflows/e2e-external.yml
+++ b/.github/workflows/e2e-external.yml
@@ -15,5 +15,5 @@ jobs:
       !contains(github.event.pull_request.labels.*.name, 'e2e/none')
     uses: ./.github/workflows/e2e.yml
     with:
-      event-name: ${{ github.event_name }}
+      event_name: ${{ github.event_name }}
     secrets: inherit

--- a/.github/workflows/e2e-external.yml
+++ b/.github/workflows/e2e-external.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: ["opened", "synchronize", "reopened", "labeled", "unlabeled"]
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     if: >-

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -1,0 +1,16 @@
+name: "e2e (main/PR)"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: ["opened", "synchronize", "reopened", "labeled", "unlabeled"]
+
+jobs:
+  e2e:
+    if: >-
+      github.event_name == 'push' ||
+      (!github.event.pull_request.head.repo.fork &&
+       !contains(github.event.pull_request.labels.*.name, 'e2e/none'))
+    uses: ./.github/workflows/e2e.yml
+    secrets: inherit

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -17,4 +17,6 @@ jobs:
        github.event.pull_request.user.login != 'dependabot[bot]' &&
        !contains(github.event.pull_request.labels.*.name, 'e2e/none'))
     uses: ./.github/workflows/e2e.yml
+    with:
+      event-name: ${{ github.event_name }}
     secrets: inherit

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: ["opened", "synchronize", "reopened", "labeled", "unlabeled"]
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     if: >-

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -14,6 +14,7 @@ jobs:
     if: >-
       github.event_name == 'push' ||
       (!github.event.pull_request.head.repo.fork &&
+       github.event.pull_request.user.login != 'dependabot[bot]' &&
        !contains(github.event.pull_request.labels.*.name, 'e2e/none'))
     uses: ./.github/workflows/e2e.yml
     secrets: inherit

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -18,5 +18,5 @@ jobs:
        !contains(github.event.pull_request.labels.*.name, 'e2e/none'))
     uses: ./.github/workflows/e2e.yml
     with:
-      event-name: ${{ github.event_name }}
+      event_name: ${{ github.event_name }}
     secrets: inherit

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Fork code runs here (pull_request_target via e2e-external.yml); keep the GITHUB_TOKEN out of
+          # .git/config so make test-e2e can't read it.
+          persist-credentials: false
           # actions/checkout v7 refuses fork-PR checkout under pull_request_target unless opted in.
           # Load-bearing only via e2e-external.yml (fork PRs under pull_request_target); a no-op on the
           # e2e-main.yml path (push / non-fork pull_request). e2e must run fork code against the real
@@ -36,7 +39,10 @@ jobs:
 
       - run: make test-e2e "GINKGO_SKIP=$SKIP_E2E"
         env:
-          SKIP_E2E: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'e2e/flatcar')) && '' || 'Flatcar' }}
+          # Skip Flatcar unless it's a push to main or the e2e/flatcar label is set. Inverted so the
+          # surviving branch is the truthy 'Flatcar' string: '' is falsy in Actions expressions, so a
+          # `cond && '' || 'Flatcar'` form would always fall through to 'Flatcar' and never run Flatcar.
+          SKIP_E2E: ${{ (github.event_name != 'push' && !contains(github.event.pull_request.labels.*.name, 'e2e/flatcar')) && 'Flatcar' || '' }}
 
       - name: Upload logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,13 +33,7 @@ jobs:
           # Fork code runs here (pull_request_target via e2e-external.yml); keep the GITHUB_TOKEN out of
           # .git/config so make test-e2e can't read it.
           persist-credentials: false
-          # actions/checkout v7 refuses fork-PR checkout under pull_request_target unless opted in. That
-          # guard only fires for a fork PR on the e2e-external.yml (pull_request_target) path; on the
-          # e2e-main.yml paths (push / same-repo pull_request) and for dependabot (non-fork) it never
-          # triggers, so `true` is a no-op there and weakens nothing. e2e runs the checked-out code
-          # against real PROXMOX_* secrets on the self-hosted runner, so execution and secrets are
-          # inseparable — the security boundary is the environment: e2e manual-approval gate, where the
-          # approver MUST review the diff for exfiltration before approving. Do not weaken that gate.
+          # checkout v7 requires this for fork-PR head checkout under pull_request_target.
           allow-unsafe-pr-checkout: true
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,14 @@ name: e2e
 
 on:
   workflow_call:
+    inputs:
+      event-name:
+        description: >-
+          The caller's github.event_name (push / pull_request / pull_request_target). Passed
+          explicitly so this workflow branches on the trigger without reading github.event_name
+          inside a called workflow — which does hold the caller's event, but is repeatedly misread.
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -25,14 +33,14 @@ jobs:
           # Fork code runs here (pull_request_target via e2e-external.yml); keep the GITHUB_TOKEN out of
           # .git/config so make test-e2e can't read it.
           persist-credentials: false
-          # actions/checkout v7 refuses fork-PR checkout under pull_request_target unless opted in. Only
-          # the pull_request_target path (e2e-external.yml: forks + dependabot) can trip that guard, so
-          # scope the opt-in to that event; it stays false on the e2e-main.yml path (push / same-repo
-          # pull_request). e2e runs the checked-out code against real PROXMOX_* secrets on the self-hosted
-          # runner, so execution and secrets are inseparable — the security boundary is the environment:
-          # e2e manual-approval gate, where the approver MUST review the diff for exfiltration before
-          # approving. Do not weaken that gate.
-          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
+          # actions/checkout v7 refuses fork-PR checkout under pull_request_target unless opted in. That
+          # guard only fires for a fork PR on the e2e-external.yml (pull_request_target) path; on the
+          # e2e-main.yml paths (push / same-repo pull_request) and for dependabot (non-fork) it never
+          # triggers, so `true` is a no-op there and weakens nothing. e2e runs the checked-out code
+          # against real PROXMOX_* secrets on the self-hosted runner, so execution and secrets are
+          # inseparable — the security boundary is the environment: e2e manual-approval gate, where the
+          # approver MUST review the diff for exfiltration before approving. Do not weaken that gate.
+          allow-unsafe-pr-checkout: true
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -43,7 +51,7 @@ jobs:
           # Skip Flatcar unless it's a push to main or the e2e/flatcar label is set. Inverted so the
           # surviving branch is the truthy 'Flatcar' string: '' is falsy in Actions expressions, so a
           # `cond && '' || 'Flatcar'` form would always fall through to 'Flatcar' and never run Flatcar.
-          SKIP_E2E: ${{ (github.event_name != 'push' && !contains(github.event.pull_request.labels.*.name, 'e2e/flatcar')) && 'Flatcar' || '' }}
+          SKIP_E2E: ${{ (inputs.event-name != 'push' && !contains(github.event.pull_request.labels.*.name, 'e2e/flatcar')) && 'Flatcar' || '' }}
 
       - name: Upload logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,17 +1,13 @@
-name: e2e tests
+name: e2e
 
 on:
-  push:
-    branches: ["main"]
-  pull_request_target:
-    types: ["opened", "synchronize", "reopened", "labeled", "unlabeled"]
+  workflow_call:
 
 permissions:
   contents: read
 
 jobs:
   e2e:
-    if: ${{ ! contains( github.event.pull_request.labels.*.name, 'e2e/none') }}
     runs-on: capmox-e2e
     environment: e2e
     concurrency:
@@ -21,31 +17,21 @@ jobs:
       PROXMOX_URL: ${{ secrets.PROXMOX_URL }}
       PROXMOX_TOKEN: ${{ secrets.PROXMOX_TOKEN }}
       PROXMOX_SECRET: ${{ secrets.PROXMOX_SECRET }}
-      SKIP_E2E: Flatcar
     steps:
-      - name: Check out branch ${{ github.ref }}
-        if: ${{ github.event_name == 'push' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Check out PR ${{ github.event.pull_request.number }}
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
-      - name: Check if requested to skip Flatcar tests
-        if: ${{ contains( github.event.pull_request.labels.*.name, 'e2e/flatcar') }}
-        run: echo 'SKIP_E2E=""' >> "$GITHUB_ENV"
+      - run: make test-e2e "GINKGO_SKIP=$SKIP_E2E"
+        env:
+          SKIP_E2E: ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'e2e/flatcar')) && '' || 'Flatcar' }}
 
-      - name: Run e2e tests
-        run: make test-e2e "GINKGO_SKIP=$SKIP_E2E"
-
-      - name: Upload artifacts
+      - name: Upload logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success() || failure()
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,13 +25,14 @@ jobs:
           # Fork code runs here (pull_request_target via e2e-external.yml); keep the GITHUB_TOKEN out of
           # .git/config so make test-e2e can't read it.
           persist-credentials: false
-          # actions/checkout v7 refuses fork-PR checkout under pull_request_target unless opted in.
-          # Load-bearing only via e2e-external.yml (fork PRs under pull_request_target); a no-op on the
-          # e2e-main.yml path (push / non-fork pull_request). e2e must run fork code against the real
-          # PROXMOX_* secrets on the self-hosted runner, so execution and secrets are inseparable. The
-          # security boundary is the environment: e2e manual-approval gate — the approver MUST review the
-          # fork diff for exfiltration before approving. Do not weaken that gate.
-          allow-unsafe-pr-checkout: true
+          # actions/checkout v7 refuses fork-PR checkout under pull_request_target unless opted in. Only
+          # the pull_request_target path (e2e-external.yml: forks + dependabot) can trip that guard, so
+          # scope the opt-in to that event; it stays false on the e2e-main.yml path (push / same-repo
+          # pull_request). e2e runs the checked-out code against real PROXMOX_* secrets on the self-hosted
+          # runner, so execution and secrets are inseparable — the security boundary is the environment:
+          # e2e manual-approval gate, where the approver MUST review the diff for exfiltration before
+          # approving. Do not weaken that gate.
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,6 +22,13 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # actions/checkout v7 refuses fork-PR checkout under pull_request_target unless opted in.
+          # Load-bearing only via e2e-external.yml (fork PRs under pull_request_target); a no-op on the
+          # e2e-main.yml path (push / non-fork pull_request). e2e must run fork code against the real
+          # PROXMOX_* secrets on the self-hosted runner, so execution and secrets are inseparable. The
+          # security boundary is the environment: e2e manual-approval gate — the approver MUST review the
+          # fork diff for exfiltration before approving. Do not weaken that gate.
+          allow-unsafe-pr-checkout: true
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,8 +30,6 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          # Fork code runs here (pull_request_target via e2e-external.yml); keep the GITHUB_TOKEN out of
-          # .git/config so make test-e2e can't read it.
           persist-credentials: false
           # checkout v7 requires this for fork-PR head checkout under pull_request_target.
           allow-unsafe-pr-checkout: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,9 +36,7 @@ jobs:
 
       - run: make test-e2e "GINKGO_SKIP=$SKIP_E2E"
         env:
-          # Skip Flatcar unless it's a push to main or the e2e/flatcar label is set. Inverted so the
-          # surviving branch is the truthy 'Flatcar' string: '' is falsy in Actions expressions, so a
-          # `cond && '' || 'Flatcar'` form would always fall through to 'Flatcar' and never run Flatcar.
+          # Skip Flatcar unless it's a push to main or the e2e/flatcar label is set.
           SKIP_E2E: ${{ (inputs.event_name != 'push' && !contains(github.event.pull_request.labels.*.name, 'e2e/flatcar')) && 'Flatcar' || '' }}
 
       - name: Upload logs
@@ -50,7 +48,7 @@ jobs:
           retention-days: 7
 
       - name: Clean up kind clusters
-        if: always()
+        if: always() || success() || failure()
         run: |
           go tool kind get clusters | xargs -I% go tool kind delete cluster --name %
           docker system prune -a -f

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,11 +3,7 @@ name: e2e
 on:
   workflow_call:
     inputs:
-      event-name:
-        description: >-
-          The caller's github.event_name (push / pull_request / pull_request_target). Passed
-          explicitly so this workflow branches on the trigger without reading github.event_name
-          inside a called workflow — which does hold the caller's event, but is repeatedly misread.
+      event_name:
         required: true
         type: string
 
@@ -43,7 +39,7 @@ jobs:
           # Skip Flatcar unless it's a push to main or the e2e/flatcar label is set. Inverted so the
           # surviving branch is the truthy 'Flatcar' string: '' is falsy in Actions expressions, so a
           # `cond && '' || 'Flatcar'` form would always fall through to 'Flatcar' and never run Flatcar.
-          SKIP_E2E: ${{ (inputs.event-name != 'push' && !contains(github.event.pull_request.labels.*.name, 'e2e/flatcar')) && 'Flatcar' || '' }}
+          SKIP_E2E: ${{ (inputs.event_name != 'push' && !contains(github.event.pull_request.labels.*.name, 'e2e/flatcar')) && 'Flatcar' || '' }}
 
       - name: Upload logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
*Issue #, if available:*

fixes #447
depends on #702

*Description of changes:*

Converts the e2e workflow into a reusable workflow with two minimal dispatchers:
  - `e2e-main.yml`: triggers on `push` to main and `pull_request` for same-repo, non-dependabot PRs.
  - `e2e-external.yml`: triggers on `pull_request_target` for fork and dependabot PRs — the trigger they need to reach the approval-gated `e2e` environment secrets (a fork/Dependabot `pull_request` run can't read them; same-repo pushes and internal PRs reach those secrets via `e2e-main`).

Since `e2e-main` is now on a `pull_request` trigger, we can actually test workflow changes within a PR.

Enables Flatcar tests on main - with the new runner it's feasible to run these more often and we reduce the risk of Flatcar support bitrotting.

Other than that, practical behaviour remains the same.

*Testing performed:*

CodeQL analyze actions + actionlint
e2e label triggers