### PR TITLE
ci(test): bump go image to 1.26.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,8 +87,18 @@ jobs:
     if: always() && (needs.pre-screen.result == 'success' || needs.pre-screen.result == 'skipped')
     runs-on: ubuntu-latest
     permissions: {}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - go: "1.25"
+            image: golang@sha256:298734aec230b5f3e8cee450ce6d7eccc39f1797ba548ee90d57e9803030c6c3 # 1.25-bookworm
+          - go: "1.26"
+            image: golang@sha256:3a8f055e02fce9585d5e4ab5135d57f2e1a947a16e2a7e6a71a78e770c169e9b # 1.26.3-alpine3.23
+    # Allow the 1.25 job to fail on PRs labelled go/1.26 (code requires 1.26+).
+    continue-on-error: ${{ matrix.go == '1.25' && contains(github.event.pull_request.labels.*.name, 'go/1.26') }}
     container:
-      image: golang@sha256:3a8f055e02fce9585d5e4ab5135d57f2e1a947a16e2a7e6a71a78e770c169e9b # 1.26.3-alpine3.23
+      image: ${{ matrix.image }}
     env:
       GOTOOLCHAIN: local
     steps:
@@ -106,7 +116,7 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: coverage
+          name: coverage-${{ matrix.go }}
           path: cover.out
           retention-days: 7
 
@@ -142,7 +152,7 @@ jobs:
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: coverage
+          name: coverage-1.26
           path: ${{ runner.temp }}/coverage
 
       # fail-fast against malformed coverage file

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     container:
-      image: golang@sha256:298734aec230b5f3e8cee450ce6d7eccc39f1797ba548ee90d57e9803030c6c3 # 1.25-bookworm
+      image: golang@sha256:3a8f055e02fce9585d5e4ab5135d57f2e1a947a16e2a7e6a71a78e770c169e9b # 1.26.3-alpine3.23
     env:
       GOTOOLCHAIN: local
     steps:


### PR DESCRIPTION
*Description of changes:*
Bump test image to go 1.26.3. Keep go 1.25 image too. Require both to pass - we don't want to merge code that will break in 1.26. PRs labelled `go/1.26` are allowed to fail on 1.25 (they will due to toolchain mismatch).

Alpine because it's small and fast. It's also good to test on musl.

`release/v0.9.0` tests will fail without this. Remove for v0.9.0 final release.

*Testing performed:*
ran it