### PR TITLE
chore(sonar-project): set sonar.projectVersion

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,4 @@
+sonar.projectVersion=0.8.0
 sonar.projectKey=ionos-cloud_cluster-api-provider-proxmox
 sonar.organization=ionos-cloud
 


### PR DESCRIPTION
`sonar.projectVersion` triggers the 'new code' event which should fix SonarQube thinking there have not been any releases since v0.7.1 and GitHub thinking the code has not been scanned since then.

https://docs.sonarsource.com/sonarqube-server/user-guide/about-new-code
https://community.sonarsource.com/t/how-does-sonarqube-determine-previous-version/36871
https://community.sonarsource.com/t/github-sonarcloud-is-reporting-errors-check-the-sonarcloud-status-page-for-help/112630/11
