### PR TITLE
Dependabot tweaks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+  cooldown:
+    default-days: 5
   groups:
     kubernetes:
       patterns:
@@ -29,3 +31,5 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+  cooldown:
+    default-days: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
       patterns:
       - sigs.k8s.io/cluster-api
       - sigs.k8s.io/cluster-api/test
+    onsi:
+      patterns:
+      - github.com/onsi/ginkgo/v2
+      - github.com/onsi/gomega
 
 - package-ecosystem: "docker"
   directory: "/"


### PR DESCRIPTION
*Issue #, if available:*
fixes #713

*Description of changes:*
Adds a 5-day cooldown to dependabot. We can bikeshed the exact number.

Also creates a group for onsi projects because those tend to be released together and should be updated together. Reduces spam like #738 #739

*Testing performed:*
linters