### PR TITLE
fix(vm_service): state machine does not run reconcileMachineAddresses

### DIFF
--- a/internal/service/taskservice/task.go
+++ b/internal/service/taskservice/task.go
@@ -103,26 +103,36 @@ func checkAndRetryTask(scope *scope.MachineScope, task *proxmox.Task) (bool, err
 	case task.IsRunning:
 		logger.Info("task is still pending", "description", task.Type)
 		return true, nil
-	case task.IsSuccessful:
+	case task.IsSuccessful && task.IsCompleted:
 		logger.Info("task is a success", "description", task.Type)
 		scope.ProxmoxMachine.Status.TaskRef = nil
 		return false, nil
 	case task.IsFailed:
-		logger.Info("task failed", "description", task.Type)
+		// Failing tasks are actually red herrings. Some tasks fail, other
+		// tasks can fail successfully (like qmstart).
+		// We save the condition so the ReconcileVM statemachine keeps on working.
+		conditionReason := conditions.GetReason(scope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition)
 
-		// NOTE: When a task fails there is not simple way to understand which operation is failing (e.g. cloning or powering on)
-		// so we are reporting failures using a dedicated reason until we find a better solution.
-		var errorMessage string
-
-		if task.ExitStatus != "OK" {
-			errorMessage = task.ExitStatus
-		} else {
-			errorMessage = "task failed but its exit status is OK; this should not happen"
+		// qmstart can fail and yet actually start the VM. We can not handle qmstart properly.
+		// In fact qmstart can find a machine already started, because proxmox's api is
+		// eventually consistent here.
+		// For all other jobs we do set the condition to failed.
+		if task.Type != "qmstart" {
+			logger.Info("task failed", "description", task.Type)
+			// We notify the user that intervention is required. This should stop the state machine.
+			conditionReason = infrav1.ProxmoxMachineVirtualMachineProvisionedTaskFailedReason
 		}
+
+		errorMessage := fmt.Sprintf("%s: %s", task.Type, task.ExitStatus)
+		if task.ExitStatus == "OK" {
+			// If you end up here, file a bug with go-proxmox.
+			errorMessage = fmt.Sprintf("task %s failed but its exit status is OK; this should not happen", task.UPID)
+		}
+
 		conditions.Set(scope.ProxmoxMachine, metav1.Condition{
 			Type:    infrav1.ProxmoxMachineVirtualMachineProvisionedCondition,
 			Status:  metav1.ConditionFalse,
-			Reason:  infrav1.ProxmoxMachineVirtualMachineProvisionedTaskFailedReason,
+			Reason:  conditionReason,
 			Message: errorMessage,
 		})
 

--- a/internal/service/taskservice/task_test.go
+++ b/internal/service/taskservice/task_test.go
@@ -123,7 +123,7 @@ func setupTaskTest(t *testing.T) (*scope.MachineScope, *proxmoxtest.MockClient) 
 }
 
 // Do not return task if there is no task.
-func TestGetTask_NilTaskRef(t *testing.T) {
+func TestGetTask_NoTaskRef(t *testing.T) {
 	machineScope, _ := setupTaskTest(t)
 	machineScope.ProxmoxMachine.Status.TaskRef = nil
 
@@ -133,7 +133,7 @@ func TestGetTask_NilTaskRef(t *testing.T) {
 }
 
 // Test missing task erroring.
-func TestGetTask_Error(t *testing.T) {
+func TestGetTask_ErrorNotFound(t *testing.T) {
 	machineScope, mockClient := setupTaskTest(t)
 	machineScope.ProxmoxMachine.Status.TaskRef = ptr.To("UPID:node1:001")
 
@@ -158,7 +158,7 @@ func TestGetTask_Success(t *testing.T) {
 }
 
 // Test ReconcileInFlightTask on empty task.
-func TestReconcileInFlightTask_NilTaskRef(t *testing.T) {
+func TestReconcileInFlightTask_NoTaskRef(t *testing.T) {
 	machineScope, _ := setupTaskTest(t)
 	machineScope.ProxmoxMachine.Status.TaskRef = nil
 
@@ -168,7 +168,7 @@ func TestReconcileInFlightTask_NilTaskRef(t *testing.T) {
 }
 
 // Test ReconcileInFlightTask on empty task but existing TaskRef.
-func TestReconcileInFlightTask_NilTask(t *testing.T) {
+func TestReconcileInFlightTask_NilTaskReturned(t *testing.T) {
 	machineScope, mockClient := setupTaskTest(t)
 	machineScope.ProxmoxMachine.Status.TaskRef = ptr.To("UPID:node1:001")
 
@@ -207,7 +207,7 @@ func TestReconcileInFlightTask_TaskSuccessful(t *testing.T) {
 }
 
 // Test ReconcileInflightTask on task failure switch case if not qmstart.
-func TestReconcileInFlightTask_TaskFailed_NonQMStart(t *testing.T) {
+func TestReconcileInFlightTask_CloneTaskFailed(t *testing.T) {
 	machineScope, mockClient := setupTaskTest(t)
 	machineScope.ProxmoxMachine.Status.TaskRef = ptr.To("UPID:node1:001")
 

--- a/internal/service/taskservice/task_test.go
+++ b/internal/service/taskservice/task_test.go
@@ -1,0 +1,332 @@
+/*
+Copyright 2023-2026 IONOS Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskservice
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/luthermonson/go-proxmox"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1 "github.com/ionos-cloud/cluster-api-provider-proxmox/api/v1alpha2"
+	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/kubernetes/ipam"
+	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/proxmox/proxmoxtest"
+	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/scope"
+)
+
+func setupTaskTest(t *testing.T) (*scope.MachineScope, *proxmoxtest.MockClient) {
+	t.Helper()
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: metav1.NamespaceDefault,
+		},
+	}
+
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: metav1.NamespaceDefault,
+		},
+	}
+
+	infraCluster := &infrav1.ProxmoxCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: infrav1.ProxmoxClusterSpec{
+			IPv4Config: &infrav1.IPConfigSpec{
+				Addresses: []string{"192.0.2.10-192.0.2.20"},
+				Prefix:    24,
+				Gateway:   "192.0.2.1",
+			},
+		},
+		Status: infrav1.ProxmoxClusterStatus{
+			NodeLocations: &infrav1.NodeLocations{},
+		},
+	}
+
+	infraMachine := &infrav1.ProxmoxMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: infrav1.ProxmoxMachineSpec{
+			Network: ptr.To(infrav1.NetworkSpec{}),
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, clusterv1.AddToScheme(scheme))
+	require.NoError(t, infrav1.AddToScheme(scheme))
+
+	kubeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, machine, infraCluster, infraMachine).
+		WithStatusSubresource(&infrav1.ProxmoxCluster{}, &infrav1.ProxmoxMachine{}).
+		Build()
+
+	logger := logr.Discard()
+	mockClient := proxmoxtest.NewMockClient(t)
+	ipamHelper := ipam.NewHelper(kubeClient, infraCluster)
+
+	clusterScope, err := scope.NewClusterScope(scope.ClusterScopeParams{
+		Client:         kubeClient,
+		Logger:         &logger,
+		Cluster:        cluster,
+		ProxmoxCluster: infraCluster,
+		ProxmoxClient:  mockClient,
+		IPAMHelper:     ipamHelper,
+	})
+	require.NoError(t, err)
+
+	machineScope, err := scope.NewMachineScope(scope.MachineScopeParams{
+		Client:         kubeClient,
+		Logger:         &logger,
+		Cluster:        cluster,
+		Machine:        machine,
+		InfraCluster:   clusterScope,
+		ProxmoxMachine: infraMachine,
+		IPAMHelper:     ipamHelper,
+	})
+	require.NoError(t, err)
+
+	return machineScope, mockClient
+}
+
+// Do not return task if there is no task.
+func TestGetTask_NilTaskRef(t *testing.T) {
+	machineScope, _ := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Status.TaskRef = nil
+
+	task, err := GetTask(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.Nil(t, task)
+}
+
+// Test missing task erroring.
+func TestGetTask_Error(t *testing.T) {
+	machineScope, mockClient := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Status.TaskRef = ptr.To("UPID:node1:001")
+
+	mockClient.EXPECT().GetTask(context.Background(), "UPID:node1:001").Return(nil, errors.New("not found")).Once()
+
+	task, err := GetTask(context.Background(), machineScope)
+	require.ErrorIs(t, err, ErrTaskNotFound)
+	require.Nil(t, task)
+}
+
+// Test successful task returning.
+func TestGetTask_Success(t *testing.T) {
+	machineScope, mockClient := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Status.TaskRef = ptr.To("UPID:node1:001")
+
+	expected := &proxmox.Task{UPID: "UPID:node1:001", IsCompleted: true, IsSuccessful: true}
+	mockClient.EXPECT().GetTask(context.Background(), "UPID:node1:001").Return(expected, nil).Once()
+
+	task, err := GetTask(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.Equal(t, expected, task)
+}
+
+// Test ReconcileInFlightTask on empty task.
+func TestReconcileInFlightTask_NilTaskRef(t *testing.T) {
+	machineScope, _ := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Status.TaskRef = nil
+
+	requeue, err := ReconcileInFlightTask(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.False(t, requeue)
+}
+
+// Test ReconcileInFlightTask on empty task but existing TaskRef.
+func TestReconcileInFlightTask_NilTask(t *testing.T) {
+	machineScope, mockClient := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Status.TaskRef = ptr.To("UPID:node1:001")
+
+	mockClient.EXPECT().GetTask(context.Background(), "UPID:node1:001").Return(nil, nil).Once()
+
+	requeue, err := ReconcileInFlightTask(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.True(t, requeue)
+}
+
+// Test ReconcileInflightTask on running task switch case.
+func TestReconcileInFlightTask_TaskRunning(t *testing.T) {
+	machineScope, mockClient := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Status.TaskRef = ptr.To("UPID:node1:001")
+
+	task := &proxmox.Task{UPID: "UPID:node1:001", IsRunning: true, Status: "running", Type: "qmclone"}
+	mockClient.EXPECT().GetTask(context.Background(), "UPID:node1:001").Return(task, nil).Once()
+
+	requeue, err := ReconcileInFlightTask(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.True(t, requeue)
+}
+
+// Test ReconcileInflightTask on successful task switch case.
+func TestReconcileInFlightTask_TaskSuccessful(t *testing.T) {
+	machineScope, mockClient := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Status.TaskRef = ptr.To("UPID:node1:001")
+
+	task := &proxmox.Task{UPID: "UPID:node1:001", IsCompleted: true, IsSuccessful: true, Status: "stopped", ExitStatus: "OK", Type: "qmclone"}
+	mockClient.EXPECT().GetTask(context.Background(), "UPID:node1:001").Return(task, nil).Once()
+
+	requeue, err := ReconcileInFlightTask(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.False(t, requeue)
+	require.Nil(t, machineScope.ProxmoxMachine.Status.TaskRef)
+}
+
+// Test ReconcileInflightTask on task failure switch case if not qmstart.
+func TestReconcileInFlightTask_TaskFailed_NonQMStart(t *testing.T) {
+	machineScope, mockClient := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Status.TaskRef = ptr.To("UPID:node1:001")
+
+	// Set an initial condition to verify it gets overwritten.
+	conditions.Set(machineScope.ProxmoxMachine, metav1.Condition{
+		Type:   infrav1.ProxmoxMachineVirtualMachineProvisionedCondition,
+		Status: metav1.ConditionFalse,
+		Reason: "SomeOtherReason",
+	})
+
+	task := &proxmox.Task{UPID: "UPID:node1:001", IsFailed: true, IsCompleted: true, Status: "stopped", ExitStatus: "ERROR: clone failed", Type: "qmclone"}
+	mockClient.EXPECT().GetTask(context.Background(), "UPID:node1:001").Return(task, nil).Once()
+
+	requeue, err := ReconcileInFlightTask(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.True(t, requeue)
+
+	// First failure: RetryAfter should be set, TaskRef should still be present.
+	require.NotNil(t, machineScope.ProxmoxMachine.Status.RetryAfter)
+	require.NotNil(t, machineScope.ProxmoxMachine.Status.TaskRef)
+
+	// Condition should be set to TaskFailed for non-qmstart tasks.
+	cond := conditions.Get(machineScope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition)
+	require.NotNil(t, cond)
+	require.Equal(t, infrav1.ProxmoxMachineVirtualMachineProvisionedTaskFailedReason, cond.Reason)
+	require.Contains(t, cond.Message, "ERROR: clone failed")
+}
+
+// Test ReconcileInflightTask on task failure switch case if qmstart (special case failure).
+func TestReconcileInFlightTask_TaskFailed_QMStart(t *testing.T) {
+	machineScope, mockClient := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Status.TaskRef = ptr.To("UPID:node1:001")
+
+	// Set a pre-existing condition that should be preserved for qmstart.
+	conditions.Set(machineScope.ProxmoxMachine, metav1.Condition{
+		Type:   infrav1.ProxmoxMachineVirtualMachineProvisionedCondition,
+		Status: metav1.ConditionFalse,
+		Reason: "WaitingForVMPowerUp",
+	})
+
+	task := &proxmox.Task{UPID: "UPID:node1:001", IsFailed: true, IsCompleted: true, Status: "stopped", ExitStatus: "ERROR: VM already running", Type: "qmstart"}
+	mockClient.EXPECT().GetTask(context.Background(), "UPID:node1:001").Return(task, nil).Once()
+
+	requeue, err := ReconcileInFlightTask(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.True(t, requeue)
+
+	// Condition reason should be preserved (not set to TaskFailed) for qmstart.
+	cond := conditions.Get(machineScope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition)
+	require.NotNil(t, cond)
+	require.Equal(t, "WaitingForVMPowerUp", cond.Reason)
+}
+
+// Test ReconcileInflightTask on task failure switch case clears timed out task.
+func TestReconcileInFlightTask_TaskFailed_SecondPass_ClearsTaskRef(t *testing.T) {
+	machineScope, mockClient := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Status.TaskRef = ptr.To("UPID:node1:001")
+
+	// Simulate second reconciliation pass: RetryAfter is already set and expired.
+	machineScope.ProxmoxMachine.Status.RetryAfter = &metav1.Time{Time: time.Now().Add(-1 * time.Minute)}
+
+	task := &proxmox.Task{UPID: "UPID:node1:001", IsFailed: true, IsCompleted: true, Status: "stopped", ExitStatus: "ERROR: clone failed", Type: "qmclone"}
+	mockClient.EXPECT().GetTask(context.Background(), "UPID:node1:001").Return(task, nil).Once()
+
+	requeue, err := ReconcileInFlightTask(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.True(t, requeue)
+
+	// Second failure pass: both TaskRef and RetryAfter should be cleared.
+	require.Nil(t, machineScope.ProxmoxMachine.Status.TaskRef)
+	require.Nil(t, machineScope.ProxmoxMachine.Status.RetryAfter)
+}
+
+// Test ReconcileInflightTask on invalid task state in go-proxmox.
+func TestReconcileInFlightTask_TaskFailed_ExitStatusOK(t *testing.T) {
+	machineScope, mockClient := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Status.TaskRef = ptr.To("UPID:node1:001")
+
+	task := &proxmox.Task{UPID: "UPID:node1:001", IsFailed: true, IsCompleted: true, Status: "stopped", ExitStatus: "OK", Type: "qmclone"}
+	mockClient.EXPECT().GetTask(context.Background(), "UPID:node1:001").Return(task, nil).Once()
+
+	requeue, err := ReconcileInFlightTask(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.True(t, requeue)
+
+	cond := conditions.Get(machineScope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition)
+	require.NotNil(t, cond)
+	require.Contains(t, cond.Message, "failed but its exit status is OK")
+}
+
+// Test ReconcileInflightTask failed task time-out.
+func TestReconcileInFlightTask_RetryAfterNotExpired(t *testing.T) {
+	machineScope, mockClient := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Status.TaskRef = ptr.To("UPID:node1:001")
+	machineScope.ProxmoxMachine.Status.RetryAfter = &metav1.Time{Time: time.Now().Add(5 * time.Minute)}
+
+	task := &proxmox.Task{UPID: "UPID:node1:001", IsFailed: true, IsCompleted: true, Status: "stopped", ExitStatus: "ERROR", Type: "qmclone"}
+	mockClient.EXPECT().GetTask(context.Background(), "UPID:node1:001").Return(task, nil).Once()
+
+	requeue, err := ReconcileInFlightTask(context.Background(), machineScope)
+	require.False(t, requeue)
+
+	var requeueErr *RequeueError
+	require.ErrorAs(t, err, &requeueErr)
+	require.Positive(t, requeueErr.RequeueAfter())
+}
+
+// Test ReconcileInflightTask unknown state switch case.
+func TestReconcileInFlightTask_UnknownState(t *testing.T) {
+	machineScope, mockClient := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Status.TaskRef = ptr.To("UPID:node1:001")
+
+	// Task with no state flags set falls through to default case.
+	task := &proxmox.Task{UPID: "UPID:node1:001", ExitStatus: "weird-state", Type: "qmclone"}
+	mockClient.EXPECT().GetTask(context.Background(), "UPID:node1:001").Return(task, nil).Once()
+
+	requeue, err := ReconcileInFlightTask(context.Background(), machineScope)
+	require.False(t, requeue)
+
+	var requeueErr *RequeueError
+	require.ErrorAs(t, err, &requeueErr)
+}

--- a/internal/service/vmservice/helpers_test.go
+++ b/internal/service/vmservice/helpers_test.go
@@ -544,7 +544,11 @@ func createBootstrapSecret(t *testing.T, c client.Client, machineScope *scope.Ma
 }
 
 func newTask() *proxmox.Task {
-	return &proxmox.Task{UPID: "result"}
+	return &proxmox.Task{
+		UPID:         "result",
+		IsSuccessful: true,
+		IsCompleted:  true,
+	}
 }
 
 func newVMResource() *proxmox.ClusterResource {

--- a/internal/service/vmservice/power.go
+++ b/internal/service/vmservice/power.go
@@ -36,15 +36,6 @@ func reconcilePowerState(ctx context.Context, machineScope *scope.MachineScope) 
 		return false, nil
 	}
 
-	/*
-		if !machineHasIPAddress(machineScope.ProxmoxMachine) {
-			machineScope.V(4).Info("ip address not set for machine")
-			// machine doesn't have an ip address yet
-			// needs to reconcile again
-			return true, nil
-		}
-	*/
-
 	machineScope.V(4).Info("ensuring machine is started")
 
 	t, err := startVirtualMachine(ctx, machineScope.InfraCluster.ProxmoxClient, machineScope.VirtualMachine)

--- a/internal/service/vmservice/power.go
+++ b/internal/service/vmservice/power.go
@@ -66,7 +66,7 @@ func reconcilePowerState(ctx context.Context, machineScope *scope.MachineScope) 
 	conditions.Set(machineScope.ProxmoxMachine, metav1.Condition{
 		Type:   infrav1.ProxmoxMachineVirtualMachineProvisionedCondition,
 		Status: metav1.ConditionFalse,
-		Reason: infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForCloudInitReason,
+		Reason: infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForClusterAPIMachineAddressesReason,
 	})
 	return false, nil
 }

--- a/internal/service/vmservice/vm.go
+++ b/internal/service/vmservice/vm.go
@@ -115,7 +115,8 @@ func ReconcileVM(ctx context.Context, scope *scope.MachineScope) (infrav1.Virtua
 	} // VirtualMachineProvisioned reason is WaitingForBootstrapReady
 
 	// handle invalid state of the machine
-	if conditions.GetReason(scope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition) == infrav1.ProxmoxMachineVirtualMachineProvisionedVMProvisionFailedReason {
+	if conditions.GetReason(scope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition) == infrav1.ProxmoxMachineVirtualMachineProvisionedVMProvisionFailedReason ||
+		conditions.GetReason(scope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition) == infrav1.ProxmoxMachineVirtualMachineProvisionedTaskFailedReason {
 		scope.Logger.V(4).Info("invalid proxmoxmachine state", "state", conditions.GetReason(scope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition))
 		// If you end up here, please file a bug report.
 		return vm, errors.New("invalid state (failed and no error)")

--- a/internal/service/vmservice/vm.go
+++ b/internal/service/vmservice/vm.go
@@ -115,8 +115,7 @@ func ReconcileVM(ctx context.Context, scope *scope.MachineScope) (infrav1.Virtua
 	} // VirtualMachineProvisioned reason is WaitingForBootstrapReady
 
 	// handle invalid state of the machine
-	if conditions.GetReason(scope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition) == infrav1.ProxmoxMachineVirtualMachineProvisionedVMProvisionFailedReason ||
-		conditions.GetReason(scope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition) == infrav1.ProxmoxMachineVirtualMachineProvisionedTaskFailedReason {
+	if proxmoxMachineHasVMProvisionFailedReason(scope) {
 		scope.Logger.V(4).Info("invalid proxmoxmachine state", "state", conditions.GetReason(scope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition))
 		// If you end up here, please file a bug report.
 		return vm, errors.New("invalid state (failed and no error)")
@@ -133,6 +132,12 @@ func ReconcileVM(ctx context.Context, scope *scope.MachineScope) (infrav1.Virtua
 
 	vm.State = infrav1.VirtualMachineStateReady
 	return vm, nil
+}
+
+func proxmoxMachineHasVMProvisionFailedReason(scope *scope.MachineScope) bool {
+	reason := conditions.GetReason(scope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition)
+	return reason == infrav1.ProxmoxMachineVirtualMachineProvisionedVMProvisionFailedReason ||
+		reason == infrav1.ProxmoxMachineVirtualMachineProvisionedTaskFailedReason
 }
 
 func checkCloudInitStatus(ctx context.Context, machineScope *scope.MachineScope) (requeue bool, err error) {

--- a/internal/service/vmservice/vm.go
+++ b/internal/service/vmservice/vm.go
@@ -80,7 +80,7 @@ func ReconcileVM(ctx context.Context, scope *scope.MachineScope) (infrav1.Virtua
 	} // VirtualMachineProvisioned reason is Cloning
 
 	if requeue, err := reconcileVirtualMachineConfig(ctx, scope); err != nil || requeue {
-		scope.Logger.V(4).Info("after reconcileVirtualMachineCOnfig", "machineName", scope.ProxmoxMachine.GetName(), "requeue", requeue, "err", err)
+		scope.Logger.V(4).Info("after reconcileVirtualMachineConfig", "machineName", scope.ProxmoxMachine.GetName(), "requeue", requeue, "err", err)
 		return vm, err
 	} // VirtualMachineProvisioned reason is WaitingForDiskReconciliation
 

--- a/internal/service/vmservice/vm_test.go
+++ b/internal/service/vmservice/vm_test.go
@@ -790,11 +790,11 @@ func TestReconcileVM_EndToEnd(t *testing.T) {
 	// Provide IPAddresses fields to fake network bootstrap.
 	machineScope.ProxmoxMachine.Status.IPAddresses = []infrav1.IPAddressesSpec{{
 		NetName: string(infrav1.DefaultNetworkDevice),
-		IPv4:    []string{"10.10.10.10"},
+		IPv4:    []string{"192.0.2.10"},
 		IPv6:    []string{"2001:db8::2"},
 	}, {
 		NetName: "default",
-		IPv4:    []string{"10.10.10.10"},
+		IPv4:    []string{"192.0.2.10"},
 		IPv6:    []string{"2001:db8::2"},
 	}}
 	machineScope.ProxmoxMachine.Status.BootstrapDataProvided = ptr.To(true)
@@ -851,6 +851,6 @@ func TestReconcileVM_EndToEnd(t *testing.T) {
 
 	// Test that reconcileMachineAddresses ran.
 	require.Equal(t, machineScope.ProxmoxMachine.GetName(), machineScope.ProxmoxMachine.Status.Addresses[0].Address)
-	require.Equal(t, "10.10.10.10", machineScope.ProxmoxMachine.Status.Addresses[1].Address)
+	require.Equal(t, "192.0.2.10", machineScope.ProxmoxMachine.Status.Addresses[1].Address)
 	require.Equal(t, "2001:db8::2", machineScope.ProxmoxMachine.Status.Addresses[2].Address)
 }

--- a/internal/service/vmservice/vm_test.go
+++ b/internal/service/vmservice/vm_test.go
@@ -723,6 +723,12 @@ func TestReconcileVM_EndToEnd(t *testing.T) {
 	machineScope.ProxmoxMachine.Spec.NumSockets = ptr.To[int32](1)
 	machineScope.ProxmoxMachine.Spec.NumCores = ptr.To[int32](1)
 	machineScope.ProxmoxMachine.Spec.MemoryMiB = ptr.To[int32](1024)
+	machineScope.ProxmoxMachine.Spec.Disks = &infrav1.Storage{
+		BootVolume: &infrav1.DiskSize{
+			Disk:   "scsi0",
+			SizeGB: 50,
+		},
+	}
 	task := newTask()
 	expectedVMConfigureRequest := []interface{}{
 		proxmox.VirtualMachineOption{Name: optionSockets, Value: *machineScope.ProxmoxMachine.Spec.NumSockets},
@@ -748,11 +754,12 @@ func TestReconcileVM_EndToEnd(t *testing.T) {
 		),
 	)
 
-	// Round 2: requeue machine until providing BootstrapData.
+	// Round 2: ConfigureVM task has completed; reconcileDisks resizes the boot volume,
+	// then reconcileIPAddresses advances the state to WaitingForBootstrapData.
 	// We're not mocking the entirety of a network setup.
+	proxmoxClient.EXPECT().GetTask(context.Background(), "result").Return(&lutherproxmox.Task{UPID: "result", IsSuccessful: true}, nil).Once()
 	proxmoxClient.EXPECT().GetVM(context.Background(), "node1", int64(123)).Return(vm, nil).Once()
-	// remove ConfigureVM task (we don't care).
-	machineScope.ProxmoxMachine.Status.TaskRef = nil
+	proxmoxClient.EXPECT().ResizeDisk(context.Background(), vm, "scsi0", "50G").Return(nil, nil).Once()
 
 	result, err = ReconcileVM(context.Background(), machineScope)
 	require.NoError(t, err)
@@ -804,25 +811,16 @@ func TestReconcileVM_EndToEnd(t *testing.T) {
 		),
 	)
 
-	// Round 4: VMPowerUP requires a task, move state machine forwards one step again.
-	conditions.Set(
-		machineScope.ProxmoxMachine,
-		metav1.Condition{
-			Type:   infrav1.ProxmoxMachineVirtualMachineProvisionedCondition,
-			Status: metav1.ConditionFalse,
-			Reason: infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForClusterAPIMachineAddressesReason,
-		},
-	)
+	// Round 4: StartVM task has completed; the VM is now running. reconcilePowerState
+	// sees it's already up and advances, then reconcileMachineAddresses sets addresses,
+	// and checkCloudInitStatus finds cloud-init done.
+	vm.Status = lutherproxmox.StatusVirtualMachineRunning
+	vm.QMPStatus = lutherproxmox.StatusVirtualMachineRunning
 
+	proxmoxClient.EXPECT().GetTask(context.Background(), "result").Return(&lutherproxmox.Task{UPID: "result", IsSuccessful: true}, nil).Once()
 	proxmoxClient.EXPECT().GetVM(context.Background(), "node1", int64(123)).Return(vm, nil).Once()
 	proxmoxClient.EXPECT().QemuAgentStatus(context.Background(), vm).Return(nil).Once()
 	proxmoxClient.EXPECT().CloudInitStatus(context.Background(), vm).Return(false, nil).Once()
-
-	// remove StartVM task (we don't care).
-	machineScope.ProxmoxMachine.Status.TaskRef = nil
-	// Set machine to running manually.
-	machineScope.VirtualMachine.Status = lutherproxmox.StatusVirtualMachineRunning
-	machineScope.VirtualMachine.QMPStatus = lutherproxmox.StatusVirtualMachineRunning
 
 	result, err = ReconcileVM(context.Background(), machineScope)
 	require.NoError(t, err)
@@ -851,7 +849,7 @@ func TestReconcileVM_EndToEnd(t *testing.T) {
 	result, err = ReconcileVM(context.Background(), machineScope)
 	require.NoError(t, err)
 
-	// Test that reconcileIPAddresses ran.
+	// Test that reconcileMachineAddresses ran.
 	require.Equal(t, machineScope.ProxmoxMachine.GetName(), machineScope.ProxmoxMachine.Status.Addresses[0].Address)
 	require.Equal(t, "10.10.10.10", machineScope.ProxmoxMachine.Status.Addresses[1].Address)
 	require.Equal(t, "2001:db8::2", machineScope.ProxmoxMachine.Status.Addresses[2].Address)

--- a/internal/service/vmservice/vm_test.go
+++ b/internal/service/vmservice/vm_test.go
@@ -709,17 +709,13 @@ func TestReconcileVM_EndToEnd(t *testing.T) {
 		Gateway:   "2001:db8::1",
 	}
 
-	machineScope.SetVirtualMachine(vm)
-	machineScope.SetVirtualMachineID(int64(vm.VMID))
-
 	machineScope.ProxmoxMachine.Spec.Description = ptr.To("test vm")
 	machineScope.ProxmoxMachine.Spec.Format = ptr.To(infrav1.TargetStorageFormatRaw)
 	machineScope.ProxmoxMachine.Spec.Full = ptr.To(true)
 	machineScope.ProxmoxMachine.Spec.Pool = ptr.To("pool")
 	machineScope.ProxmoxMachine.Spec.SnapName = ptr.To("snap")
 	machineScope.ProxmoxMachine.Spec.Storage = ptr.To("storage")
-	machineScope.ProxmoxMachine.Spec.AllowedNodes = []string{"node1"}
-	machineScope.ProxmoxMachine.Spec.VirtualMachineID = ptr.To[int64](123)
+	machineScope.ProxmoxMachine.Spec.AllowedNodes = []string{"node1", "node2"}
 	machineScope.ProxmoxMachine.Spec.NumSockets = ptr.To[int32](1)
 	machineScope.ProxmoxMachine.Spec.NumCores = ptr.To[int32](1)
 	machineScope.ProxmoxMachine.Spec.MemoryMiB = ptr.To[int32](1024)
@@ -729,6 +725,38 @@ func TestReconcileVM_EndToEnd(t *testing.T) {
 			SizeGB: 50,
 		},
 	}
+
+	// Round 0: no VM exists yet; CloneVM creates one and requeues for the task to complete.
+	proxmoxClient.EXPECT().GetReservableMemoryBytes(context.Background(), "node1", int64(100)).Return(0, nil).Once()
+	proxmoxClient.EXPECT().GetReservableMemoryBytes(context.Background(), "node2", int64(100)).Return(^uint64(0), nil).Once()
+	proxmoxClient.EXPECT().CloneVM(context.Background(), 123, proxmox.VMCloneRequest{
+		Node:        "node1",
+		Name:        "test",
+		Description: "test vm",
+		Format:      "raw",
+		Full:        1,
+		Pool:        "pool",
+		SnapName:    "snap",
+		Storage:     "storage",
+		Target:      "node2",
+	}).Return(proxmox.VMCloneResponse{NewID: 123, Task: newTask()}, nil).Once()
+
+	result, err := ReconcileVM(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.Equal(t, infrav1.VirtualMachineStatePending, result.State)
+	require.Equal(
+		t,
+		infrav1.ProxmoxMachineVirtualMachineProvisionedCloningReason,
+		conditions.GetReason(
+			machineScope.ProxmoxMachine,
+			infrav1.ProxmoxMachineVirtualMachineProvisionedCondition,
+		),
+	)
+
+	// Round 1: clone task complete; ConfigureVM sets VM options and requeues.
+	proxmoxClient.EXPECT().GetTask(context.Background(), "result").Return(&lutherproxmox.Task{UPID: "result", IsSuccessful: true}, nil).Once()
+	proxmoxClient.EXPECT().GetVM(context.Background(), "node2", int64(123)).Return(vm, nil).Once()
+
 	task := newTask()
 	expectedVMConfigureRequest := []interface{}{
 		proxmox.VirtualMachineOption{Name: optionSockets, Value: *machineScope.ProxmoxMachine.Spec.NumSockets},
@@ -737,12 +765,9 @@ func TestReconcileVM_EndToEnd(t *testing.T) {
 		proxmox.VirtualMachineOption{Name: optionDescription, Value: machineScope.ProxmoxMachine.Spec.Description},
 	}
 
-	// Round 1: state machine advances to reconcileVirtualMachineConfig,
-	// since this is a goproxmox task, we need to requeue afterwards.
-	proxmoxClient.EXPECT().GetVM(context.Background(), "node1", int64(123)).Return(vm, nil).Once()
 	proxmoxClient.EXPECT().ConfigureVM(context.Background(), vm, expectedVMConfigureRequest...).Return(task, nil).Once()
 
-	result, err := ReconcileVM(context.Background(), machineScope)
+	result, err = ReconcileVM(context.Background(), machineScope)
 	require.NoError(t, err)
 	require.Equal(t, infrav1.VirtualMachineStatePending, result.State)
 	require.Equal(
@@ -758,7 +783,7 @@ func TestReconcileVM_EndToEnd(t *testing.T) {
 	// then reconcileIPAddresses advances the state to WaitingForBootstrapData.
 	// We're not mocking the entirety of a network setup.
 	proxmoxClient.EXPECT().GetTask(context.Background(), "result").Return(&lutherproxmox.Task{UPID: "result", IsSuccessful: true}, nil).Once()
-	proxmoxClient.EXPECT().GetVM(context.Background(), "node1", int64(123)).Return(vm, nil).Once()
+	proxmoxClient.EXPECT().GetVM(context.Background(), "node2", int64(123)).Return(vm, nil).Once()
 	proxmoxClient.EXPECT().ResizeDisk(context.Background(), vm, "scsi0", "50G").Return(nil, nil).Once()
 
 	result, err = ReconcileVM(context.Background(), machineScope)
@@ -784,7 +809,7 @@ func TestReconcileVM_EndToEnd(t *testing.T) {
 		},
 	)
 
-	proxmoxClient.EXPECT().GetVM(context.Background(), "node1", int64(123)).Return(vm, nil).Once()
+	proxmoxClient.EXPECT().GetVM(context.Background(), "node2", int64(123)).Return(vm, nil).Once()
 	proxmoxClient.EXPECT().StartVM(context.Background(), vm).Return(newTask(), nil).Once()
 
 	// Provide IPAddresses fields to fake network bootstrap.
@@ -818,7 +843,7 @@ func TestReconcileVM_EndToEnd(t *testing.T) {
 	vm.QMPStatus = lutherproxmox.StatusVirtualMachineRunning
 
 	proxmoxClient.EXPECT().GetTask(context.Background(), "result").Return(&lutherproxmox.Task{UPID: "result", IsSuccessful: true}, nil).Once()
-	proxmoxClient.EXPECT().GetVM(context.Background(), "node1", int64(123)).Return(vm, nil).Once()
+	proxmoxClient.EXPECT().GetVM(context.Background(), "node2", int64(123)).Return(vm, nil).Once()
 	proxmoxClient.EXPECT().QemuAgentStatus(context.Background(), vm).Return(nil).Once()
 	proxmoxClient.EXPECT().CloudInitStatus(context.Background(), vm).Return(false, nil).Once()
 
@@ -841,9 +866,9 @@ func TestReconcileVM_EndToEnd(t *testing.T) {
 		Status: metav1.ConditionTrue,
 		Reason: "Available",
 	})
-	machineScope.Machine.Status.NodeRef = clusterv1.MachineNodeReference{Name: "node1"}
+	machineScope.Machine.Status.NodeRef = clusterv1.MachineNodeReference{Name: "node2"}
 
-	proxmoxClient.EXPECT().GetVM(context.Background(), "node1", int64(123)).Return(vm, nil).Once()
+	proxmoxClient.EXPECT().GetVM(context.Background(), "node2", int64(123)).Return(vm, nil).Once()
 	proxmoxClient.EXPECT().UnmountCloudInitISO(context.Background(), vm, "ide0").Return(nil).Once()
 
 	result, err = ReconcileVM(context.Background(), machineScope)

--- a/internal/service/vmservice/vm_test.go
+++ b/internal/service/vmservice/vm_test.go
@@ -726,6 +726,8 @@ func TestReconcileVM_EndToEnd(t *testing.T) {
 		},
 	}
 
+	task := newTask()
+
 	// Round 0: no VM exists yet; CloneVM creates one and requeues for the task to complete.
 	proxmoxClient.EXPECT().GetReservableMemoryBytes(context.Background(), "node1", int64(100)).Return(0, nil).Once()
 	proxmoxClient.EXPECT().GetReservableMemoryBytes(context.Background(), "node2", int64(100)).Return(^uint64(0), nil).Once()
@@ -739,7 +741,7 @@ func TestReconcileVM_EndToEnd(t *testing.T) {
 		SnapName:    "snap",
 		Storage:     "storage",
 		Target:      "node2",
-	}).Return(proxmox.VMCloneResponse{NewID: 123, Task: newTask()}, nil).Once()
+	}).Return(proxmox.VMCloneResponse{NewID: 123, Task: task}, nil).Once()
 
 	result, err := ReconcileVM(context.Background(), machineScope)
 	require.NoError(t, err)
@@ -754,10 +756,9 @@ func TestReconcileVM_EndToEnd(t *testing.T) {
 	)
 
 	// Round 1: clone task complete; ConfigureVM sets VM options and requeues.
-	proxmoxClient.EXPECT().GetTask(context.Background(), "result").Return(&lutherproxmox.Task{UPID: "result", IsSuccessful: true}, nil).Once()
+	proxmoxClient.EXPECT().GetTask(context.Background(), "result").Return(task, nil).Once()
 	proxmoxClient.EXPECT().GetVM(context.Background(), "node2", int64(123)).Return(vm, nil).Once()
 
-	task := newTask()
 	expectedVMConfigureRequest := []interface{}{
 		proxmox.VirtualMachineOption{Name: optionSockets, Value: *machineScope.ProxmoxMachine.Spec.NumSockets},
 		proxmox.VirtualMachineOption{Name: optionCores, Value: *machineScope.ProxmoxMachine.Spec.NumCores},
@@ -782,7 +783,7 @@ func TestReconcileVM_EndToEnd(t *testing.T) {
 	// Round 2: ConfigureVM task has completed; reconcileDisks resizes the boot volume,
 	// then reconcileIPAddresses advances the state to WaitingForBootstrapData.
 	// We're not mocking the entirety of a network setup.
-	proxmoxClient.EXPECT().GetTask(context.Background(), "result").Return(&lutherproxmox.Task{UPID: "result", IsSuccessful: true}, nil).Once()
+	proxmoxClient.EXPECT().GetTask(context.Background(), "result").Return(task, nil).Once()
 	proxmoxClient.EXPECT().GetVM(context.Background(), "node2", int64(123)).Return(vm, nil).Once()
 	proxmoxClient.EXPECT().ResizeDisk(context.Background(), vm, "scsi0", "50G").Return(nil, nil).Once()
 
@@ -842,7 +843,7 @@ func TestReconcileVM_EndToEnd(t *testing.T) {
 	vm.Status = lutherproxmox.StatusVirtualMachineRunning
 	vm.QMPStatus = lutherproxmox.StatusVirtualMachineRunning
 
-	proxmoxClient.EXPECT().GetTask(context.Background(), "result").Return(&lutherproxmox.Task{UPID: "result", IsSuccessful: true}, nil).Once()
+	proxmoxClient.EXPECT().GetTask(context.Background(), "result").Return(task, nil).Once()
 	proxmoxClient.EXPECT().GetVM(context.Background(), "node2", int64(123)).Return(vm, nil).Once()
 	proxmoxClient.EXPECT().QemuAgentStatus(context.Background(), vm).Return(nil).Once()
 	proxmoxClient.EXPECT().CloudInitStatus(context.Background(), vm).Return(false, nil).Once()

--- a/internal/service/vmservice/vm_test.go
+++ b/internal/service/vmservice/vm_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"testing"
 
+	lutherproxmox "github.com/luthermonson/go-proxmox"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -694,4 +695,164 @@ func TestReconcileVM_CloudInitRunning(t *testing.T) {
 	result, err := ReconcileVM(context.Background(), machineScope)
 	require.NoError(t, err)
 	require.Equal(t, infrav1.VirtualMachineStatePending, result.State)
+}
+
+// This test is supposed to test the entire state machine transition.
+func TestReconcileVM_EndToEnd(t *testing.T) {
+	machineScope, proxmoxClient, _ := setupReconcilerTest(t)
+	vm := newStoppedVM()
+	vm.VirtualMachineConfig.IDE0 = "local:iso/cloud-init.iso,media=cdrom"
+
+	machineScope.InfraCluster.ProxmoxCluster.Spec.IPv6Config = &infrav1.IPConfigSpec{
+		Addresses: []string{"2001:db8::/64"},
+		Prefix:    64,
+		Gateway:   "2001:db8::1",
+	}
+
+	machineScope.SetVirtualMachine(vm)
+	machineScope.SetVirtualMachineID(int64(vm.VMID))
+
+	machineScope.ProxmoxMachine.Spec.Description = ptr.To("test vm")
+	machineScope.ProxmoxMachine.Spec.Format = ptr.To(infrav1.TargetStorageFormatRaw)
+	machineScope.ProxmoxMachine.Spec.Full = ptr.To(true)
+	machineScope.ProxmoxMachine.Spec.Pool = ptr.To("pool")
+	machineScope.ProxmoxMachine.Spec.SnapName = ptr.To("snap")
+	machineScope.ProxmoxMachine.Spec.Storage = ptr.To("storage")
+	machineScope.ProxmoxMachine.Spec.AllowedNodes = []string{"node1"}
+	machineScope.ProxmoxMachine.Spec.VirtualMachineID = ptr.To[int64](123)
+	machineScope.ProxmoxMachine.Spec.NumSockets = ptr.To[int32](1)
+	machineScope.ProxmoxMachine.Spec.NumCores = ptr.To[int32](1)
+	machineScope.ProxmoxMachine.Spec.MemoryMiB = ptr.To[int32](1024)
+	task := newTask()
+	expectedVMConfigureRequest := []interface{}{
+		proxmox.VirtualMachineOption{Name: optionSockets, Value: *machineScope.ProxmoxMachine.Spec.NumSockets},
+		proxmox.VirtualMachineOption{Name: optionCores, Value: *machineScope.ProxmoxMachine.Spec.NumCores},
+		proxmox.VirtualMachineOption{Name: optionMemory, Value: *machineScope.ProxmoxMachine.Spec.MemoryMiB},
+		proxmox.VirtualMachineOption{Name: optionDescription, Value: machineScope.ProxmoxMachine.Spec.Description},
+	}
+
+	// Round 1: state machine advances to reconcileVirtualMachineConfig,
+	// since this is a goproxmox task, we need to requeue afterwards.
+	proxmoxClient.EXPECT().GetVM(context.Background(), "node1", int64(123)).Return(vm, nil).Once()
+	proxmoxClient.EXPECT().ConfigureVM(context.Background(), vm, expectedVMConfigureRequest...).Return(task, nil).Once()
+
+	result, err := ReconcileVM(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.Equal(t, infrav1.VirtualMachineStatePending, result.State)
+	require.Equal(
+		t,
+		infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForDiskReconciliationReason,
+		conditions.GetReason(
+			machineScope.ProxmoxMachine,
+			infrav1.ProxmoxMachineVirtualMachineProvisionedCondition,
+		),
+	)
+
+	// Round 2: requeue machine until providing BootstrapData.
+	// We're not mocking the entirety of a network setup.
+	proxmoxClient.EXPECT().GetVM(context.Background(), "node1", int64(123)).Return(vm, nil).Once()
+	// remove ConfigureVM task (we don't care).
+	machineScope.ProxmoxMachine.Status.TaskRef = nil
+
+	result, err = ReconcileVM(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.Equal(t, infrav1.VirtualMachineStatePending, result.State)
+	require.Equal(
+		t,
+		infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForBootstrapDataReconciliationReason,
+		conditions.GetReason(
+			machineScope.ProxmoxMachine,
+			infrav1.ProxmoxMachineVirtualMachineProvisionedCondition,
+		),
+	)
+
+	// Round 3: manually move the state machine forwards one step as
+	// we're not testing bootstrap.go.
+	conditions.Set(
+		machineScope.ProxmoxMachine,
+		metav1.Condition{
+			Type:   infrav1.ProxmoxMachineVirtualMachineProvisionedCondition,
+			Status: metav1.ConditionFalse,
+			Reason: infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForVMPowerUpReason,
+		},
+	)
+
+	proxmoxClient.EXPECT().GetVM(context.Background(), "node1", int64(123)).Return(vm, nil).Once()
+	proxmoxClient.EXPECT().StartVM(context.Background(), vm).Return(newTask(), nil).Once()
+
+	// Provide IPAddresses fields to fake network bootstrap.
+	machineScope.ProxmoxMachine.Status.IPAddresses = []infrav1.IPAddressesSpec{{
+		NetName: string(infrav1.DefaultNetworkDevice),
+		IPv4:    []string{"10.10.10.10"},
+		IPv6:    []string{"2001:db8::2"},
+	}, {
+		NetName: "default",
+		IPv4:    []string{"10.10.10.10"},
+		IPv6:    []string{"2001:db8::2"},
+	}}
+	machineScope.ProxmoxMachine.Status.BootstrapDataProvided = ptr.To(true)
+
+	result, err = ReconcileVM(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.Equal(t, infrav1.VirtualMachineStatePending, result.State)
+	require.Equal(
+		t,
+		infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForVMPowerUpReason,
+		conditions.GetReason(
+			machineScope.ProxmoxMachine,
+			infrav1.ProxmoxMachineVirtualMachineProvisionedCondition,
+		),
+	)
+
+	// Round 4: VMPowerUP requires a task, move state machine forwards one step again.
+	conditions.Set(
+		machineScope.ProxmoxMachine,
+		metav1.Condition{
+			Type:   infrav1.ProxmoxMachineVirtualMachineProvisionedCondition,
+			Status: metav1.ConditionFalse,
+			Reason: infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForClusterAPIMachineAddressesReason,
+		},
+	)
+
+	proxmoxClient.EXPECT().GetVM(context.Background(), "node1", int64(123)).Return(vm, nil).Once()
+	proxmoxClient.EXPECT().QemuAgentStatus(context.Background(), vm).Return(nil).Once()
+	proxmoxClient.EXPECT().CloudInitStatus(context.Background(), vm).Return(false, nil).Once()
+
+	// remove StartVM task (we don't care).
+	machineScope.ProxmoxMachine.Status.TaskRef = nil
+	// Set machine to running manually.
+	machineScope.VirtualMachine.Status = lutherproxmox.StatusVirtualMachineRunning
+	machineScope.VirtualMachine.QMPStatus = lutherproxmox.StatusVirtualMachineRunning
+
+	result, err = ReconcileVM(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.Equal(t, infrav1.VirtualMachineStateReady, result.State)
+	require.Equal(
+		t,
+		infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForBootstrapReadyReason,
+		conditions.GetReason(
+			machineScope.ProxmoxMachine,
+			infrav1.ProxmoxMachineVirtualMachineProvisionedCondition,
+		),
+	)
+
+	// Round 5: cloud-init has finished and the ISO is ready to be unmounted.
+	// The CAPI machine has become available with a node reference.
+	conditions.Set(machineScope.Machine, metav1.Condition{
+		Type:   string(clusterv1.AvailableCondition),
+		Status: metav1.ConditionTrue,
+		Reason: "Available",
+	})
+	machineScope.Machine.Status.NodeRef = clusterv1.MachineNodeReference{Name: "node1"}
+
+	proxmoxClient.EXPECT().GetVM(context.Background(), "node1", int64(123)).Return(vm, nil).Once()
+	proxmoxClient.EXPECT().UnmountCloudInitISO(context.Background(), vm, "ide0").Return(nil).Once()
+
+	result, err = ReconcileVM(context.Background(), machineScope)
+	require.NoError(t, err)
+
+	// Test that reconcileIPAddresses ran.
+	require.Equal(t, machineScope.ProxmoxMachine.GetName(), machineScope.ProxmoxMachine.Status.Addresses[0].Address)
+	require.Equal(t, "10.10.10.10", machineScope.ProxmoxMachine.Status.Addresses[1].Address)
+	require.Equal(t, "2001:db8::2", machineScope.ProxmoxMachine.Status.Addresses[2].Address)
 }

--- a/internal/service/vmservice/vm_test.go
+++ b/internal/service/vmservice/vm_test.go
@@ -698,7 +698,7 @@ func TestReconcileVM_CloudInitRunning(t *testing.T) {
 }
 
 // This test is supposed to test the entire state machine transition.
-func TestReconcileVM_EndToEnd(t *testing.T) {
+func TestReconcileVM_StateMachine(t *testing.T) {
 	machineScope, proxmoxClient, _ := setupReconcilerTest(t)
 	vm := newStoppedVM()
 	vm.VirtualMachineConfig.IDE0 = "local:iso/cloud-init.iso,media=cdrom"


### PR DESCRIPTION
*Issue #, if available:*
#710
#714 

*Description of changes:*
The state machine was set to the wrong state after reconcilePowerState, therefore proxmoxmachine.Status.Addresses was never populated. Our tests for reconcileMachineAddresses succesfully ran as the code itself was fine. Our E2E tests did not fail because we do not depend on this field.

To catch these kinds of errors in the future, I've made a new test for ReconcileVM which tries to test its workings in their entirety.

*Testing performed:*
`make test`