### PR TITLE
fix: add claim-rooted IPAM resolver

### DIFF
--- a/internal/service/vmservice/helpers_test.go
+++ b/internal/service/vmservice/helpers_test.go
@@ -304,9 +304,8 @@ func createIPAddressResource(t *testing.T, c client.Client, name string, machine
 
 // createIPAddress creates an IP address resource from strings.
 // If no pool or nil pool is passed then a dummy pool is used.
-// If one objectRefs is passed then it's used as a pool (intended for most tests, typically pass 0 for offset).
-// If two objectRefs are passed then the first pool is used for the IP address name and the second for creating
-// the IP address resource (intended for createNetworkSpecForMachine, pass your poolRef index for offset).
+// If a pool is passed then it is used for creating the IP address resource.
+// IP address names are always derived from the machine, device, offset, and default suffix.
 func createIPAddress(t *testing.T, c client.Client, machineScope *scope.MachineScope, device infrav1.NetName, ip string, offset int, pool ...*corev1.TypedLocalObjectReference) {
 	ipPrefix, err := netip.ParsePrefix(ip)
 	if err != nil {

--- a/internal/service/vmservice/helpers_test.go
+++ b/internal/service/vmservice/helpers_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fields "k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ipamicv1 "sigs.k8s.io/cluster-api-ipam-provider-in-cluster/api/v1alpha2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
@@ -146,6 +147,7 @@ func setupReconcilerTest(t *testing.T) (*scope.MachineScope, *proxmoxtest.MockCl
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: metav1.NamespaceDefault,
+			UID:       k8stypes.UID("test-machine-uid"),
 			Finalizers: []string{
 				infrav1.MachineFinalizer,
 			},
@@ -260,10 +262,14 @@ func createIPAddressResource(t *testing.T, c client.Client, name string, machine
 					APIVersion: machineScope.ProxmoxMachine.APIVersion,
 					Kind:       "ProxmoxMachine",
 					Name:       machineScope.Name(),
+					UID:        machineScope.ProxmoxMachine.UID,
 				}},
 			},
 			Spec: ipamv1.IPAddressClaimSpec{
 				PoolRef: poolRef,
+			},
+			Status: ipamv1.IPAddressClaimStatus{
+				AddressRef: ipamv1.IPAddressReference{Name: name},
 			},
 		}
 		require.NoError(t, c.Create(context.Background(), ipAddrClaim))
@@ -284,6 +290,9 @@ func createIPAddressResource(t *testing.T, c client.Client, name string, machine
 			Namespace: machineScope.Namespace(),
 		},
 		Spec: ipamv1.IPAddressSpec{
+			ClaimRef: ipamv1.IPAddressClaimReference{
+				Name: name,
+			},
 			Address: ip.Addr().String(),
 			Prefix:  ptr.To(prefix),
 			Gateway: gateway,
@@ -317,8 +326,7 @@ func createIPAddress(t *testing.T, c client.Client, machineScope *scope.MachineS
 		pools[1] = pools[0]
 	}
 
-	poolName := ptr.Deref(pools[0], corev1.TypedLocalObjectReference{Name: "dummy"}).Name
-	ipName := ipam.IPAddressFormat(machineScope.Name(), device, offset, poolName)
+	ipName := ipam.IPAddressFormat(machineScope.Name(), device, offset, infrav1.DefaultSuffix)
 	createIPAddressResource(t, c, ipName, machineScope, ipPrefix, offset, pools[1])
 }
 
@@ -345,7 +353,7 @@ func createNetworkSpecForMachine(t *testing.T, c client.Client, machineScope *sc
 		}
 
 		for offset, poolRef := range ipPoolRefs {
-			createIPAddress(t, c, machineScope, infrav1.DefaultSuffix, ipPrefixes[i], offset, &corev1.TypedLocalObjectReference{Name: string(device.Name)}, &poolRef)
+			createIPAddress(t, c, machineScope, device.Name, ipPrefixes[i], offset, &poolRef)
 			i++
 		}
 	}

--- a/internal/service/vmservice/ip.go
+++ b/internal/service/vmservice/ip.go
@@ -26,11 +26,11 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	ipamv1 "sigs.k8s.io/cluster-api/api/ipam/v1beta2"
 	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/cluster-api/util/record"
 
 	infrav1 "github.com/ionos-cloud/cluster-api-provider-proxmox/api/v1alpha2"
 	ipam "github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/kubernetes/ipam"
@@ -120,11 +120,6 @@ func setVMIPAddressTag(ctx context.Context, machineScope *scope.MachineScope, ip
 	return requeue, nil
 }
 
-// findIPAddress returns all IPAddresses owned by a pool and a machine.
-func findIPAddress(ctx context.Context, poolRef corev1.TypedLocalObjectReference, machineScope *scope.MachineScope) ([]ipamv1.IPAddress, error) {
-	return machineScope.IPAMHelper.GetIPAddressV2(ctx, poolRef, machineScope.ProxmoxMachine)
-}
-
 func findIPAddressGatewayMetric(ctx context.Context, machineScope *scope.MachineScope, ipAddress *ipamv1.IPAddress) (*int32, error) {
 	annotations, err := machineScope.IPAMHelper.GetIPPoolAnnotations(ctx, ipAddress)
 	if err != nil {
@@ -155,19 +150,24 @@ func findIPAddressGatewayMetric(ctx context.Context, machineScope *scope.Machine
 func handleIPAddresses(ctx context.Context, machineScope *scope.MachineScope, ipClaimDef ipam.IPClaimDef) ([]ipamv1.IPAddress, error) {
 	device := ipClaimDef.Device
 
-	ipAddresses, err := findIPAddress(ctx, ipClaimDef.PoolRef, machineScope)
+	resolution, err := machineScope.IPAMHelper.ResolveIPAddressClaim(ctx, machineScope.ProxmoxMachine, ipClaimDef)
 	if err != nil {
-		// Technically this error cannot occur as fieldselectors just return empty lists
-		if !apierrors.IsNotFound(err) {
-			return []ipamv1.IPAddress{}, err
-		}
+		return []ipamv1.IPAddress{}, err
 	}
 
-	index := slices.IndexFunc(ipAddresses, func(ip ipamv1.IPAddress) bool {
-		return ip.GetAnnotations()[infrav1.ProxmoxPoolOffsetAnnotation] == ipClaimDef.Annotations[infrav1.ProxmoxPoolOffsetAnnotation]
-	})
-
-	if index < 0 {
+	switch resolution.Status {
+	case ipam.ClaimMissing:
+		if resolution.OrphanedAddressName != "" {
+			record.Warnf(machineScope.ProxmoxMachine, "OrphanedIPAddress",
+				"Found deterministic IPAddress %q without expected IPAddressClaim %q; ignoring orphaned address until claim exists",
+				resolution.OrphanedAddressName, resolution.ClaimName,
+			)
+			machineScope.Logger.Info("found deterministic IPAddress without expected IPAddressClaim; ignoring orphaned address until claim exists",
+				"claim", resolution.ClaimName,
+				"address", resolution.OrphanedAddressName,
+				"device", device,
+			)
+		}
 		machineScope.Logger.V(4).Info("IPAddress not found, creating it.", "device", device)
 		// IP address not yet created.
 		err = machineScope.IPAMHelper.CreateIPAddressClaim(ctx, machineScope.ProxmoxMachine, ipClaimDef)
@@ -177,10 +177,25 @@ func handleIPAddresses(ctx context.Context, machineScope *scope.MachineScope, ip
 
 		// send the machine to requeue so ipaddresses can be created
 		return []ipamv1.IPAddress{}, nil
+	case ipam.ClaimPending:
+		machineScope.Logger.V(4).Info("IPAddressClaim has no AddressRef yet.", "claim", resolution.ClaimName, "device", device)
+		return []ipamv1.IPAddress{}, nil
+	case ipam.ClaimResolved:
+		machineScope.Logger.V(4).Info("IPAddresses found.", "ip", resolution.Address, "device", device)
+		return []ipamv1.IPAddress{*resolution.Address}, nil
+	case ipam.ClaimConflict:
+		message := fmt.Sprintf("Static IP claim %q is conflicting (%s); inspect the IPAddressClaim ownership, poolRef, and referenced IPAddress before provisioning can continue.", resolution.ClaimName, resolution.ConflictReason)
+		conditions.Set(machineScope.ProxmoxMachine, metav1.Condition{
+			Type:    infrav1.ProxmoxMachineVirtualMachineProvisionedCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForStaticIPAllocationReason,
+			Message: message,
+		})
+		machineScope.Logger.Info("IPAddressClaim conflict blocks static IP allocation", "claim", resolution.ClaimName, "reason", resolution.ConflictReason, "device", device)
+		return []ipamv1.IPAddress{}, nil
+	default:
+		return []ipamv1.IPAddress{}, errors.Errorf("unknown IPAddressClaim resolution status %q", resolution.Status)
 	}
-
-	machineScope.Logger.V(4).Info("IPAddresses found, ", "ip", ipAddresses, "device", device)
-	return ipAddresses, nil
 }
 
 func handleDevices(ctx context.Context, machineScope *scope.MachineScope, addresses map[infrav1.NetName]map[corev1.TypedLocalObjectReference][]ipamv1.IPAddress) (bool, error) {
@@ -243,12 +258,12 @@ func handleDevices(ctx context.Context, machineScope *scope.MachineScope, addres
 				poolMap = make(map[corev1.TypedLocalObjectReference][]ipamv1.IPAddress)
 			}
 
-			poolMap[ipPool] = ipAddresses
+			poolMap[ipPool] = append(poolMap[ipPool], ipAddresses...)
 			addresses[net.Name] = poolMap
 
 			// append default pool addresses to map
 			if _, exists := defaultPoolMap[ipPool]; exists && ptr.Deref(net.DefaultIPv4, false) || ptr.Deref(net.DefaultIPv6, false) {
-				defaultPoolMap[ipPool] = ipAddresses
+				defaultPoolMap[ipPool] = append(defaultPoolMap[ipPool], ipAddresses...)
 			}
 		}
 		addresses["default"] = defaultPoolMap

--- a/internal/service/vmservice/ip.go
+++ b/internal/service/vmservice/ip.go
@@ -262,7 +262,7 @@ func handleDevices(ctx context.Context, machineScope *scope.MachineScope, addres
 			addresses[net.Name] = poolMap
 
 			// append default pool addresses to map
-			if _, exists := defaultPoolMap[ipPool]; exists && ptr.Deref(net.DefaultIPv4, false) || ptr.Deref(net.DefaultIPv6, false) {
+			if _, exists := defaultPoolMap[ipPool]; exists && (ptr.Deref(net.DefaultIPv4, false) || ptr.Deref(net.DefaultIPv6, false)) {
 				defaultPoolMap[ipPool] = append(defaultPoolMap[ipPool], ipAddresses...)
 			}
 		}

--- a/internal/service/vmservice/ip_test.go
+++ b/internal/service/vmservice/ip_test.go
@@ -509,6 +509,90 @@ func TestReconcileIPAddresses_IPv6(t *testing.T) {
 	requireConditionIsFalse(t, machineScope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition)
 }
 
+func TestReconcileIPAddresses_DefaultMapIgnoresNonDefaultPoolWhenIPv6Default(t *testing.T) {
+	machineScope, _, kubeClient := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForStaticIPAllocationReason)
+
+	proxmoxCluster := machineScope.InfraCluster.ProxmoxCluster
+	proxmoxCluster.Spec.IPv6Config = &infrav1.IPConfigSpec{
+		Addresses: []string{"fe80::"},
+		Prefix:    64,
+		Gateway:   "fe80::",
+		Metric:    nil,
+	}
+	require.NoError(t, kubeClient.Update(context.Background(), proxmoxCluster))
+
+	patch := client.MergeFrom(proxmoxCluster.DeepCopy())
+	proxmoxCluster.Status.InClusterIPPoolRef = []corev1.LocalObjectReference{
+		{Name: "test-v4-icip"},
+		{Name: "test-v6-icip"},
+	}
+	proxmoxCluster.Status.InClusterZoneRef = []infrav1.InClusterZoneRef{{
+		Zone:                 ptr.To("default"),
+		InClusterIPPoolRefV4: ptr.To(corev1.LocalObjectReference{Name: "test-v4-icip"}),
+		InClusterIPPoolRefV6: ptr.To(corev1.LocalObjectReference{Name: "test-v6-icip"}),
+	}}
+	require.NoError(t, kubeClient.Status().Patch(context.Background(), proxmoxCluster, patch))
+
+	require.NoError(t, machineScope.IPAMHelper.CreateOrUpdateInClusterIPPool(context.Background()))
+
+	defaultPool := corev1.TypedLocalObjectReference{
+		APIGroup: ptr.To(ipamicv1.GroupVersion.String()),
+		Kind:     reflect.ValueOf(ipamicv1.InClusterIPPool{}).Type().Name(),
+		Name:     getDefaultPoolRefs(machineScope).InClusterIPPoolRefV4.Name,
+	}
+	defaultPoolV6 := corev1.TypedLocalObjectReference{
+		APIGroup: ptr.To("ipam.cluster.x-k8s.io"),
+		Kind:     InClusterIPPool,
+		Name:     getDefaultPoolRefs(machineScope).InClusterIPPoolRefV6.Name,
+	}
+	extraPool := corev1.TypedLocalObjectReference{
+		APIGroup: ptr.To("ipam.cluster.x-k8s.io"),
+		Kind:     GlobalInClusterIPPool,
+		Name:     "extra-ipv6-pool",
+	}
+
+	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
+		NetworkDevices: []infrav1.NetworkDevice{{
+			Name:        infrav1.DefaultNetworkDevice,
+			DefaultIPv4: ptr.To(true),
+			DefaultIPv6: ptr.To(true),
+			InterfaceConfig: infrav1.InterfaceConfig{
+				IPPoolRef: []corev1.TypedLocalObjectReference{extraPool},
+			},
+		}},
+	}
+
+	vm := newStoppedVM()
+	vm.VirtualMachineConfig.Tags = ipTag
+	machineScope.SetVirtualMachine(vm)
+
+	createIPPools(t, kubeClient, machineScope)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "10.10.10.10", 0, &defaultPool)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "fe80::1", 1, &defaultPoolV6)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "2001:db8::10", 2, &extraPool)
+
+	requeue, err := reconcileIPAddresses(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.True(t, requeue)
+
+	require.Equal(t,
+		infrav1.IPAddressesSpec{
+			NetName: string(infrav1.DefaultNetworkDevice),
+			IPv4:    []string{"10.10.10.10"},
+			IPv6:    []string{"fe80::1", "2001:db8::10"},
+		},
+		*machineScope.ProxmoxMachine.GetIPAddressesNet(infrav1.DefaultNetworkDevice),
+	)
+	require.Equal(t,
+		infrav1.IPAddressesSpec{
+			NetName: "default",
+			IPv4:    []string{"10.10.10.10"},
+			IPv6:    []string{"fe80::1"},
+		},
+		*machineScope.ProxmoxMachine.GetIPAddressesNet("default"),
+	)
+}
+
 // TestReconcileIPAddresses_MachineIPPoolRef tests.
 func TestReconcileIPAddresses_MachineIPPoolRef(t *testing.T) {
 	machineScope, _, kubeClient := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForStaticIPAllocationReason)

--- a/internal/service/vmservice/ip_test.go
+++ b/internal/service/vmservice/ip_test.go
@@ -23,12 +23,17 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ipamicv1 "sigs.k8s.io/cluster-api-ipam-provider-in-cluster/api/v1alpha2"
+	ipamv1 "sigs.k8s.io/cluster-api/api/ipam/v1beta2"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "github.com/ionos-cloud/cluster-api-provider-proxmox/api/v1alpha2"
 	. "github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/consts"
+	ipam "github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/kubernetes/ipam"
 )
 
 const ipTag = "ip_net0_10.10.10.10"
@@ -57,6 +62,40 @@ func TestReconcileIPAddresses_CreateDefaultClaim(t *testing.T) {
 	require.Equal(t, 1, len(*claimsDefaultPool))
 
 	requireConditionIsFalse(t, machineScope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition)
+}
+
+func TestReconcileIPAddresses_PendingClaimDoesNotCreateDuplicateClaim(t *testing.T) {
+	machineScope, _, kubeClient := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForStaticIPAllocationReason)
+
+	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
+		NetworkDevices: []infrav1.NetworkDevice{{
+			Name:        infrav1.DefaultNetworkDevice,
+			DefaultIPv4: ptr.To(true),
+		}},
+	}
+	defaultPoolRef := corev1.TypedLocalObjectReference{
+		APIGroup: ptr.To(ipamicv1.GroupVersion.String()),
+		Kind:     reflect.ValueOf(ipamicv1.InClusterIPPool{}).Type().Name(),
+		Name:     getDefaultPoolRefs(machineScope).InClusterIPPoolRefV4.Name,
+	}
+	ipClaimDef := ipam.IPClaimDef{
+		PoolRef: defaultPoolRef,
+		Device:  infrav1.DefaultNetworkDevice,
+		Annotations: map[string]string{
+			infrav1.ProxmoxPoolOffsetAnnotation:     "0",
+			infrav1.ProxmoxDefaultGatewayAnnotation: "true",
+		},
+	}
+	require.NoError(t, machineScope.IPAMHelper.CreateIPAddressClaim(context.Background(), machineScope.ProxmoxMachine, ipClaimDef))
+
+	requeue, err := reconcileIPAddresses(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.True(t, requeue)
+
+	claimsDefaultPool := getIPAddressClaimsPerPool(t, kubeClient, machineScope, defaultPoolRef.Name)
+	require.NotNil(t, claimsDefaultPool)
+	require.Len(t, *claimsDefaultPool, 1)
+	require.Empty(t, machineScope.ProxmoxMachine.GetIPAddresses())
 }
 
 // TestReconcileIPAddresses_CreateAdditionalClaim tests if an IPAddressClaim is created for the missing IPAddress on net1.
@@ -108,6 +147,65 @@ func TestReconcileIPAddresses_CreateAdditionalClaim(t *testing.T) {
 	require.Equal(t, 1, len(*claimsExtraPool0))
 
 	requireConditionIsFalse(t, machineScope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition)
+}
+
+func TestReconcileIPAddresses_ClaimConflictSetsWaitingConditionAndDoesNotCreateClaim(t *testing.T) {
+	machineScope, _, kubeClient := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForStaticIPAllocationReason)
+
+	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
+		NetworkDevices: []infrav1.NetworkDevice{{
+			Name:        infrav1.DefaultNetworkDevice,
+			DefaultIPv4: ptr.To(true),
+		}},
+	}
+	defaultPoolRef := corev1.TypedLocalObjectReference{
+		APIGroup: ptr.To(ipamicv1.GroupVersion.String()),
+		Kind:     reflect.ValueOf(ipamicv1.InClusterIPPool{}).Type().Name(),
+		Name:     getDefaultPoolRefs(machineScope).InClusterIPPoolRefV4.Name,
+	}
+	claimName := ipam.IPAddressFormat(machineScope.Name(), infrav1.DefaultNetworkDevice, 0, infrav1.DefaultSuffix)
+	claim := &ipamv1.IPAddressClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      claimName,
+			Namespace: machineScope.Namespace(),
+			Annotations: map[string]string{
+				infrav1.ProxmoxPoolOffsetAnnotation: "0",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: infrav1.GroupVersion.String(),
+				Kind:       infrav1.ProxmoxMachineKind,
+				Name:       "other-machine",
+				UID:        k8stypes.UID("other-machine-uid"),
+			}},
+		},
+		Spec: ipamv1.IPAddressClaimSpec{
+			PoolRef: ipamv1.IPPoolReference{
+				APIGroup: ipamicv1.GroupVersion.Group,
+				Kind:     defaultPoolRef.Kind,
+				Name:     defaultPoolRef.Name,
+			},
+		},
+	}
+	require.NoError(t, kubeClient.Create(context.Background(), claim))
+
+	requeue, err := reconcileIPAddresses(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.True(t, requeue)
+
+	var existingClaim ipamv1.IPAddressClaim
+	require.NoError(t, kubeClient.Get(context.Background(), client.ObjectKey{Name: claimName, Namespace: machineScope.Namespace()}, &existingClaim))
+	require.Equal(t, "other-machine", existingClaim.OwnerReferences[0].Name)
+
+	claims := &ipamv1.IPAddressClaimList{}
+	require.NoError(t, kubeClient.List(context.Background(), claims))
+	require.Len(t, claims.Items, 1)
+	require.Equal(t,
+		infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForStaticIPAllocationReason,
+		conditions.GetReason(machineScope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition),
+	)
+	message := conditions.GetMessage(machineScope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition)
+	require.Contains(t, message, claimName)
+	require.Contains(t, message, string(ipam.ConflictOwnerMismatch))
 }
 
 // TestReconcileIPAddresses_AddIPTag tests if a machine with all resources created will add a task to add tags to proxmox VMs.
@@ -205,6 +303,43 @@ func TestReconcileIPAddresses_SetIPAddresses(t *testing.T) {
 	)
 
 	requireConditionIsFalse(t, machineScope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition)
+}
+
+func TestReconcileIPAddresses_DuplicatePoolRefOffsetsAppendAddresses(t *testing.T) {
+	machineScope, _, kubeClient := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForStaticIPAllocationReason)
+
+	duplicatePool := corev1.TypedLocalObjectReference{
+		APIGroup: ptr.To("ipam.cluster.x-k8s.io"),
+		Kind:     GlobalInClusterIPPool,
+		Name:     "duplicate-pool",
+	}
+
+	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
+		NetworkDevices: []infrav1.NetworkDevice{{
+			Name: infrav1.DefaultNetworkDevice,
+			InterfaceConfig: infrav1.InterfaceConfig{
+				IPPoolRef: []corev1.TypedLocalObjectReference{duplicatePool, duplicatePool},
+			},
+		}},
+	}
+
+	vm := newStoppedVM()
+	vm.VirtualMachineConfig.Tags = ipTag
+	machineScope.SetVirtualMachine(vm)
+
+	createIPPools(t, kubeClient, machineScope)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "10.50.10.10", 0, &duplicatePool)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "10.50.10.11", 1, &duplicatePool)
+
+	requeue, err := reconcileIPAddresses(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.True(t, requeue)
+
+	require.NotNil(t, machineScope.ProxmoxMachine.GetIPAddressesNet(infrav1.DefaultNetworkDevice))
+	require.Equal(t,
+		[]string{"10.50.10.10", "10.50.10.11"},
+		machineScope.ProxmoxMachine.GetIPAddressesNet(infrav1.DefaultNetworkDevice).IPv4,
+	)
 }
 
 // TestReconcileIPAddresses_MultipleDevices tests if proxmoxMachine.Status.IPAddresses gets reconciled with IPv4 and IPv6 on multiple devices.

--- a/pkg/kubernetes/ipam/ipam.go
+++ b/pkg/kubernetes/ipam/ipam.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -428,16 +429,141 @@ type IPClaimDef struct {
 	Annotations map[string]string
 }
 
+// IPAddressClaimResolutionStatus describes the state of the deterministic
+// IPAddressClaim expected for an IPClaimDef.
+type IPAddressClaimResolutionStatus string
+
+const (
+	ClaimMissing  IPAddressClaimResolutionStatus = "ClaimMissing"
+	ClaimPending  IPAddressClaimResolutionStatus = "ClaimPending"
+	ClaimResolved IPAddressClaimResolutionStatus = "ClaimResolved"
+	ClaimConflict IPAddressClaimResolutionStatus = "ClaimConflict"
+)
+
+// IPAddressClaimConflictReason describes why an existing IPAddressClaim cannot
+// be safely consumed for the requested IPClaimDef.
+type IPAddressClaimConflictReason string
+
+const (
+	ConflictOwnerMismatch  IPAddressClaimConflictReason = "OwnerMismatch"
+	ConflictPoolMismatch   IPAddressClaimConflictReason = "PoolMismatch"
+	ConflictAddressMissing IPAddressClaimConflictReason = "AddressMissing"
+	ConflictAddressPoolRef IPAddressClaimConflictReason = "AddressPoolRef"
+)
+
+// IPAddressClaimResolution is the result of resolving the deterministic
+// IPAddressClaim for an IPClaimDef.
+type IPAddressClaimResolution struct {
+	Status              IPAddressClaimResolutionStatus
+	ConflictReason      IPAddressClaimConflictReason
+	ClaimName           string
+	Claim               *ipamv1.IPAddressClaim
+	Address             *ipamv1.IPAddress
+	OrphanedAddressName string
+}
+
+func ipClaimName(owner client.Object, ipClaimRef IPClaimDef) (string, error) {
+	offset, exists := ipClaimRef.Annotations[infrav1.ProxmoxPoolOffsetAnnotation]
+	if !exists {
+		offset = "0"
+	}
+
+	offsetNum, err := strconv.Atoi(offset)
+	if err != nil {
+		return "", err
+	}
+
+	return IPAddressFormat(owner.GetName(), ipClaimRef.Device, offsetNum, infrav1.DefaultSuffix), nil
+}
+
+// ResolveIPAddressClaim resolves the deterministic IPAddressClaim for a
+// ProxmoxMachine and only returns an allocated IPAddress when claim ownership
+// and pool references are valid.
+func (h *Helper) ResolveIPAddressClaim(ctx context.Context, moxm *infrav1.ProxmoxMachine, ipClaimRef IPClaimDef) (IPAddressClaimResolution, error) {
+	claimName, err := ipClaimName(moxm, ipClaimRef)
+	if err != nil {
+		return IPAddressClaimResolution{}, err
+	}
+
+	result := IPAddressClaimResolution{
+		Status:    ClaimMissing,
+		ClaimName: claimName,
+	}
+
+	claim := &ipamv1.IPAddressClaim{}
+	if err := h.ctrlClient.Get(ctx, client.ObjectKey{Name: claimName, Namespace: moxm.Namespace}, claim); err != nil {
+		if apierrors.IsNotFound(err) {
+			orphanedAddress := &ipamv1.IPAddress{}
+			if orphanErr := h.ctrlClient.Get(ctx, client.ObjectKey{Name: claimName, Namespace: moxm.Namespace}, orphanedAddress); orphanErr == nil {
+				result.OrphanedAddressName = orphanedAddress.Name
+			} else if !apierrors.IsNotFound(orphanErr) {
+				return result, orphanErr
+			}
+			return result, nil
+		}
+		return result, err
+	}
+	result.Claim = claim
+
+	isOwner, err := controllerutil.HasOwnerReference(claim.OwnerReferences, moxm, h.ctrlClient.Scheme())
+	if err != nil {
+		return result, err
+	}
+	if !isOwner && !hasDirectOwnerReference(claim.OwnerReferences, moxm) {
+		result.Status = ClaimConflict
+		result.ConflictReason = ConflictOwnerMismatch
+		return result, nil
+	}
+
+	if !matchesClaimPoolRef(*claim, ipClaimRef.PoolRef) {
+		result.Status = ClaimConflict
+		result.ConflictReason = ConflictPoolMismatch
+		return result, nil
+	}
+
+	if claim.Status.AddressRef.Name == "" {
+		result.Status = ClaimPending
+		return result, nil
+	}
+
+	addr := &ipamv1.IPAddress{}
+	if err := h.ctrlClient.Get(ctx, client.ObjectKey{Name: claim.Status.AddressRef.Name, Namespace: claim.Namespace}, addr); err != nil {
+		if apierrors.IsNotFound(err) {
+			result.Status = ClaimConflict
+			result.ConflictReason = ConflictAddressMissing
+			return result, nil
+		}
+		return result, err
+	}
+
+	if !matchesPoolRef(*addr, ipClaimRef.PoolRef) {
+		result.Status = ClaimConflict
+		result.ConflictReason = ConflictAddressPoolRef
+		return result, nil
+	}
+
+	annotations := addr.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	// Claim annotations are the capmox source of truth for provisioning metadata
+	// such as offset/default-gateway, so they intentionally override address
+	// annotations in the in-memory result returned to callers.
+	maps.Insert(annotations, maps.All(claim.GetAnnotations()))
+	addr.SetAnnotations(annotations)
+
+	result.Status = ClaimResolved
+	result.Address = addr
+	return result, nil
+}
+
 // CreateIPAddressClaim creates an IPAddressClaim for a given object.
 func (h *Helper) CreateIPAddressClaim(ctx context.Context, owner client.Object, ipClaimRef IPClaimDef) error {
 	key := client.ObjectKey{
 		Namespace: owner.GetNamespace(),
 		Name:      owner.GetName(),
 	}
-	suffix := infrav1.DefaultSuffix
-
 	ref := ipClaimRef.PoolRef
-	device := ipClaimRef.Device
 	annotations := ipClaimRef.Annotations
 	if annotations == nil {
 		annotations = make(map[string]string)
@@ -477,13 +603,7 @@ func (h *Helper) CreateIPAddressClaim(ctx context.Context, owner client.Object, 
 		labels[infrav1.ProxmoxZoneLabel] = key
 	}
 
-	// Add a fallback for this ipAddress's offset.
-	offset, exists := annotations[infrav1.ProxmoxPoolOffsetAnnotation]
-	if !exists {
-		offset = "0"
-	}
-
-	offsetNum, err := strconv.Atoi(offset)
+	claimName, err := ipClaimName(owner, ipClaimRef)
 	if err != nil {
 		return err
 	}
@@ -491,7 +611,7 @@ func (h *Helper) CreateIPAddressClaim(ctx context.Context, owner client.Object, 
 	// TODO: suffix makes no sense, fmt.Sprintf() needs to be shared with testing
 	desired := &ipamv1.IPAddressClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        IPAddressFormat(owner.GetName(), device, offsetNum, suffix),
+			Name:        claimName,
 			Namespace:   owner.GetNamespace(),
 			Labels:      labels,
 			Annotations: annotations,
@@ -549,11 +669,15 @@ func (h *Helper) GetIPAddressV2(ctx context.Context, poolRef corev1.TypedLocalOb
 			return nil, err
 		}
 
-		// check if current moxm is in the owner reference
+		// Check if current moxm is in the owner reference. Some restored or
+		// converted objects can make controllerutil's scheme-based comparison too
+		// strict, so also accept the direct uid/name/kind/apiVersion match from the
+		// stored OwnerReference.
 		isOwner, err := controllerutil.HasOwnerReference(ipAddressClaim.OwnerReferences, moxm, h.ctrlClient.Scheme())
 		if err != nil {
 			return nil, err
 		}
+		isOwner = isOwner || hasDirectOwnerReference(ipAddressClaim.OwnerReferences, moxm)
 
 		// Forward the offset counter and default gateway from the ippool Reference
 		annotations := addr.GetAnnotations()
@@ -588,9 +712,7 @@ func (h *Helper) GetIPAddressByPool(ctx context.Context, poolRef corev1.TypedLoc
 	}
 
 	addresses.Items = slices.DeleteFunc(addresses.Items, func(n ipamv1.IPAddress) bool {
-		// Check if we are actually dealing with the right resource kind.
-		groupVersion, _ := schema.ParseGroupVersion(n.APIVersion)
-		return groupVersion.Group != GetIPAMInClusterAPIVersion()
+		return !matchesPoolRef(n, poolRef)
 	})
 
 	// Sort result by IPAddress.Name to provide stability to testing.
@@ -599,6 +721,56 @@ func (h *Helper) GetIPAddressByPool(ctx context.Context, poolRef corev1.TypedLoc
 	})
 
 	return addresses.Items, nil
+}
+
+func matchesPoolRef(address ipamv1.IPAddress, poolRef corev1.TypedLocalObjectReference) bool {
+	// Check if we are actually dealing with the requested pool. Do not use
+	// IPAddress TypeMeta/APIVersion here: typed client/cache list results may not
+	// carry TypeMeta on individual items, while the canonical pool identity is in
+	// spec.poolRef.
+	if address.Spec.PoolRef.Name != poolRef.Name {
+		return false
+	}
+	if expectedGroup := normalizedAPIGroup(ptr.Deref(poolRef.APIGroup, "")); expectedGroup != "" && normalizedAPIGroup(address.Spec.PoolRef.APIGroup) != expectedGroup {
+		return false
+	}
+	if poolRef.Kind != "" && address.Spec.PoolRef.Kind != poolRef.Kind {
+		return false
+	}
+	return true
+}
+
+func matchesClaimPoolRef(claim ipamv1.IPAddressClaim, poolRef corev1.TypedLocalObjectReference) bool {
+	if claim.Spec.PoolRef.Name != poolRef.Name {
+		return false
+	}
+	if expectedGroup := normalizedAPIGroup(ptr.Deref(poolRef.APIGroup, "")); expectedGroup != "" && normalizedAPIGroup(claim.Spec.PoolRef.APIGroup) != expectedGroup {
+		return false
+	}
+	if poolRef.Kind != "" && claim.Spec.PoolRef.Kind != poolRef.Kind {
+		return false
+	}
+	return true
+}
+
+func normalizedAPIGroup(apiGroupOrVersion string) string {
+	groupVersion, err := schema.ParseGroupVersion(apiGroupOrVersion)
+	if err == nil && groupVersion.Group != "" {
+		return groupVersion.Group
+	}
+	return apiGroupOrVersion
+}
+
+func hasDirectOwnerReference(ownerReferences []metav1.OwnerReference, moxm *infrav1.ProxmoxMachine) bool {
+	for _, ownerReference := range ownerReferences {
+		if ownerReference.UID == moxm.UID &&
+			ownerReference.Name == moxm.Name &&
+			ownerReference.Kind == infrav1.ProxmoxMachineKind &&
+			normalizedAPIGroup(ownerReference.APIVersion) == infrav1.GroupVersion.Group {
+			return true
+		}
+	}
+	return false
 }
 
 func gvkForObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionKind, error) {

--- a/pkg/kubernetes/ipam/ipam.go
+++ b/pkg/kubernetes/ipam/ipam.go
@@ -434,9 +434,13 @@ type IPClaimDef struct {
 type IPAddressClaimResolutionStatus string
 
 const (
-	ClaimMissing  IPAddressClaimResolutionStatus = "ClaimMissing"
-	ClaimPending  IPAddressClaimResolutionStatus = "ClaimPending"
+	// ClaimMissing means the expected deterministic IPAddressClaim does not exist.
+	ClaimMissing IPAddressClaimResolutionStatus = "ClaimMissing"
+	// ClaimPending means the expected IPAddressClaim exists but has no AddressRef yet.
+	ClaimPending IPAddressClaimResolutionStatus = "ClaimPending"
+	// ClaimResolved means the expected IPAddressClaim and referenced IPAddress are valid.
 	ClaimResolved IPAddressClaimResolutionStatus = "ClaimResolved"
+	// ClaimConflict means the expected IPAddressClaim exists but cannot be safely consumed.
 	ClaimConflict IPAddressClaimResolutionStatus = "ClaimConflict"
 )
 
@@ -445,9 +449,13 @@ const (
 type IPAddressClaimConflictReason string
 
 const (
-	ConflictOwnerMismatch  IPAddressClaimConflictReason = "OwnerMismatch"
-	ConflictPoolMismatch   IPAddressClaimConflictReason = "PoolMismatch"
+	// ConflictOwnerMismatch means the expected IPAddressClaim is not owned by the ProxmoxMachine.
+	ConflictOwnerMismatch IPAddressClaimConflictReason = "OwnerMismatch"
+	// ConflictPoolMismatch means the expected IPAddressClaim references a different pool.
+	ConflictPoolMismatch IPAddressClaimConflictReason = "PoolMismatch"
+	// ConflictAddressMissing means the IPAddressClaim AddressRef points at a missing IPAddress.
 	ConflictAddressMissing IPAddressClaimConflictReason = "AddressMissing"
+	// ConflictAddressPoolRef means the referenced IPAddress belongs to a different pool.
 	ConflictAddressPoolRef IPAddressClaimConflictReason = "AddressPoolRef"
 )
 

--- a/pkg/kubernetes/ipam/ipam_test.go
+++ b/pkg/kubernetes/ipam/ipam_test.go
@@ -542,6 +542,27 @@ func (s *IPAMTestSuite) Test_ResolveIPAddressClaimMissing() {
 	s.Nil(result.Address)
 }
 
+func (s *IPAMTestSuite) Test_ResolveIPAddressClaimInvalidOffset() {
+	machine := s.testMachine()
+	ipClaimDef := s.testIPClaimDef(infrav1.DefaultNetworkDevice, "not-an-int", "test-cluster-v4-icip")
+
+	result, err := s.helper.ResolveIPAddressClaim(s.ctx, machine, ipClaimDef)
+
+	s.Error(err)
+	s.Empty(result)
+}
+
+func (s *IPAMTestSuite) Test_IPClaimNameDefaultsMissingOffset() {
+	machine := s.testMachine()
+	ipClaimDef := s.testIPClaimDef("net1", "2", "test-cluster-v4-icip")
+	delete(ipClaimDef.Annotations, infrav1.ProxmoxPoolOffsetAnnotation)
+
+	name, err := ipClaimName(machine, ipClaimDef)
+
+	s.NoError(err)
+	s.Equal(IPAddressFormat(machine.Name, "net1", 0, infrav1.DefaultSuffix), name)
+}
+
 func (s *IPAMTestSuite) Test_ResolveIPAddressClaimPending() {
 	machine := s.testMachine()
 	ipClaimDef := s.testIPClaimDef(infrav1.DefaultNetworkDevice, "0", "test-cluster-v4-icip")
@@ -687,6 +708,65 @@ func (s *IPAMTestSuite) Test_ResolveIPAddressClaimMissingWithOrphanedDeterminist
 	s.Nil(result.Address)
 }
 
+func (s *IPAMTestSuite) Test_GetIPAddressByPoolFiltersByPoolRefAndSorts() {
+	poolRef := corev1.TypedLocalObjectReference{
+		Name:     "test-cluster-v4-icip",
+		APIGroup: ptr.To(ipamicv1.GroupVersion.String()),
+		Kind:     GetInClusterIPPoolKind(),
+	}
+
+	matchingB := s.testIPAddress("test", "matching-b", poolRef.Name)
+	matchingA := s.testIPAddress("test", "matching-a", poolRef.Name)
+	wrongKind := s.testIPAddress("test", "wrong-kind", poolRef.Name)
+	wrongKind.Spec.PoolRef.Kind = GetGlobalInClusterIPPoolKind()
+	wrongGroup := s.testIPAddress("test", "wrong-group", poolRef.Name)
+	wrongGroup.Spec.PoolRef.APIGroup = "other.ipam.example.com"
+	otherPool := s.testIPAddress("test", "other-pool", "other-pool")
+	s.NoError(s.cl.Create(s.ctx, matchingB))
+	s.NoError(s.cl.Create(s.ctx, matchingA))
+	s.NoError(s.cl.Create(s.ctx, wrongKind))
+	s.NoError(s.cl.Create(s.ctx, wrongGroup))
+	s.NoError(s.cl.Create(s.ctx, otherPool))
+
+	addresses, err := s.helper.GetIPAddressByPool(s.ctx, poolRef)
+
+	s.NoError(err)
+	s.Len(addresses, 2)
+	s.Equal("matching-a", addresses[0].Name)
+	s.Equal("matching-b", addresses[1].Name)
+}
+
+func (s *IPAMTestSuite) Test_GetIPAddressV2ReturnsOwnedAddressesAndMergesClaimAnnotations() {
+	machine := s.testMachine()
+	poolRef := corev1.TypedLocalObjectReference{
+		Name:     "test-cluster-v4-icip",
+		APIGroup: ptr.To(ipamicv1.GroupVersion.String()),
+		Kind:     GetInClusterIPPoolKind(),
+	}
+
+	ownedClaimDef := s.testIPClaimDef(infrav1.DefaultNetworkDevice, "0", poolRef.Name)
+	ownedClaim := s.testIPAddressClaim(machine, ownedClaimDef, "")
+	ownedAddress := s.testIPAddress(machine.Namespace, ownedClaim.Name, poolRef.Name)
+	ownedAddress.Annotations = nil
+	s.NoError(s.cl.Create(s.ctx, ownedClaim))
+	s.NoError(s.cl.Create(s.ctx, ownedAddress))
+
+	otherClaimDef := s.testIPClaimDef(infrav1.DefaultNetworkDevice, "1", poolRef.Name)
+	otherClaim := s.testIPAddressClaim(machine, otherClaimDef, "")
+	otherClaim.OwnerReferences[0].UID = types.UID("other-uid")
+	otherClaim.OwnerReferences[0].Name = "other-machine"
+	otherAddress := s.testIPAddress(machine.Namespace, otherClaim.Name, poolRef.Name)
+	s.NoError(s.cl.Create(s.ctx, otherClaim))
+	s.NoError(s.cl.Create(s.ctx, otherAddress))
+
+	addresses, err := s.helper.GetIPAddressV2(s.ctx, poolRef, machine)
+
+	s.NoError(err)
+	s.Len(addresses, 1)
+	s.Equal(ownedAddress.Name, addresses[0].Name)
+	s.Equal("0", addresses[0].Annotations[infrav1.ProxmoxPoolOffsetAnnotation])
+}
+
 func (s *IPAMTestSuite) Test_HasDirectOwnerReferenceRequiresExactMachineIdentity() {
 	machine := s.testMachine()
 	ownerRef := metav1.OwnerReference{
@@ -740,6 +820,43 @@ func (s *IPAMTestSuite) Test_MatchesPoolRefIgnoresIPAddressTypeMeta() {
 		Name:     "other-pool",
 		APIGroup: GetIPAMInClusterAPIGroup(),
 		Kind:     GetInClusterIPPoolKind(),
+	}))
+	s.False(matchesPoolRef(ip, corev1.TypedLocalObjectReference{
+		Name:     "test-cluster-v4-icip",
+		APIGroup: ptr.To("other.ipam.example.com"),
+		Kind:     GetInClusterIPPoolKind(),
+	}))
+	s.False(matchesPoolRef(ip, corev1.TypedLocalObjectReference{
+		Name:     "test-cluster-v4-icip",
+		APIGroup: GetIPAMInClusterAPIGroup(),
+		Kind:     GetGlobalInClusterIPPoolKind(),
+	}))
+}
+
+func (s *IPAMTestSuite) Test_MatchesClaimPoolRefComparesNameGroupAndKind() {
+	machine := s.testMachine()
+	ipClaimDef := s.testIPClaimDef(infrav1.DefaultNetworkDevice, "0", "test-cluster-v4-icip")
+	claim := s.testIPAddressClaim(machine, ipClaimDef, "")
+
+	s.True(matchesClaimPoolRef(*claim, corev1.TypedLocalObjectReference{
+		Name:     "test-cluster-v4-icip",
+		APIGroup: ptr.To(ipamicv1.GroupVersion.String()),
+		Kind:     GetInClusterIPPoolKind(),
+	}))
+	s.False(matchesClaimPoolRef(*claim, corev1.TypedLocalObjectReference{
+		Name:     "other-pool",
+		APIGroup: ptr.To(ipamicv1.GroupVersion.String()),
+		Kind:     GetInClusterIPPoolKind(),
+	}))
+	s.False(matchesClaimPoolRef(*claim, corev1.TypedLocalObjectReference{
+		Name:     "test-cluster-v4-icip",
+		APIGroup: ptr.To("other.ipam.example.com"),
+		Kind:     GetInClusterIPPoolKind(),
+	}))
+	s.False(matchesClaimPoolRef(*claim, corev1.TypedLocalObjectReference{
+		Name:     "test-cluster-v4-icip",
+		APIGroup: ptr.To(ipamicv1.GroupVersion.String()),
+		Kind:     GetGlobalInClusterIPPoolKind(),
 	}))
 }
 

--- a/pkg/kubernetes/ipam/ipam_test.go
+++ b/pkg/kubernetes/ipam/ipam_test.go
@@ -50,6 +50,8 @@ type IPAMTestSuite struct {
 	helper      *Helper
 }
 
+const otherMachineName = "other-machine"
+
 func TestIPAMTestSuite(t *testing.T) {
 	suite.Run(t, new(IPAMTestSuite))
 }
@@ -619,7 +621,7 @@ func (s *IPAMTestSuite) Test_ResolveIPAddressClaimConflictOwnerMismatch() {
 	ipClaimDef := s.testIPClaimDef(infrav1.DefaultNetworkDevice, "0", "test-cluster-v4-icip")
 	claim := s.testIPAddressClaim(machine, ipClaimDef, "")
 	claim.OwnerReferences[0].UID = types.UID("other-uid")
-	claim.OwnerReferences[0].Name = "other-machine"
+	claim.OwnerReferences[0].Name = otherMachineName
 	s.NoError(s.cl.Create(s.ctx, claim))
 
 	result, err := s.helper.ResolveIPAddressClaim(s.ctx, machine, ipClaimDef)
@@ -754,7 +756,7 @@ func (s *IPAMTestSuite) Test_GetIPAddressV2ReturnsOwnedAddressesAndMergesClaimAn
 	otherClaimDef := s.testIPClaimDef(infrav1.DefaultNetworkDevice, "1", poolRef.Name)
 	otherClaim := s.testIPAddressClaim(machine, otherClaimDef, "")
 	otherClaim.OwnerReferences[0].UID = types.UID("other-uid")
-	otherClaim.OwnerReferences[0].Name = "other-machine"
+	otherClaim.OwnerReferences[0].Name = otherMachineName
 	otherAddress := s.testIPAddress(machine.Namespace, otherClaim.Name, poolRef.Name)
 	s.NoError(s.cl.Create(s.ctx, otherClaim))
 	s.NoError(s.cl.Create(s.ctx, otherAddress))
@@ -787,7 +789,7 @@ func (s *IPAMTestSuite) Test_HasDirectOwnerReferenceRequiresExactMachineIdentity
 	s.False(hasDirectOwnerReference([]metav1.OwnerReference{uidMismatch}, machine))
 
 	nameMismatch := ownerRef
-	nameMismatch.Name = "other-machine"
+	nameMismatch.Name = otherMachineName
 	s.False(hasDirectOwnerReference([]metav1.OwnerReference{nameMismatch}, machine))
 
 	kindMismatch := ownerRef

--- a/pkg/kubernetes/ipam/ipam_test.go
+++ b/pkg/kubernetes/ipam/ipam_test.go
@@ -85,6 +85,7 @@ func (s *IPAMTestSuite) SetupTest() {
 		WithScheme(scheme).
 		WithObjects(s.cluster).
 		WithObjects(s.capiCluster).
+		WithIndex(&ipamv1.IPAddress{}, IPAddressPoolRefNameField, IPAddressByPoolRefName).
 		Build()
 
 	s.cl = fakeCl
@@ -528,6 +529,220 @@ func (s *IPAMTestSuite) Test_GetIPAddress() {
 	s.Equal(ip.Spec.Address, "10.10.10.11")
 }
 
+func (s *IPAMTestSuite) Test_ResolveIPAddressClaimMissing() {
+	machine := s.testMachine()
+	ipClaimDef := s.testIPClaimDef(infrav1.DefaultNetworkDevice, "0", "test-cluster-v4-icip")
+
+	result, err := s.helper.ResolveIPAddressClaim(s.ctx, machine, ipClaimDef)
+
+	s.NoError(err)
+	s.Equal(ClaimMissing, result.Status)
+	s.Equal(IPAddressFormat(machine.Name, infrav1.DefaultNetworkDevice, 0, infrav1.DefaultSuffix), result.ClaimName)
+	s.Nil(result.Claim)
+	s.Nil(result.Address)
+}
+
+func (s *IPAMTestSuite) Test_ResolveIPAddressClaimPending() {
+	machine := s.testMachine()
+	ipClaimDef := s.testIPClaimDef(infrav1.DefaultNetworkDevice, "0", "test-cluster-v4-icip")
+	claim := s.testIPAddressClaim(machine, ipClaimDef, "")
+	s.NoError(s.cl.Create(s.ctx, claim))
+
+	result, err := s.helper.ResolveIPAddressClaim(s.ctx, machine, ipClaimDef)
+
+	s.NoError(err)
+	s.Equal(ClaimPending, result.Status)
+	s.Equal(claim.Name, result.ClaimName)
+	s.Equal(claim.Name, result.Claim.Name)
+	s.Nil(result.Address)
+}
+
+func (s *IPAMTestSuite) Test_ResolveIPAddressClaimResolved() {
+	machine := s.testMachine()
+	ipClaimDef := s.testIPClaimDef(infrav1.DefaultNetworkDevice, "0", "test-cluster-v4-icip")
+	claim := s.testIPAddressClaim(machine, ipClaimDef, "allocated-address")
+	address := s.testIPAddress(claim.Namespace, "allocated-address", "test-cluster-v4-icip")
+	s.NoError(s.cl.Create(s.ctx, claim))
+	s.NoError(s.cl.Create(s.ctx, address))
+
+	result, err := s.helper.ResolveIPAddressClaim(s.ctx, machine, ipClaimDef)
+
+	s.NoError(err)
+	s.Equal(ClaimResolved, result.Status)
+	s.NotNil(result.Address)
+	s.Equal(address.Name, result.Address.Name)
+	s.Equal("10.10.10.11", result.Address.Spec.Address)
+}
+
+func (s *IPAMTestSuite) Test_ResolveIPAddressClaimResolvedMergesClaimAnnotations() {
+	machine := s.testMachine()
+	ipClaimDef := s.testIPClaimDef(infrav1.DefaultNetworkDevice, "2", "test-cluster-v4-icip")
+	ipClaimDef.Annotations[infrav1.ProxmoxDefaultGatewayAnnotation] = "true"
+	claim := s.testIPAddressClaim(machine, ipClaimDef, "allocated-address")
+	address := s.testIPAddress(claim.Namespace, "allocated-address", "test-cluster-v4-icip")
+	address.Annotations = map[string]string{"address-annotation": "preserved"}
+	s.NoError(s.cl.Create(s.ctx, claim))
+	s.NoError(s.cl.Create(s.ctx, address))
+
+	result, err := s.helper.ResolveIPAddressClaim(s.ctx, machine, ipClaimDef)
+
+	s.NoError(err)
+	s.Equal(ClaimResolved, result.Status)
+	s.Equal("preserved", result.Address.Annotations["address-annotation"])
+	s.Equal("2", result.Address.Annotations[infrav1.ProxmoxPoolOffsetAnnotation])
+	s.Equal("true", result.Address.Annotations[infrav1.ProxmoxDefaultGatewayAnnotation])
+}
+
+func (s *IPAMTestSuite) Test_ResolveIPAddressClaimConflictOwnerMismatch() {
+	machine := s.testMachine()
+	ipClaimDef := s.testIPClaimDef(infrav1.DefaultNetworkDevice, "0", "test-cluster-v4-icip")
+	claim := s.testIPAddressClaim(machine, ipClaimDef, "")
+	claim.OwnerReferences[0].UID = types.UID("other-uid")
+	claim.OwnerReferences[0].Name = "other-machine"
+	s.NoError(s.cl.Create(s.ctx, claim))
+
+	result, err := s.helper.ResolveIPAddressClaim(s.ctx, machine, ipClaimDef)
+
+	s.NoError(err)
+	s.Equal(ClaimConflict, result.Status)
+	s.Equal(ConflictOwnerMismatch, result.ConflictReason)
+	s.Equal(claim.Name, result.Claim.Name)
+	s.Nil(result.Address)
+}
+
+func (s *IPAMTestSuite) Test_ResolveIPAddressClaimConflictPoolMismatch() {
+	machine := s.testMachine()
+	ipClaimDef := s.testIPClaimDef(infrav1.DefaultNetworkDevice, "0", "test-cluster-v4-icip")
+	claim := s.testIPAddressClaim(machine, ipClaimDef, "")
+	claim.Spec.PoolRef.Name = "other-pool"
+	s.NoError(s.cl.Create(s.ctx, claim))
+
+	result, err := s.helper.ResolveIPAddressClaim(s.ctx, machine, ipClaimDef)
+
+	s.NoError(err)
+	s.Equal(ClaimConflict, result.Status)
+	s.Equal(ConflictPoolMismatch, result.ConflictReason)
+	s.Nil(result.Address)
+}
+
+func (s *IPAMTestSuite) Test_ResolveIPAddressClaimConflictAddressMissing() {
+	machine := s.testMachine()
+	ipClaimDef := s.testIPClaimDef(infrav1.DefaultNetworkDevice, "0", "test-cluster-v4-icip")
+	claim := s.testIPAddressClaim(machine, ipClaimDef, "missing-address")
+	s.NoError(s.cl.Create(s.ctx, claim))
+
+	result, err := s.helper.ResolveIPAddressClaim(s.ctx, machine, ipClaimDef)
+
+	s.NoError(err)
+	s.Equal(ClaimConflict, result.Status)
+	s.Equal(ConflictAddressMissing, result.ConflictReason)
+	s.Nil(result.Address)
+}
+
+func (s *IPAMTestSuite) Test_ResolveIPAddressClaimConflictAddressPoolRef() {
+	machine := s.testMachine()
+	ipClaimDef := s.testIPClaimDef(infrav1.DefaultNetworkDevice, "0", "test-cluster-v4-icip")
+	claim := s.testIPAddressClaim(machine, ipClaimDef, "allocated-address")
+	address := s.testIPAddress(claim.Namespace, "allocated-address", "other-pool")
+	s.NoError(s.cl.Create(s.ctx, claim))
+	s.NoError(s.cl.Create(s.ctx, address))
+
+	result, err := s.helper.ResolveIPAddressClaim(s.ctx, machine, ipClaimDef)
+
+	s.NoError(err)
+	s.Equal(ClaimConflict, result.Status)
+	s.Equal(ConflictAddressPoolRef, result.ConflictReason)
+	s.Nil(result.Address)
+}
+
+func (s *IPAMTestSuite) Test_ResolveIPAddressClaimDirectOwnerReferenceFallback() {
+	machine := s.testMachine()
+	ipClaimDef := s.testIPClaimDef(infrav1.DefaultNetworkDevice, "0", "test-cluster-v4-icip")
+	claim := s.testIPAddressClaim(machine, ipClaimDef, "allocated-address")
+	claim.OwnerReferences[0].APIVersion = infrav1.GroupVersion.Group
+	address := s.testIPAddress(claim.Namespace, "allocated-address", "test-cluster-v4-icip")
+	s.NoError(s.cl.Create(s.ctx, claim))
+	s.NoError(s.cl.Create(s.ctx, address))
+
+	result, err := s.helper.ResolveIPAddressClaim(s.ctx, machine, ipClaimDef)
+
+	s.NoError(err)
+	s.Equal(ClaimResolved, result.Status)
+	s.NotNil(result.Address)
+	s.Equal(address.Name, result.Address.Name)
+}
+
+func (s *IPAMTestSuite) Test_ResolveIPAddressClaimMissingWithOrphanedDeterministicIPAddress() {
+	machine := s.testMachine()
+	ipClaimDef := s.testIPClaimDef(infrav1.DefaultNetworkDevice, "0", "test-cluster-v4-icip")
+	orphanName := IPAddressFormat(machine.Name, infrav1.DefaultNetworkDevice, 0, infrav1.DefaultSuffix)
+	s.NoError(s.cl.Create(s.ctx, s.testIPAddress(machine.Namespace, orphanName, "test-cluster-v4-icip")))
+
+	result, err := s.helper.ResolveIPAddressClaim(s.ctx, machine, ipClaimDef)
+
+	s.NoError(err)
+	s.Equal(ClaimMissing, result.Status)
+	s.Equal(orphanName, result.OrphanedAddressName)
+	s.Nil(result.Claim)
+	s.Nil(result.Address)
+}
+
+func (s *IPAMTestSuite) Test_HasDirectOwnerReferenceRequiresExactMachineIdentity() {
+	machine := s.testMachine()
+	ownerRef := metav1.OwnerReference{
+		APIVersion: infrav1.GroupVersion.String(),
+		Kind:       infrav1.ProxmoxMachineKind,
+		Name:       machine.Name,
+		UID:        machine.UID,
+	}
+
+	s.True(hasDirectOwnerReference([]metav1.OwnerReference{ownerRef}, machine))
+
+	groupOnly := ownerRef
+	groupOnly.APIVersion = infrav1.GroupVersion.Group
+	s.True(hasDirectOwnerReference([]metav1.OwnerReference{groupOnly}, machine))
+
+	uidMismatch := ownerRef
+	uidMismatch.UID = types.UID("other-uid")
+	s.False(hasDirectOwnerReference([]metav1.OwnerReference{uidMismatch}, machine))
+
+	nameMismatch := ownerRef
+	nameMismatch.Name = "other-machine"
+	s.False(hasDirectOwnerReference([]metav1.OwnerReference{nameMismatch}, machine))
+
+	kindMismatch := ownerRef
+	kindMismatch.Kind = "OtherMachine"
+	s.False(hasDirectOwnerReference([]metav1.OwnerReference{kindMismatch}, machine))
+
+	apiGroupMismatch := ownerRef
+	apiGroupMismatch.APIVersion = "other.infrastructure.cluster.x-k8s.io/v1alpha2"
+	s.False(hasDirectOwnerReference([]metav1.OwnerReference{apiGroupMismatch}, machine))
+}
+
+func (s *IPAMTestSuite) Test_MatchesPoolRefIgnoresIPAddressTypeMeta() {
+	ip := ipamv1.IPAddress{
+		TypeMeta: metav1.TypeMeta{Kind: "IPAddress", APIVersion: "unrelated.example.com/v1"},
+		Spec: ipamv1.IPAddressSpec{
+			PoolRef: ipamv1.IPPoolReference{
+				APIGroup: "ipam.cluster.x-k8s.io",
+				Kind:     GetInClusterIPPoolKind(),
+				Name:     "test-cluster-v4-icip",
+			},
+		},
+	}
+
+	s.True(matchesPoolRef(ip, corev1.TypedLocalObjectReference{
+		Name:     "test-cluster-v4-icip",
+		APIGroup: GetIPAMInClusterAPIGroup(),
+		Kind:     GetInClusterIPPoolKind(),
+	}))
+	s.False(matchesPoolRef(ip, corev1.TypedLocalObjectReference{
+		Name:     "other-pool",
+		APIGroup: GetIPAMInClusterAPIGroup(),
+		Kind:     GetInClusterIPPoolKind(),
+	}))
+}
+
 func getCluster() *infrav1.ProxmoxCluster {
 	return &infrav1.ProxmoxCluster{
 		TypeMeta: metav1.TypeMeta{
@@ -549,6 +764,82 @@ func getCluster() *infrav1.ProxmoxCluster {
 				Gateway:   "10.0.0.0",
 				Prefix:    24,
 			},
+		},
+	}
+}
+
+func (s *IPAMTestSuite) testMachine() *infrav1.ProxmoxMachine {
+	return &infrav1.ProxmoxMachine{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       infrav1.ProxmoxMachineKind,
+			APIVersion: infrav1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-machine",
+			Namespace: "test",
+			UID:       types.UID("test-machine-uid"),
+		},
+	}
+}
+
+func (s *IPAMTestSuite) testIPClaimDef(device infrav1.NetName, offset, poolName string) IPClaimDef {
+	return IPClaimDef{
+		Device: device,
+		PoolRef: corev1.TypedLocalObjectReference{
+			Name:     poolName,
+			APIGroup: ptr.To(ipamicv1.GroupVersion.String()),
+			Kind:     GetInClusterIPPoolKind(),
+		},
+		Annotations: map[string]string{
+			infrav1.ProxmoxPoolOffsetAnnotation: offset,
+		},
+	}
+}
+
+func (s *IPAMTestSuite) testIPAddressClaim(machine *infrav1.ProxmoxMachine, ipClaimDef IPClaimDef, addressName string) *ipamv1.IPAddressClaim {
+	claimName, err := ipClaimName(machine, ipClaimDef)
+	s.NoError(err)
+
+	return &ipamv1.IPAddressClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        claimName,
+			Namespace:   machine.Namespace,
+			Annotations: ipClaimDef.Annotations,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: infrav1.GroupVersion.String(),
+				Kind:       infrav1.ProxmoxMachineKind,
+				Name:       machine.Name,
+				UID:        machine.UID,
+			}},
+		},
+		Spec: ipamv1.IPAddressClaimSpec{
+			PoolRef: ipamv1.IPPoolReference{
+				APIGroup: ipamicv1.GroupVersion.Group,
+				Kind:     ipClaimDef.PoolRef.Kind,
+				Name:     ipClaimDef.PoolRef.Name,
+			},
+		},
+		Status: ipamv1.IPAddressClaimStatus{
+			AddressRef: ipamv1.IPAddressReference{Name: addressName},
+		},
+	}
+}
+
+func (s *IPAMTestSuite) testIPAddress(namespace, name, poolName string) *ipamv1.IPAddress {
+	return &ipamv1.IPAddress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: ipamv1.IPAddressSpec{
+			PoolRef: ipamv1.IPPoolReference{
+				APIGroup: ipamicv1.GroupVersion.Group,
+				Kind:     GetInClusterIPPoolKind(),
+				Name:     poolName,
+			},
+			Address: "10.10.10.11",
+			Prefix:  ptr.To[int32](24),
+			Gateway: "10.10.10.1",
 		},
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*

#758

*Description of changes:*

This PR makes static-IP provisioning resolve the expected `IPAddressClaim` directly instead of relying on address-listing recovery paths.

The new claim-rooted resolver:

- computes the deterministic claim name for the machine/device/offset
- distinguishes missing, pending, resolved, and conflicting claims
- validates claim ownership before consuming an allocation
- validates both the claim `poolRef` and referenced `IPAddress.spec.poolRef`
- merges claim annotations onto the resolved address in memory
- surfaces conflicts as `WaitingForStaticIPAllocation` with an actionable condition message
- logs and emits a warning event when a deterministic orphan `IPAddress` exists without the expected claim

This avoids consuming stale or wrong-pool restored IPAM objects while keeping PR scope limited to the provisioning path.

*Testing performed:*

- `make test WHAT=./pkg/kubernetes/ipam/...`
- `make test WHAT=./internal/service/vmservice/...`
- `make test`

Manual rollout validation (All was done in cluster with stale ip addresses): 

- Deleted control-plane Machine `qak8scapicl1-cp-tsv85`
- CAPI created replacement:
  - Machine: `qak8scapicl1-cp-vp2pl`
  - ProxmoxMachine: `qak8scapicl1-cp-640dc8f1-7t9dv`
  - VMID: `104`
  - IP: `192.168.160.5`
  - Proxmox node: `hv24`
- Replacement control-plane node joined and became Ready
- TalosControlPlane returned to `READY=true` with 3 ready replicas
- Cluster `/readyz` returned `ok`
- All 6 workload nodes were Ready
- Proxmox confirmed VM 104 running with tag `ip_net0_192.168.160.5`
- Old VMID 108 config no longer existed