### PR TITLE
Remove direct github.com/pkg/errors usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/luthermonson/go-proxmox v0.4.1
 	github.com/onsi/ginkgo/v2 v2.28.3
 	github.com/onsi/gomega v1.40.0
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
@@ -255,6 +254,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect

--- a/internal/controller/proxmoxcluster_controller.go
+++ b/internal/controller/proxmoxcluster_controller.go
@@ -22,7 +22,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -134,7 +135,7 @@ func (r *ProxmoxClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		IPAMHelper:     ipam.NewHelper(r.Client, proxmoxCluster.DeepCopy()),
 	})
 	if err != nil {
-		return reconcile.Result{}, errors.Errorf("failed to create scope: %+v", err)
+		return reconcile.Result{}, fmt.Errorf("failed to create scope: %+v", err)
 	}
 
 	// Always close the scope when exiting this function so we can persist any ProxmoxCluster changes.
@@ -167,7 +168,7 @@ func (r *ProxmoxClusterReconciler) reconcileDelete(ctx context.Context, clusterS
 	// we should only allow to remove the finalizer when there are no ProxmoxMachines left.
 	machines, err := clusterScope.ListProxmoxMachinesForCluster(ctx)
 	if err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "could not retrieve proxmox machines for cluster %q", clusterScope.InfraClusterName())
+		return reconcile.Result{}, fmt.Errorf("could not retrieve proxmox machines for cluster %q: %w", clusterScope.InfraClusterName(), err)
 	}
 
 	// Requeue if there are one or more machines left.

--- a/internal/controller/proxmoxmachine_controller.go
+++ b/internal/controller/proxmoxmachine_controller.go
@@ -18,9 +18,11 @@ package controller
 
 import (
 	"context"
+	"fmt"
+
+	"errors"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -122,7 +124,7 @@ func (r *ProxmoxMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	infraCluster, err := r.getInfraCluster(ctx, &logger, cluster, proxmoxMachine)
 	if err != nil {
-		return ctrl.Result{}, errors.Errorf("error getting infra provider cluster or control plane object: %v", err)
+		return ctrl.Result{}, fmt.Errorf("error getting infra provider cluster or control plane object: %v", err)
 	}
 	if infraCluster == nil {
 		logger.Info("ProxmoxCluster is not ready yet")
@@ -222,7 +224,7 @@ func (r *ProxmoxMachineReconciler) reconcileNormal(ctx context.Context, machineS
 			return reconcile.Result{RequeueAfter: requeueErr.RequeueAfter()}, nil
 		}
 		machineScope.Logger.Error(err, "error reconciling VM")
-		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile VM")
+		return reconcile.Result{}, fmt.Errorf("failed to reconcile VM: %w", err)
 	}
 	machineScope.ProxmoxMachine.Status.VMStatus = &vm.State
 

--- a/internal/inject/inject.go
+++ b/internal/inject/inject.go
@@ -19,9 +19,11 @@ package inject
 
 import (
 	"context"
+	"fmt"
+
+	"errors"
 
 	"github.com/luthermonson/go-proxmox"
-	"github.com/pkg/errors"
 
 	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/cloudinit"
 	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/ignition"
@@ -62,13 +64,13 @@ func (i *ISOInjector) injectCloudInit(ctx context.Context) error {
 	// Render metadata.
 	metadata, err := i.MetaRenderer.Render()
 	if err != nil {
-		return errors.Wrap(err, "unable to render metadata")
+		return fmt.Errorf("unable to render metadata: %w", err)
 	}
 
 	// Render network-config.
 	network, err := i.NetworkRenderer.Render()
 	if err != nil {
-		return errors.Wrap(err, "unable to render network-config")
+		return fmt.Errorf("unable to render network-config: %w", err)
 	}
 
 	logger.V(4).Info("CloudInit:", "network-config", string(network))
@@ -76,7 +78,7 @@ func (i *ISOInjector) injectCloudInit(ctx context.Context) error {
 	// Inject an ISO with userdata, metadata and network-config into the VirtualMachine.
 	err = i.VirtualMachine.CloudInit(ctx, CloudInitISODevice, string(i.BootstrapData), string(metadata), "", string(network))
 	if err != nil {
-		return errors.Wrap(err, "unable to inject CloudInit ISO")
+		return fmt.Errorf("unable to inject CloudInit ISO: %w", err)
 	}
 
 	return nil
@@ -100,12 +102,12 @@ func (i *ISOInjector) injectIgnition(ctx context.Context) error {
 	// Render metadata.
 	metadata, err := i.MetaRenderer.Render()
 	if err != nil {
-		return errors.Wrap(err, "unable to render metadata")
+		return fmt.Errorf("unable to render metadata: %w", err)
 	}
 
 	bootstrapData, _, err := i.IgnitionEnricher.Enrich()
 	if err != nil {
-		return errors.Wrap(err, "unable to enrich ignition")
+		return fmt.Errorf("unable to enrich ignition: %w", err)
 	}
 
 	logger.V(4).Info("Ingnition", "bootstrapData", bootstrapData)
@@ -113,7 +115,7 @@ func (i *ISOInjector) injectIgnition(ctx context.Context) error {
 	// Inject an ISO with ignition userdata, metadata and an empty network-config v1 into the VirtualMachine.
 	err = i.VirtualMachine.CloudInit(ctx, CloudInitISODevice, string(bootstrapData), string(metadata), "", string(cloudinit.EmptyNetworkV1))
 	if err != nil {
-		return errors.Wrap(err, "unable to inject ignition userdata iso")
+		return fmt.Errorf("unable to inject ignition userdata iso: %w", err)
 	}
 
 	return nil

--- a/internal/service/taskservice/task.go
+++ b/internal/service/taskservice/task.go
@@ -22,8 +22,9 @@ import (
 	"fmt"
 	"time"
 
+	"errors"
+
 	"github.com/luthermonson/go-proxmox"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 

--- a/internal/service/vmservice/bootstrap.go
+++ b/internal/service/vmservice/bootstrap.go
@@ -26,8 +26,9 @@ import (
 	"strconv"
 	"strings"
 
+	"errors"
+
 	"github.com/luthermonson/go-proxmox"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -101,7 +102,7 @@ func reconcileBootstrapData(ctx context.Context, machineScope *scope.MachineScop
 			Message: err.Error(),
 		})
 		machineScope.Logger.V(0).Error(err, "nicData", "json", func() string { ret, _ := json.Marshal(nicData); return string(ret) }())
-		return false, errors.Wrap(err, "failed to inject bootstrap data")
+		return false, fmt.Errorf("failed to inject bootstrap data: %w", err)
 	}
 
 	// Todo: This status field is now superfluous
@@ -179,7 +180,7 @@ func getBootstrapData(ctx context.Context, scope *scope.MachineScope) ([]byte, *
 
 	secret := &corev1.Secret{}
 	if err := scope.GetBootstrapSecret(ctx, secret); err != nil {
-		return nil, nil, errors.Wrapf(err, "failed to retrieve bootstrap data secret")
+		return nil, nil, fmt.Errorf("failed to retrieve bootstrap data secret: %w", err)
 	}
 
 	format := cloudinit.FormatCloudConfig
@@ -241,7 +242,7 @@ func getNetworkConfigDataForDevice(ctx context.Context, machineScope *scope.Mach
 		ipConfig := types.IPConfig{}
 		ip, err := netip.ParsePrefix(fmt.Sprintf("%s/%d", ipAddr.Spec.Address, ptr.Deref(ipAddr.Spec.Prefix, 0)))
 		if err != nil {
-			return nil, errors.Wrapf(err, "error converting ip address spec to netip prefix: %+v", ipAddr.Spec)
+			return nil, fmt.Errorf("error converting ip address spec to netip prefix: %+v: %w", ipAddr.Spec, err)
 		}
 		ipConfig.IPAddress = ip
 		ipConfig.Gateway = ipAddr.Spec.Gateway
@@ -249,7 +250,7 @@ func getNetworkConfigDataForDevice(ctx context.Context, machineScope *scope.Mach
 		// TODO: IPConfigs is stupid. No need to gather metrics here.
 		metric, err := findIPAddressGatewayMetric(ctx, machineScope, &ipAddr)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error converting metric annotation, kind=%s, name=%s", ipAddr.Spec.PoolRef.Kind, ipAddr.Spec.PoolRef.Name)
+			return nil, fmt.Errorf("error converting metric annotation, kind=%s, name=%s: %w", ipAddr.Spec.PoolRef.Kind, ipAddr.Spec.PoolRef.Name, err)
 		}
 		ipConfig.Metric = metric
 
@@ -289,7 +290,10 @@ func getNetworkDevices(ctx context.Context, machineScope *scope.MachineScope, ne
 	requeue, err := handleDevices(ctx, machineScope, ipAddressMap)
 	if requeue || err != nil {
 		// invalid state. Machine should've had all IPs assigned
-		return nil, errors.Wrapf(err, "unable to get IPs for network config data")
+		if err == nil {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("unable to get IPs for network config data: %w", err)
 	}
 
 	// network devices.
@@ -300,7 +304,7 @@ func getNetworkDevices(ctx context.Context, machineScope *scope.MachineScope, ne
 
 		conf, err := getNetworkConfigDataForDevice(ctx, machineScope, nic.Name, ipPoolRefs)
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to get network config data for device=%s", nic.Name)
+			return nil, fmt.Errorf("unable to get network config data for device=%s: %w", nic.Name, err)
 		}
 		if len(nic.DNSServers) != 0 {
 			config.DNSServers = nic.DNSServers
@@ -340,7 +344,7 @@ func getVirtualNetworkDevices(_ context.Context, _ *scope.MachineScope, network 
 				}
 			}
 			if len(config.Interfaces)-1 < i {
-				return nil, errors.Errorf("unable to find vrf interface=%s child interface %s", config.Name, child)
+				return nil, fmt.Errorf("unable to find vrf interface=%s child interface %s", config.Name, child)
 			}
 		}
 

--- a/internal/service/vmservice/delete.go
+++ b/internal/service/vmservice/delete.go
@@ -20,7 +20,8 @@ import (
 	"context"
 	"strings"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"

--- a/internal/service/vmservice/find.go
+++ b/internal/service/vmservice/find.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"fmt"
 
+	"errors"
+
 	"github.com/luthermonson/go-proxmox"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cluster-api/util"
@@ -89,7 +90,7 @@ func updateVMLocation(ctx context.Context, s *scope.MachineScope) error {
 	// find the VM, to make sure the vm config is up-to-date.
 	vm, err := s.InfraCluster.ProxmoxClient.GetVM(ctx, rsc.Node, vmID)
 	if err != nil {
-		return errors.Wrapf(err, "unable to find vm with id %d", rsc.VMID)
+		return fmt.Errorf("unable to find vm with id %d: %w", rsc.VMID, err)
 	}
 
 	// Requeue if machine doesn't have a name yet.

--- a/internal/service/vmservice/ip.go
+++ b/internal/service/vmservice/ip.go
@@ -24,7 +24,8 @@ import (
 	"slices"
 	"strconv"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,9 +53,9 @@ func reconcileIPAddresses(ctx context.Context, machineScope *scope.MachineScope)
 	if pm.Spec.Network != nil {
 		if requeue, err = handleDevices(ctx, machineScope, netPoolAddresses); err != nil || requeue {
 			if err == nil {
-				return true, errors.Wrap(err, "requeuing network reconcillation")
+				return true, nil
 			}
-			return true, errors.Wrap(err, "unable to handle network devices")
+			return true, fmt.Errorf("unable to handle network devices: %w", err)
 		}
 	}
 
@@ -111,7 +112,7 @@ func setVMIPAddressTag(ctx context.Context, machineScope *scope.MachineScope, ip
 		machineScope.Logger.V(4).Info("adding virtual machine ip tag.", "ip", ipAddress.Spec.Address)
 		t, err := machineScope.InfraCluster.ProxmoxClient.TagVM(ctx, vm, ipTag)
 		if err != nil {
-			return false, errors.Wrapf(err, "unable to add IP tag to VirtualMachine %s", machineScope.Name())
+			return false, fmt.Errorf("unable to add IP tag to VirtualMachine %s: %w", machineScope.Name(), err)
 		}
 		machineScope.ProxmoxMachine.Status.TaskRef = ptr.To(string(t.UPID))
 		requeue = true
@@ -172,7 +173,7 @@ func handleIPAddresses(ctx context.Context, machineScope *scope.MachineScope, ip
 		// IP address not yet created.
 		err = machineScope.IPAMHelper.CreateIPAddressClaim(ctx, machineScope.ProxmoxMachine, ipClaimDef)
 		if err != nil {
-			return []ipamv1.IPAddress{}, errors.Wrapf(err, "unable to create IP address claim for machine %s", machineScope.Name())
+			return []ipamv1.IPAddress{}, fmt.Errorf("unable to create IP address claim for machine %s: %w", machineScope.Name(), err)
 		}
 
 		// send the machine to requeue so ipaddresses can be created
@@ -230,7 +231,7 @@ func handleDevices(ctx context.Context, machineScope *scope.MachineScope, addres
 
 			ipAddresses, err := handleIPAddresses(ctx, machineScope, ipClaimDef)
 			if err != nil {
-				return true, errors.Wrapf(err, "unable to handle IPAddress for device %+v, pool %s", net.Name, ipPool.Name)
+				return true, fmt.Errorf("unable to handle IPAddress for device %+v, pool %s: %w", net.Name, ipPool.Name, err)
 			}
 			// fast track ip address generation with only one requeue
 			if len(ipAddresses) == 0 {

--- a/internal/service/vmservice/vm.go
+++ b/internal/service/vmservice/vm.go
@@ -19,10 +19,12 @@ package vmservice
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -125,7 +127,7 @@ func ReconcileVM(ctx context.Context, scope *scope.MachineScope) (infrav1.Virtua
 	// unmount the cloud-init iso if it is still mounted.
 	if conditions.IsTrue(scope.Machine, clusterv1.AvailableCondition) && scope.Machine.Status.NodeRef.IsDefined() {
 		if err := unmountCloudInitISO(ctx, scope); err != nil {
-			return vm, errors.Wrapf(err, "failed to unmount cloud-init iso for vm %s", scope.Name())
+			return vm, fmt.Errorf("failed to unmount cloud-init iso for vm %s: %w", scope.Name(), err)
 		}
 	} // State Machine is finished
 	scope.Logger.V(4).Info("condition", "condition", conditions.GetReason(scope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition))
@@ -148,7 +150,7 @@ func checkCloudInitStatus(ctx context.Context, machineScope *scope.MachineScope)
 
 	if !machineScope.SkipQemuGuestCheck() {
 		if err := machineScope.InfraCluster.ProxmoxClient.QemuAgentStatus(ctx, machineScope.VirtualMachine); err != nil {
-			return true, errors.Wrap(err, "error waiting for agent")
+			return true, fmt.Errorf("error waiting for agent: %w", err)
 		}
 	}
 
@@ -206,7 +208,7 @@ func ensureVirtualMachine(ctx context.Context, machineScope *scope.MachineScope)
 		switch {
 		case errors.Is(err, ErrVMNotFound):
 			if err := updateVMLocation(ctx, machineScope); err != nil {
-				return false, errors.Wrap(err, "error trying to locate vm")
+				return false, fmt.Errorf("error trying to locate vm: %w", err)
 			}
 
 			// we always want to trigger reconciliation at this point.
@@ -354,7 +356,7 @@ func reconcileVirtualMachineConfig(ctx context.Context, machineScope *scope.Mach
 
 	task, err := machineScope.InfraCluster.ProxmoxClient.ConfigureVM(ctx, machineScope.VirtualMachine, vmOptions...)
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to configure VM %s", machineScope.Name())
+		return false, fmt.Errorf("failed to configure VM %s: %w", machineScope.Name(), err)
 	}
 
 	machineScope.ProxmoxMachine.Status.TaskRef = ptr.To(string(task.UPID))
@@ -407,7 +409,7 @@ func getClusterAPIMachineAddresses(scope *scope.MachineScope) ([]clusterv1.Machi
 	})
 	// TODO: DHCP as InternalIP
 	if index == -1 {
-		return addresses, errors.Errorf("Machine has no default IPAddresses")
+		return addresses, fmt.Errorf("Machine has no default IPAddresses")
 	}
 
 	defaultAddresses := machineAddresses[index]

--- a/internal/webhook/proxmoxcluster_webhook.go
+++ b/internal/webhook/proxmoxcluster_webhook.go
@@ -24,7 +24,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	"go4.org/netipx"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/internal/webhook/proxmoxclustertemplate_webhook.go
+++ b/internal/webhook/proxmoxclustertemplate_webhook.go
@@ -21,7 +21,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/pkg/cloudinit/errors.go
+++ b/pkg/cloudinit/errors.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package cloudinit
 
-import "github.com/pkg/errors"
+import "errors"
 
 var (
 	// ErrMissingHostname returns an error if required hostname is empty.

--- a/pkg/cloudinit/network.go
+++ b/pkg/cloudinit/network.go
@@ -18,9 +18,9 @@ package cloudinit
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/netip"
 
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 	"k8s.io/utils/ptr"
 
@@ -185,9 +185,11 @@ func (r *NetworkConfig) Render() ([]byte, error) {
 	var unused interface{}
 	err = yaml.Unmarshal(nc, &unused)
 	if err != nil {
-		return nil, errors.Wrap(err,
+		return nil, fmt.Errorf(
 			"Template produced invalid YAML. Please file a bug at: "+
-				"https://github.com/ionos-cloud/cluster-api-provider-proxmox/")
+				"https://github.com/ionos-cloud/cluster-api-provider-proxmox/: %w",
+			err,
+		)
 	}
 
 	return nc, nil

--- a/pkg/cloudinit/render.go
+++ b/pkg/cloudinit/render.go
@@ -18,10 +18,9 @@ package cloudinit
 
 import (
 	"bytes"
+	"fmt"
 	"net/netip"
 	"text/template"
-
-	"github.com/pkg/errors"
 )
 
 func is6(addr string) bool {
@@ -32,12 +31,12 @@ func render(name string, tpl string, data BaseCloudInitData) ([]byte, error) {
 	f := map[string]any{"is6": is6}
 	mt, err := template.New(name).Funcs(f).Parse(tpl)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse %s template", name)
+		return nil, fmt.Errorf("failed to parse %s template: %w", name, err)
 	}
 
 	buffer := &bytes.Buffer{}
 	if err = mt.Execute(buffer, data); err != nil {
-		return nil, errors.Wrapf(err, "failed to render %s", name)
+		return nil, fmt.Errorf("failed to render %s: %w", name, err)
 	}
 	return buffer.Bytes(), nil
 }

--- a/pkg/ignition/enrich.go
+++ b/pkg/ignition/enrich.go
@@ -24,7 +24,6 @@ import (
 
 	ignition "github.com/flatcar/ignition/config/v2_3"
 	ignitionTypes "github.com/flatcar/ignition/config/v2_3/types"
-	"github.com/pkg/errors"
 	"k8s.io/utils/ptr"
 
 	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/types"
@@ -44,7 +43,7 @@ type Enricher struct {
 func (e *Enricher) Enrich() ([]byte, string, error) {
 	ign, err := e.getEnrichConfig()
 	if err != nil {
-		return nil, "", errors.Wrap(err, "getting enrich config")
+		return nil, "", fmt.Errorf("getting enrich config: %w", err)
 	}
 
 	return buildIgnitionConfig(e.BootstrapData, ign)
@@ -98,7 +97,7 @@ func (e *Enricher) getEnrichConfig() (*ignitionTypes.Config, error) {
 	// populate networkd units
 	nets, err := RenderNetworkConfigData(e.Network)
 	if err != nil {
-		return nil, errors.Wrap(err, "rendering networkd units")
+		return nil, fmt.Errorf("rendering networkd units: %w", err)
 	}
 
 	for name, contents := range nets {
@@ -131,7 +130,7 @@ func buildIgnitionConfig(bootstrapData []byte, enrichConfig *ignitionTypes.Confi
 	// We control bootstrapData config, so treat it as strict.
 	ign, reports, err := convertToIgnition(bootstrapData, false)
 	if err != nil {
-		return nil, "", errors.Wrapf(err, "converting bootstrap-data to Ignition")
+		return nil, "", fmt.Errorf("converting bootstrap-data to Ignition: %w", err)
 	}
 
 	if enrichConfig != nil {
@@ -140,7 +139,7 @@ func buildIgnitionConfig(bootstrapData []byte, enrichConfig *ignitionTypes.Confi
 
 	userData, err := json.Marshal(&ign)
 	if err != nil {
-		return nil, "", errors.Wrapf(err, "marshaling generated Ignition config into JSON")
+		return nil, "", fmt.Errorf("marshaling generated Ignition config into JSON: %w", err)
 	}
 
 	return userData, reports, nil
@@ -149,7 +148,7 @@ func buildIgnitionConfig(bootstrapData []byte, enrichConfig *ignitionTypes.Confi
 func convertToIgnition(data []byte, strict bool) (ignitionTypes.Config, string, error) {
 	cfg, reports, err := ignition.Parse(data)
 	if err != nil {
-		return ignitionTypes.Config{}, "", errors.Wrapf(err, "parsing Ignition config")
+		return ignitionTypes.Config{}, "", fmt.Errorf("parsing Ignition config: %w", err)
 	}
 	if strict && len(reports.Entries) > 0 || reports.IsFatal() {
 		return ignitionTypes.Config{}, "", fmt.Errorf("error parsing Ignition config: %v", reports.String())

--- a/pkg/ignition/network.go
+++ b/pkg/ignition/network.go
@@ -22,8 +22,6 @@ import (
 	"net/netip"
 	"text/template"
 
-	"github.com/pkg/errors"
-
 	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/types"
 )
 
@@ -181,12 +179,12 @@ func is6(addr string) bool {
 func render(name string, tpl string, data types.NetworkConfigData) ([]byte, error) {
 	mt, err := template.New(name).Funcs(map[string]any{"is6": is6}).Parse(tpl)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse %s template", name)
+		return nil, fmt.Errorf("failed to parse %s template: %w", name, err)
 	}
 
 	buffer := &bytes.Buffer{}
 	if err = mt.Execute(buffer, data); err != nil {
-		return nil, errors.Wrapf(err, "failed to render %s", name)
+		return nil, fmt.Errorf("failed to render %s: %w", name, err)
 	}
 	return buffer.Bytes(), nil
 }

--- a/pkg/kubernetes/ipam/ipam.go
+++ b/pkg/kubernetes/ipam/ipam.go
@@ -28,7 +28,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
+	"errors"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -140,7 +141,7 @@ func (h *Helper) poolFromObjectRef(ctx context.Context, o interface{}, namespace
 
 		ret = pool
 	default:
-		return nil, errors.Errorf("unsupported pool type %s", ref.Kind)
+		return nil, fmt.Errorf("unsupported pool type %s", ref.Kind)
 	}
 
 	if err != nil {
@@ -377,7 +378,7 @@ func (h *Helper) GetIPPool(ctx context.Context, ref corev1.TypedLocalObjectRefer
 
 		ret = pool
 	default:
-		return nil, errors.Errorf("unsupported pool type %s", ref.Kind)
+		return nil, fmt.Errorf("unsupported pool type %s", ref.Kind)
 	}
 
 	if err != nil {
@@ -445,10 +446,11 @@ func (h *Helper) CreateIPAddressClaim(ctx context.Context, owner client.Object, 
 
 	poolObj, err := h.GetIPPool(ctx, ref)
 	if err != nil {
-		return errors.Wrapf(err, "unable to find %s %s for cluster %s",
+		return fmt.Errorf("unable to find %s %s for cluster %s: %w",
 			ref.Kind,
 			ref.Name,
 			owner.GetName(),
+			err,
 		)
 	}
 
@@ -604,7 +606,7 @@ func (h *Helper) GetIPAddressByPool(ctx context.Context, poolRef corev1.TypedLoc
 func gvkForObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionKind, error) {
 	gvk, err := apiutil.GVKForObject(obj, scheme)
 	if err != nil {
-		return schema.GroupVersionKind{}, errors.Wrapf(err, "unable to determine group version for %T", obj)
+		return schema.GroupVersionKind{}, fmt.Errorf("unable to determine group version for %T: %w", obj, err)
 	}
 	return gvk, err
 }

--- a/pkg/proxmox/goproxmox/api_client.go
+++ b/pkg/proxmox/goproxmox/api_client.go
@@ -25,9 +25,10 @@ import (
 	"slices"
 	"strings"
 
+	"errors"
+
 	"github.com/go-logr/logr"
 	"github.com/luthermonson/go-proxmox"
-	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	infrav1 "github.com/ionos-cloud/cluster-api-provider-proxmox/api/v1alpha2"
@@ -360,17 +361,17 @@ func (c *APIClient) UnmountCloudInitISO(ctx context.Context, vm *proxmox.Virtual
 // CloudInitStatus returns the cloud-init status of the VM.
 func (c *APIClient) CloudInitStatus(ctx context.Context, vm *proxmox.VirtualMachine) (running bool, err error) {
 	if err := c.QemuAgentStatus(ctx, vm); err != nil {
-		return false, errors.Wrap(err, "error waiting for agent")
+		return false, fmt.Errorf("error waiting for agent: %w", err)
 	}
 
 	pid, err := vm.AgentExec(ctx, []string{"cloud-init", "status"}, "")
 	if err != nil {
-		return false, errors.Wrap(err, "unable to get cloud-init status")
+		return false, fmt.Errorf("unable to get cloud-init status: %w", err)
 	}
 
 	status, err := vm.WaitForAgentExecExit(ctx, pid, 2)
 	if err != nil {
-		return false, errors.Wrap(err, "unable to wait for agent exec")
+		return false, fmt.Errorf("unable to wait for agent exec: %w", err)
 	}
 
 	if status.Exited == 1 && status.ExitCode == 0 && strings.Contains(status.OutData, "running") {
@@ -386,7 +387,7 @@ func (c *APIClient) CloudInitStatus(ctx context.Context, vm *proxmox.VirtualMach
 // QemuAgentStatus returns the qemu-agent status of the VM.
 func (c *APIClient) QemuAgentStatus(ctx context.Context, vm *proxmox.VirtualMachine) error {
 	if err := vm.WaitForAgent(ctx, 5); err != nil {
-		return errors.Wrap(err, "error waiting for agent")
+		return fmt.Errorf("error waiting for agent: %w", err)
 	}
 
 	return nil

--- a/pkg/proxmox/goproxmox/errors.go
+++ b/pkg/proxmox/goproxmox/errors.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package goproxmox
 
-import "github.com/pkg/errors"
+import "errors"
 
 var (
 	// ErrCloudInitFailed is returned when cloud-init failed execution.

--- a/pkg/scope/cluster.go
+++ b/pkg/scope/cluster.go
@@ -25,9 +25,10 @@ import (
 	"slices"
 	"strings"
 
+	"errors"
+
 	"github.com/go-logr/logr"
 	"github.com/luthermonson/go-proxmox"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -103,7 +104,7 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 
 	helper, err := patch.NewHelper(params.ProxmoxCluster, params.Client)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to init patch helper")
+		return nil, fmt.Errorf("failed to init patch helper: %w", err)
 	}
 
 	clusterScope.patchHelper = helper
@@ -126,7 +127,7 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 		// using proxmoxcluster.spec.credentialsRef
 		pmoxClient, err := clusterScope.setupProxmoxClient(context.TODO())
 		if err != nil {
-			return nil, errors.Wrap(err, "Unable to initialize ProxmoxClient")
+			return nil, fmt.Errorf("Unable to initialize ProxmoxClient: %w", err)
 		}
 		clusterScope.ProxmoxClient = pmoxClient
 	}
@@ -154,7 +155,7 @@ func (s *ClusterScope) setupProxmoxClient(ctx context.Context) (capmox.Client, e
 				Message: "credentials secret not found",
 			})
 		}
-		return nil, errors.Wrap(err, "failed to get credentials secret")
+		return nil, fmt.Errorf("failed to get credentials secret: %w", err)
 	}
 
 	token := string(secret.Data["token"])

--- a/pkg/scope/machine.go
+++ b/pkg/scope/machine.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"fmt"
 
+	"errors"
+
 	"github.com/go-logr/logr"
 	"github.com/luthermonson/go-proxmox"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -91,7 +92,7 @@ func NewMachineScope(params MachineScopeParams) (*MachineScope, error) {
 
 	helper, err := patch.NewHelper(params.ProxmoxMachine, params.Client)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to init patch helper")
+		return nil, fmt.Errorf("failed to init patch helper: %w", err)
 	}
 	return &MachineScope{
 		Logger:      params.Logger,


### PR DESCRIPTION
## Description
- replace direct `github.com/pkg/errors` imports with the standard library `errors` and `fmt`
- preserve wrapping with `%w` where callers rely on `errors.Is` or `errors.As`
- keep nil-wrap behavior in requeue paths that previously depended on `errors.Wrap(nil, ...)` returning nil
- move `github.com/pkg/errors` from direct to indirect in `go.mod`, since it is still pulled in transitively

Fixes #654

## Testing
- `go test ./internal/service/vmservice ./internal/inject ./pkg/cloudinit ./pkg/ignition ./pkg/kubernetes/ipam ./pkg/proxmox/goproxmox ./pkg/scope`
- `go test ./...` (fails locally because envtest cannot find `/usr/local/kubebuilder/bin/etcd`; non-envtest packages run and pass)
- `git diff --check`