### PR TITLE
fix(proxmoxmachine): tolerate owner Machine NotFound to unblock stuck deletes

### DIFF
--- a/internal/controller/proxmoxmachine_controller.go
+++ b/internal/controller/proxmoxmachine_controller.go
@@ -97,6 +97,35 @@ func (r *ProxmoxMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// Fetch the Machine.
 	machine, err := util.GetOwnerMachine(ctx, r.Client, proxmoxMachine.ObjectMeta)
 	if err != nil {
+		// The owner Machine OwnerRef is set but the Machine object itself is
+		// gone. This is the stuck-finalizer deadlock: without this branch the
+		// reconciler returns the NotFound error to controller-runtime, which
+		// requeues with exponential backoff forever, never reaching
+		// reconcileDelete and never removing our finalizer. The ProxmoxMachine
+		// then blocks the parent ProxmoxCluster (waiting for machines) and the
+		// Cluster from finalizing.
+		//
+		// We can hit this whenever the owner Machine is removed before the
+		// InfraMachine is finalized: a manual finalizer strip, the
+		// `cluster.x-k8s.io/force-delete-machine` annotation, or any other
+		// actor that out-of-band reaps the Machine.
+		if apierrors.IsNotFound(err) {
+			if !proxmoxMachine.ObjectMeta.DeletionTimestamp.IsZero() {
+				logger.Info("Owner Machine not found while ProxmoxMachine is being deleted; removing finalizer to unblock cluster delete. The underlying Proxmox VM may still exist and should be verified by an administrator.")
+				if ctrlutil.RemoveFinalizer(proxmoxMachine, infrav1.MachineFinalizer) {
+					if err := r.Client.Update(ctx, proxmoxMachine); err != nil {
+						return ctrl.Result{}, errors.Wrap(err, "removing finalizer after owner Machine not found")
+					}
+				}
+				return ctrl.Result{}, nil
+			}
+			// ProxmoxMachine is not being deleted. The OwnerRef points to a
+			// missing Machine — log and skip rather than error-loop. Either
+			// the OwnerRef will be corrected, or the ProxmoxMachine will be
+			// deleted, both of which trigger another reconcile.
+			logger.Info("Owner Machine not found and ProxmoxMachine is not being deleted; skipping reconcile.")
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, err
 	}
 	if machine == nil {

--- a/internal/controller/proxmoxmachine_controller_test.go
+++ b/internal/controller/proxmoxmachine_controller_test.go
@@ -21,8 +21,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -51,6 +54,68 @@ var _ = Describe("ProxmoxMachineReconciler", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeZero())
+		})
+
+		It("should remove the finalizer when the owner Machine is missing during deletion", func() {
+			reconciler := &ProxmoxMachineReconciler{
+				Client:        k8sClient,
+				Scheme:        runtime.NewScheme(),
+				ProxmoxClient: proxmoxClient,
+			}
+			ctx := context.Background()
+
+			By("Creating a ProxmoxMachine with a Machine OwnerRef pointing to a non-existent Machine, and our finalizer set")
+			instance := &infrav1.ProxmoxMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "orphan-pmm",
+					Namespace:  "default",
+					Finalizers: []string{infrav1.MachineFinalizer},
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: clusterv1.GroupVersion.String(),
+						Kind:       "Machine",
+						Name:       "missing-machine",
+						UID:        "11111111-1111-1111-1111-111111111111",
+					}},
+				},
+				Spec: infrav1.ProxmoxMachineSpec{
+					VirtualMachineCloneSpec: infrav1.VirtualMachineCloneSpec{
+						TemplateSource: infrav1.TemplateSource{
+							SourceNode: ptr.To("pve"),
+							TemplateID: ptr.To(int32(100)),
+						},
+					},
+					NumSockets: ptr.To(int32(1)),
+					NumCores:   ptr.To(int32(1)),
+					MemoryMiB:  ptr.To(int32(1024)),
+					Disks: &infrav1.Storage{
+						BootVolume: &infrav1.DiskSize{Disk: "scsi[0]", SizeGB: 10},
+					},
+					Network: &infrav1.NetworkSpec{
+						NetworkDevices: []infrav1.NetworkDevice{{
+							Name:   infrav1.NetName("net0"),
+							Bridge: ptr.To("vmbr1"),
+							Model:  ptr.To("virtio"),
+							MTU:    ptr.To(int32(1500)),
+						}},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+			By("Issuing a Delete so the API server sets a deletionTimestamp (finalizer keeps the object alive)")
+			Expect(k8sClient.Delete(ctx, instance)).To(Succeed())
+
+			By("Reconciling — owner Machine NotFound on the delete path should remove the finalizer instead of erroring")
+			result, err := reconciler.Reconcile(ctx, ctrl.Request{
+				NamespacedName: client.ObjectKey{Namespace: instance.Namespace, Name: instance.Name},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			By("Verifying the ProxmoxMachine has been reaped by the API server now that the finalizer is gone")
+			got := &infrav1.ProxmoxMachine{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Namespace: instance.Namespace, Name: instance.Name}, got)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "expected ProxmoxMachine to be gone after finalizer removal")
 		})
 	})
 })


### PR DESCRIPTION
## What this fixes

The `ProxmoxMachine` reconciler currently deadlocks any `ProxmoxMachine` whose owner `Machine` has been removed before the InfraMachine was finalized. Reproduction: take any cluster, remove a `Machine` out-of-band (manual finalizer strip, `cluster.x-k8s.io/force-delete-machine` annotation, or any other actor) before its `ProxmoxMachine` finishes finalizing. The `ProxmoxMachine` then sits in `Terminating` forever and blocks the parent `ProxmoxCluster` and `Cluster` from finalizing.

## Root cause

[`internal/controller/proxmoxmachine_controller.go#L97-L105`](https://github.com/ionos-cloud/cluster-api-provider-proxmox/blob/main/internal/controller/proxmoxmachine_controller.go#L97-L105):

```go
machine, err := util.GetOwnerMachine(ctx, r.Client, proxmoxMachine.ObjectMeta)
if err != nil {
    return ctrl.Result{}, err
}
```

`util.GetOwnerMachine` returns `nil, nil` only when there is **no** Machine OwnerRef at all. When the OwnerRef is present but the Machine object is gone, it calls `client.Get` and returns `apierrors.NotFound`. The reconciler returns that error verbatim, controller-runtime backs off exponentially, and the delete branch (`if !proxmoxMachine.ObjectMeta.DeletionTimestamp.IsZero()`) is never reached. The `MachineFinalizer` never comes off.

The log signature observed in production:
```
"Reconciler error" err="Machine.cluster.x-k8s.io \"<name>\" not found"
```
repeating every backoff cycle for hours.

This is a known class of issue: [`docs/Troubleshooting.md`](https://github.com/ionos-cloud/cluster-api-provider-proxmox/blob/main/docs/Troubleshooting.md) under "Machine deletion deadlock" already documents the manual workaround (strip the `proxmoxmachine` finalizer by hand). This PR addresses the underlying controller behaviour so the manual workaround is no longer needed.

## What this PR does

In `Reconcile`, when `GetOwnerMachine` returns `IsNotFound`:

- **If the `ProxmoxMachine` has a `DeletionTimestamp`:** remove the `MachineFinalizer` and return cleanly. A log line tells the operator to verify the underlying Proxmox VM, since a full `machineScope` cannot be constructed without the owner Machine and `vmservice.DeleteVM` requires the scope. This is the conservative choice: unblock the controller-level deadlock without taking destructive action against the hypervisor under partial state.
- **If the `ProxmoxMachine` is not being deleted:** log and return `nil` instead of error-looping. Either the OwnerRef will be corrected (which triggers another reconcile via the watch) or the `ProxmoxMachine` will be deleted (which triggers another reconcile via the delete event).

All other failure modes still propagate as before.

## Tests

Adds an envtest in `proxmoxmachine_controller_test.go` covering the deletion-with-missing-owner case: the test creates a `ProxmoxMachine` with a Machine OwnerRef pointing to a non-existent Machine and the `MachineFinalizer` set, deletes it (the API server records a `deletionTimestamp` since the finalizer is held), runs `Reconcile`, and asserts the object is reaped (i.e. the finalizer was removed).

```
$ make test WHAT=./internal/controller/...
ok  github.com/ionos-cloud/cluster-api-provider-proxmox/internal/controller  30.534s  coverage: 50.6% of statements
```

## Compatibility

- No CRD changes.
- No public API changes.
- The IONOS Troubleshooting doc workaround still works as a runtime escape hatch for clusters that were stuck before this fix is deployed.

## Why I'm sending this

We hit this in production (CAPMOX v0.8.1) when a workload cluster's apiserver became unreachable mid-delete and a Machine ended up reaped before its InfraMachine finalized — the exact deadlock above. Walking the diagnosis backward led here. Happy to iterate on the patch shape, the log wording, or the test scaffolding.