### PR TITLE
test: use documentation IP ranges

### DIFF
--- a/api/v1alpha1/proxmoxcluster_types_test.go
+++ b/api/v1alpha1/proxmoxcluster_types_test.go
@@ -82,12 +82,12 @@ func defaultCluster() *ProxmoxCluster {
 		},
 		Spec: ProxmoxClusterSpec{
 			IPv4Config: &IPConfigSpec{
-				Addresses: []string{"10.0.0.0/24"},
+				Addresses: []string{"203.0.113.0/24"},
 				Prefix:    24,
-				Gateway:   "10.0.0.254",
+				Gateway:   "203.0.113.254",
 				Metric:    func() *uint32 { var a uint32 = 123; return &a }(),
 			},
-			DNSServers: []string{"1.2.3.4"},
+			DNSServers: []string{"192.0.2.4"},
 		},
 	}
 }
@@ -221,9 +221,9 @@ func TestSetInClusterIPPoolRef(t *testing.T) {
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: ipamicv1.InClusterIPPoolSpec{
-			Addresses: []string{"10.10.10.2/24"},
+			Addresses: []string{"192.0.2.2/24"},
 			Prefix:    24,
-			Gateway:   "10.10.10.1",
+			Gateway:   "192.0.2.1",
 		},
 	}
 

--- a/api/v1alpha2/proxmoxcluster_types_test.go
+++ b/api/v1alpha2/proxmoxcluster_types_test.go
@@ -82,12 +82,12 @@ func defaultCluster() *ProxmoxCluster {
 		},
 		Spec: ProxmoxClusterSpec{
 			IPv4Config: &IPConfigSpec{
-				Addresses: []string{"10.0.0.0/24"},
+				Addresses: []string{"203.0.113.0/24"},
 				Prefix:    24,
-				Gateway:   "10.0.0.254",
+				Gateway:   "203.0.113.254",
 				Metric:    ptr.To(int32(123)),
 			},
-			DNSServers: []string{"1.2.3.4"},
+			DNSServers: []string{"192.0.2.4"},
 		},
 	}
 }
@@ -228,9 +228,9 @@ func TestSetInClusterIPPoolRef(t *testing.T) {
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: ipamicv1.InClusterIPPoolSpec{
-			Addresses: []string{"10.10.10.2/24"},
+			Addresses: []string{"192.0.2.2/24"},
 			Prefix:    24,
-			Gateway:   "10.10.10.1",
+			Gateway:   "192.0.2.1",
 		},
 	}
 

--- a/cmd/convert/main_test.go
+++ b/cmd/convert/main_test.go
@@ -37,7 +37,7 @@ metadata:
   name: test
 spec:
   controlPlaneEndpoint:
-    host: 10.0.0.1
+    host: 203.0.113.1
     port: 6443
 `
 

--- a/internal/controller/proxmoxcluster_controller_test.go
+++ b/internal/controller/proxmoxcluster_controller_test.go
@@ -341,19 +341,19 @@ func buildProxmoxCluster(name string) infrav1.ProxmoxCluster {
 		},
 		Spec: infrav1.ProxmoxClusterSpec{
 			ControlPlaneEndpoint: infrav1.APIEndpoint{
-				Host: "10.10.10.11",
+				Host: "192.0.2.11",
 				Port: 6443,
 			},
 			IPv4Config: &infrav1.IPConfigSpec{
 				Addresses: []string{
-					"10.10.10.2-10.10.10.10",
-					"10.10.10.100-10.10.10.125",
-					"10.10.10.192/64",
+					"192.0.2.2-192.0.2.10",
+					"192.0.2.100-192.0.2.125",
+					"192.0.2.192/24",
 				},
-				Gateway: "10.10.10.1",
+				Gateway: "192.0.2.1",
 				Prefix:  24,
 			},
-			DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+			DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 		},
 	}
 
@@ -393,9 +393,9 @@ func dummyIPAddress(client client.Client, owner client.Object, poolName string) 
 				Kind:     gvk.Kind,
 				Name:     poolName,
 			},
-			Address: "10.10.10.11",
+			Address: "192.0.2.11",
 			Prefix:  ptr.To[int32](24),
-			Gateway: "10.10.10.1",
+			Gateway: "192.0.2.1",
 		},
 	}
 }
@@ -425,14 +425,14 @@ func createProxmoxCluster() *infrav1.ProxmoxCluster {
 		Spec: infrav1.ProxmoxClusterSpec{
 			IPv4Config: &infrav1.IPConfigSpec{
 				Addresses: []string{
-					"10.10.10.2-10.10.10.10",
-					"10.10.10.100-10.10.10.125",
-					"10.10.10.192/64",
+					"192.0.2.2-192.0.2.10",
+					"192.0.2.100-192.0.2.125",
+					"192.0.2.192/24",
 				},
-				Gateway: "10.10.10.1",
+				Gateway: "192.0.2.1",
 				Prefix:  24,
 			},
-			DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+			DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 		},
 	}
 	Expect(testEnv.Create(testEnv.GetContext(), proxmoxCluster)).To(Succeed())

--- a/internal/inject/inject_test.go
+++ b/internal/inject/inject_test.go
@@ -113,8 +113,8 @@ func TestISOInjectorInjectCloudInit(t *testing.T) {
 		NetworkRenderer: cloudinit.NewNetworkConfig([]types.NetworkConfigData{
 			{
 				Name:       "eth0",
-				IPConfigs:  []types.IPConfig{{IPAddress: netip.MustParsePrefix("10.1.1.6/24"), Gateway: "10.1.1.1"}},
-				DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+				IPConfigs:  []types.IPConfig{{IPAddress: netip.MustParsePrefix("192.0.2.6/24"), Gateway: "192.0.2.1"}},
+				DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 			},
 		}),
 	}
@@ -156,8 +156,8 @@ func TestISOInjectorInjectCloudInit_Errors(t *testing.T) {
 		NetworkRenderer: cloudinit.NewNetworkConfig([]types.NetworkConfigData{
 			{
 				Name:       "eth0",
-				IPConfigs:  []types.IPConfig{{IPAddress: netip.MustParsePrefix("10.1.1.6/24"), Gateway: "10.1.1.1"}},
-				DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+				IPConfigs:  []types.IPConfig{{IPAddress: netip.MustParsePrefix("192.0.2.6/24"), Gateway: "192.0.2.1"}},
+				DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 			},
 		}),
 	}
@@ -206,8 +206,8 @@ func TestISOInjectorInjectIgnition(t *testing.T) {
 		Network: []types.NetworkConfigData{
 			{
 				Name:       "eth0",
-				IPConfigs:  []types.IPConfig{{IPAddress: netip.MustParsePrefix("10.1.1.6/24"), Gateway: "10.1.1.1"}},
-				DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+				IPConfigs:  []types.IPConfig{{IPAddress: netip.MustParsePrefix("192.0.2.6/24"), Gateway: "192.0.2.1"}},
+				DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 			},
 		},
 	}
@@ -257,8 +257,8 @@ func TestISOInjectorInjectIgnition_Errors(t *testing.T) {
 		Network: []types.NetworkConfigData{
 			{
 				Name:       "eth0",
-				IPConfigs:  []types.IPConfig{{IPAddress: netip.MustParsePrefix("10.1.1.9/24"), Gateway: "10.1.1.1"}},
-				DNSServers: []string{"10.1.1.1"},
+				IPConfigs:  []types.IPConfig{{IPAddress: netip.MustParsePrefix("192.0.2.9/24"), Gateway: "192.0.2.1"}},
+				DNSServers: []string{"192.0.2.1"},
 			},
 		},
 	}
@@ -310,8 +310,8 @@ func TestISOInjectorInject_Unsupported(t *testing.T) {
 		NetworkRenderer: cloudinit.NewNetworkConfig([]types.NetworkConfigData{
 			{
 				Name:       "eth0",
-				IPConfigs:  []types.IPConfig{{IPAddress: netip.MustParsePrefix("10.1.1.6/24"), Gateway: "10.1.1.1"}},
-				DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+				IPConfigs:  []types.IPConfig{{IPAddress: netip.MustParsePrefix("192.0.2.6/24"), Gateway: "192.0.2.1"}},
+				DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 			},
 		}),
 	}

--- a/internal/service/vmservice/bootstrap_test.go
+++ b/internal/service/vmservice/bootstrap_test.go
@@ -153,7 +153,7 @@ func addIPPool(machineScope *scope.MachineScope, poolRef corev1.TypedLocalObject
 			Name:   netName,
 			InterfaceConfig: infrav1.InterfaceConfig{
 				IPPoolRef:  []corev1.TypedLocalObjectReference{},
-				DNSServers: []string{fmt.Sprintf("1.2.3.%d", 4+index)},
+				DNSServers: []string{fmt.Sprintf("192.0.2.%d", 4+index)},
 			},
 		}
 		networkDevices = append(networkDevices, nic)
@@ -187,7 +187,7 @@ func TestReconcileBootstrapData_NoNetworkConfig_UpdateStatus(t *testing.T) {
 	// NetworkSetup
 	// defaultPool addresses need to be created individually since they refer to no interface atm
 	defaultPool := addDefaultIPPool(machineScope)
-	createIPAddress(t, kubeClient, machineScope, "net0", "10.10.10.10/24", 0, &defaultPool)
+	createIPAddress(t, kubeClient, machineScope, "net0", "192.0.2.10/24", 0, &defaultPool)
 
 	// reconcile BootstrapData
 	requeue, err := reconcileBootstrapData(context.Background(), machineScope)
@@ -197,7 +197,7 @@ func TestReconcileBootstrapData_NoNetworkConfig_UpdateStatus(t *testing.T) {
 	// Check generated bootstrapData against setup
 	networkConfigData := getNetworkConfigDataFromVM(t, *networkDataPtr)
 	require.Equal(t, 1, len(networkConfigData))
-	require.Equal(t, "10.10.10.10"+"/24", networkConfigData[0].IPConfigs[0].IPAddress.String())
+	require.Equal(t, "192.0.2.10"+"/24", networkConfigData[0].IPConfigs[0].IPAddress.String())
 	require.Equal(t, "A6:23:64:4D:84:CB", networkConfigData[0].MacAddress)
 	require.Equal(t, "eth0", networkConfigData[0].Name)
 	require.Equal(t, infrav1.DefaultNetworkDevice, networkConfigData[0].ProxName)
@@ -223,11 +223,11 @@ func TestReconcileBootstrapData_UpdateStatus(t *testing.T) {
 	// update extraPool for gateway/prefix test
 	poolObj := getIPAddressPool(t, machineScope, extraPool0)
 	poolObj.(*ipamicv1.GlobalInClusterIPPool).Spec.Prefix = 16
-	poolObj.(*ipamicv1.GlobalInClusterIPPool).Spec.Gateway = "10.100.10.1"
+	poolObj.(*ipamicv1.GlobalInClusterIPPool).Spec.Gateway = "203.0.113.1"
 	createOrUpdateIPPool(t, kubeClient, machineScope, nil, poolObj)
 
-	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "10.10.10.10/24", 0, &defaultPool)
-	createIPAddress(t, kubeClient, machineScope, "net1", "10.100.10.10", 0, &extraPool0)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "192.0.2.10/24", 0, &defaultPool)
+	createIPAddress(t, kubeClient, machineScope, "net1", "203.0.113.100", 0, &extraPool0)
 
 	setupVMWithMetadata(machineScope, "virtio=A6:23:64:4D:84:CB,bridge=vmbr0", "virtio=AA:23:64:4D:84:CD,bridge=vmbr1")
 	createBootstrapSecret(t, kubeClient, machineScope, cloudinit.FormatCloudConfig)
@@ -240,13 +240,13 @@ func TestReconcileBootstrapData_UpdateStatus(t *testing.T) {
 	// Check generated bootstrapData against setup
 	networkConfigData := getNetworkConfigDataFromVM(t, *networkDataPtr)
 	require.True(t, len(networkConfigData) > 0)
-	require.Equal(t, "10.10.10.10"+"/24", networkConfigData[0].IPConfigs[0].IPAddress.String())
+	require.Equal(t, "192.0.2.10"+"/24", networkConfigData[0].IPConfigs[0].IPAddress.String())
 	require.Equal(t, "A6:23:64:4D:84:CB", networkConfigData[0].MacAddress)
 	require.Equal(t, "eth0", networkConfigData[0].Name)
 	require.Equal(t, infrav1.DefaultNetworkDevice, networkConfigData[0].ProxName)
 	require.Equal(t, "ethernet", networkConfigData[0].Type)
-	require.Equal(t, "10.100.10.10"+"/16", networkConfigData[1].IPConfigs[0].IPAddress.String())
-	require.Equal(t, "10.100.10.1", networkConfigData[1].IPConfigs[0].Gateway)
+	require.Equal(t, "203.0.113.100"+"/16", networkConfigData[1].IPConfigs[0].IPAddress.String())
+	require.Equal(t, "203.0.113.1", networkConfigData[1].IPConfigs[0].Gateway)
 	require.Equal(t, "AA:23:64:4D:84:CD", networkConfigData[1].MacAddress)
 	require.Equal(t, "eth1", networkConfigData[1].Name)
 	require.Equal(t, infrav1.NetName("net1"), networkConfigData[1].ProxName)
@@ -266,7 +266,7 @@ func TestReconcileBootstrapData_BadInjector(t *testing.T) {
 	defaultPool := addDefaultIPPool(machineScope)
 
 	createIPPools(t, kubeClient, machineScope)
-	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "10.10.10.10", 0, &defaultPool)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "192.0.2.10", 0, &defaultPool)
 
 	getISOInjector = func(_ *proxmox.VirtualMachine, _ []byte, _, _ cloudinit.Renderer) isoInjector {
 		return FakeISOInjector{Error: errors.New("bad FakeISOInjector")}
@@ -389,16 +389,16 @@ func TestGetCommonInterfaceConfig(t *testing.T) {
 				Model:  ptr.To("virtio"),
 				Name:   "net1",
 				InterfaceConfig: infrav1.InterfaceConfig{
-					DNSServers: []string{"1.2.3.4"},
+					DNSServers: []string{"192.0.2.4"},
 					LinkMTU:    &MTU,
 					Routing: infrav1.Routing{
 						Routes: []infrav1.RouteSpec{
-							{To: ptr.To("default"), Via: ptr.To("192.168.178.1")},
-							{To: ptr.To("172.24.16.0/24"), Via: ptr.To("192.168.178.1"), Table: ptr.To(int32(100))},
+							{To: ptr.To("default"), Via: ptr.To("198.51.100.1")},
+							{To: ptr.To("203.0.113.16/24"), Via: ptr.To("198.51.100.1"), Table: ptr.To(int32(100))},
 						},
 						RoutingPolicy: []infrav1.RoutingPolicySpec{
-							{To: ptr.To("10.10.10.0/24"), Table: ptr.To(int32(100))},
-							{From: ptr.To("172.24.16.0/24"), Table: ptr.To(int32(100))},
+							{To: ptr.To("192.0.2.0/24"), Table: ptr.To(int32(100))},
+							{From: ptr.To("203.0.113.16/24"), Table: ptr.To(int32(100))},
 						},
 					},
 				},
@@ -408,11 +408,11 @@ func TestGetCommonInterfaceConfig(t *testing.T) {
 
 	cfg := &types.NetworkConfigData{Name: "net1"}
 	getCommonInterfaceConfig(context.Background(), machineScope, cfg, machineScope.ProxmoxMachine.Spec.Network.NetworkDevices[0].InterfaceConfig)
-	require.Equal(t, "1.2.3.4", cfg.DNSServers[0])
+	require.Equal(t, "192.0.2.4", cfg.DNSServers[0])
 	require.Equal(t, "default", *cfg.Routes[0].To)
-	require.Equal(t, "172.24.16.0/24", *cfg.Routes[1].To)
-	require.Equal(t, "10.10.10.0/24", *cfg.FIBRules[0].To)
-	require.Equal(t, "172.24.16.0/24", *cfg.FIBRules[1].From)
+	require.Equal(t, "203.0.113.16/24", *cfg.Routes[1].To)
+	require.Equal(t, "192.0.2.0/24", *cfg.FIBRules[0].To)
+	require.Equal(t, "203.0.113.16/24", *cfg.FIBRules[1].From)
 }
 
 func TestGetVirtualNetworkDevices_VRFDevice_MissingInterface(t *testing.T) {
@@ -467,7 +467,7 @@ func TestReconcileBootstrapData_DualStack(t *testing.T) {
 
 	// create missing defaultPoolV6 and ipAddresses
 	require.NoError(t, machineScope.IPAMHelper.CreateOrUpdateInClusterIPPool(context.Background()))
-	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "10.0.0.254", 0, &defaultPool)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "203.0.113.254", 0, &defaultPool)
 	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "2001:db8::2", 1, &defaultPoolV6)
 
 	// perform test
@@ -482,8 +482,8 @@ func TestReconcileBootstrapData_DualStack(t *testing.T) {
 	require.Equal(t, 1, len(networkConfigData))
 	require.Equal(t, 2, len(networkConfigData[0].IPConfigs))
 	ipConfigs := networkConfigData[0].IPConfigs
-	require.Equal(t, "10.0.0.1", ipConfigs[0].Gateway)
-	require.Equal(t, "10.0.0.254/24", ipConfigs[0].IPAddress.String())
+	require.Equal(t, "203.0.113.1", ipConfigs[0].Gateway)
+	require.Equal(t, "203.0.113.254/24", ipConfigs[0].IPAddress.String())
 	require.Equal(t, "2001:db8::1", ipConfigs[1].Gateway)
 	require.Equal(t, "2001:db8::2/96", ipConfigs[1].IPAddress.String())
 }
@@ -524,7 +524,7 @@ func TestReconcileBootstrapData_DualStack_AdditionalDevices(t *testing.T) {
 	addGlobalInClusterIPPool(machineScope, "extraPool1", "net1")
 
 	// Create missing ip addresses and pools.
-	createNetworkSpecForMachine(t, kubeClient, machineScope, "10.10.10.10", "2001:db8::2", "10.0.0.10", "2001:db8::9")
+	createNetworkSpecForMachine(t, kubeClient, machineScope, "192.0.2.10", "2001:db8::2", "203.0.113.10", "2001:db8::9")
 
 	// Perform test.
 	requeue, err := reconcileBootstrapData(context.Background(), machineScope)
@@ -539,13 +539,13 @@ func TestReconcileBootstrapData_DualStack_AdditionalDevices(t *testing.T) {
 	require.Equal(t, 2, len(networkConfigData[0].IPConfigs))
 	require.Equal(t, 2, len(networkConfigData[1].IPConfigs))
 	ipConfigs := networkConfigData[0].IPConfigs
-	require.Equal(t, "10.0.0.1", ipConfigs[0].Gateway)
-	require.Equal(t, "10.10.10.10/24", ipConfigs[0].IPAddress.String())
+	require.Equal(t, "203.0.113.1", ipConfigs[0].Gateway)
+	require.Equal(t, "192.0.2.10/24", ipConfigs[0].IPAddress.String())
 	require.Equal(t, "2001:db8::1", ipConfigs[1].Gateway)
 	require.Equal(t, "2001:db8::2/96", ipConfigs[1].IPAddress.String())
 	ipConfigs = networkConfigData[1].IPConfigs
 	require.Equal(t, "", ipConfigs[0].Gateway) // No Gateway assigned
-	require.Equal(t, "10.0.0.10/24", ipConfigs[0].IPAddress.String())
+	require.Equal(t, "203.0.113.10/24", ipConfigs[0].IPAddress.String())
 	require.Equal(t, "", ipConfigs[1].Gateway) // No Gateway assigned
 	require.Equal(t, "2001:db8::9/64", ipConfigs[1].IPAddress.String())
 }
@@ -582,7 +582,7 @@ func TestReconcileBootstrapData_DualStack_SplitDefaultGateway(t *testing.T) {
 	addDefaultIPPoolV6(machineScope, 1)
 
 	// Create missing ip addresses and pools.
-	createNetworkSpecForMachine(t, kubeClient, machineScope, "10.10.10.10", "2001:db8::2")
+	createNetworkSpecForMachine(t, kubeClient, machineScope, "192.0.2.10", "2001:db8::2")
 
 	// Perform test.
 	requeue, err := reconcileBootstrapData(context.Background(), machineScope)
@@ -597,8 +597,8 @@ func TestReconcileBootstrapData_DualStack_SplitDefaultGateway(t *testing.T) {
 	require.Equal(t, 1, len(networkConfigData[0].IPConfigs))
 	require.Equal(t, 1, len(networkConfigData[1].IPConfigs))
 	ipConfigs := networkConfigData[0].IPConfigs
-	require.Equal(t, "10.0.0.1", ipConfigs[0].Gateway)
-	require.Equal(t, "10.10.10.10/24", ipConfigs[0].IPAddress.String())
+	require.Equal(t, "203.0.113.1", ipConfigs[0].Gateway)
+	require.Equal(t, "192.0.2.10/24", ipConfigs[0].IPAddress.String())
 	require.True(t, ipConfigs[0].Default)
 	ipConfigs = networkConfigData[1].IPConfigs
 	require.Equal(t, "2001:db8::1", ipConfigs[0].Gateway)
@@ -629,7 +629,7 @@ func TestReconcileBootstrapData_VirtualDevices_VRF(t *testing.T) {
 	addGlobalInClusterIPPool(machineScope, "extraPool0", "net0")
 	addGlobalInClusterIPPool(machineScope, "extraPool1", "net1")
 
-	createNetworkSpecForMachine(t, kubeClient, machineScope, "10.10.10.10", "10.20.10.10/23", "10.100.10.10/22")
+	createNetworkSpecForMachine(t, kubeClient, machineScope, "192.0.2.10", "198.51.100.20/23", "203.0.113.100/22")
 
 	requeue, err := reconcileBootstrapData(context.Background(), machineScope)
 	require.NoError(t, err)
@@ -645,11 +645,11 @@ func TestReconcileBootstrapData_VirtualDevices_VRF(t *testing.T) {
 	require.Equal(t, 0, len(networkConfigData[2].IPConfigs))
 	require.Equal(t, 1, len(networkConfigData[2].Interfaces))
 	ipConfigs := networkConfigData[0].IPConfigs
-	require.Equal(t, "10.0.0.1", ipConfigs[0].Gateway)
-	require.Equal(t, "10.10.10.10/24", ipConfigs[0].IPAddress.String())
-	require.Equal(t, "10.20.10.10/23", ipConfigs[1].IPAddress.String())
+	require.Equal(t, "203.0.113.1", ipConfigs[0].Gateway)
+	require.Equal(t, "192.0.2.10/24", ipConfigs[0].IPAddress.String())
+	require.Equal(t, "198.51.100.20/23", ipConfigs[1].IPAddress.String())
 	ipConfigs = networkConfigData[1].IPConfigs
-	require.Equal(t, "10.100.10.10/22", ipConfigs[0].IPAddress.String())
+	require.Equal(t, "203.0.113.100/22", ipConfigs[0].IPAddress.String())
 	// VRF Data
 	require.Equal(t, "vrf", networkConfigData[2].Type)
 	require.Equal(t, "vrf-blue", networkConfigData[2].Name)
@@ -670,7 +670,7 @@ func TestReconcileBootstrapDataMissingSecret(t *testing.T) {
 	machineScope, _, kubeClient := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForBootstrapDataReconciliationReason)
 	setupVMWithMetadata(machineScope, "virtio=A6:23:64:4D:84:CB,bridge=vmbr0")
 
-	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "10.10.10.10", 0)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "192.0.2.10", 0)
 
 	requeue, err := reconcileBootstrapData(context.Background(), machineScope)
 	require.Error(t, err)
@@ -698,7 +698,7 @@ func TestReconcileBootstrapData_Format_CloudConfig(t *testing.T) {
 	machineScope, _, kubeClient := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForBootstrapDataReconciliationReason)
 	setupVMWithMetadata(machineScope, "virtio=A6:23:64:4D:84:CB,bridge=vmbr0")
 	createBootstrapSecret(t, kubeClient, machineScope, cloudinit.FormatCloudConfig)
-	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "10.10.10.10", 0)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "192.0.2.10", 0)
 
 	setupFakeIsoInjector(t)
 
@@ -719,7 +719,7 @@ func TestReconcileBootstrapData_Format_Ignition(t *testing.T) {
 	setupVMWithMetadata(machineScope, "virtio=A6:23:64:4D:84:CB,bridge=vmbr0")
 	createBootstrapSecret(t, kubeClient, machineScope, ignition.FormatIgnition)
 
-	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "10.10.10.10", 0)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "192.0.2.10", 0)
 
 	getIgnitionISOInjector = func(_ *proxmox.VirtualMachine, _ cloudinit.Renderer, _ *ignition.Enricher) isoInjector {
 		return FakeIgnitionISOInjector{}
@@ -767,7 +767,7 @@ func TestReconcileBootstrapData_DefaultDeviceIPPoolRef(t *testing.T) {
 	// NetworkSetup for extra pools.
 	addGlobalInClusterIPPool(machineScope, "extraPool0", "net0")
 
-	createNetworkSpecForMachine(t, kubeClient, machineScope, "10.10.10.10", "10.5.10.10/23")
+	createNetworkSpecForMachine(t, kubeClient, machineScope, "192.0.2.10", "198.51.100.5/23")
 
 	// Perform the test
 	requeue, err := reconcileBootstrapData(context.Background(), machineScope)
@@ -781,8 +781,8 @@ func TestReconcileBootstrapData_DefaultDeviceIPPoolRef(t *testing.T) {
 	require.Equal(t, 1, len(networkConfigData))
 	require.Equal(t, 2, len(networkConfigData[0].IPConfigs))
 	ipConfigs := networkConfigData[0].IPConfigs
-	require.Equal(t, "10.0.0.1", ipConfigs[0].Gateway)
-	require.Equal(t, "10.10.10.10/24", ipConfigs[0].IPAddress.String())
+	require.Equal(t, "203.0.113.1", ipConfigs[0].Gateway)
+	require.Equal(t, "192.0.2.10/24", ipConfigs[0].IPAddress.String())
 	require.Equal(t, "", ipConfigs[1].Gateway)
-	require.Equal(t, "10.5.10.10/23", ipConfigs[1].IPAddress.String())
+	require.Equal(t, "198.51.100.5/23", ipConfigs[1].IPAddress.String())
 }

--- a/internal/service/vmservice/helpers_test.go
+++ b/internal/service/vmservice/helpers_test.go
@@ -122,11 +122,11 @@ func setupReconcilerTest(t *testing.T) (*scope.MachineScope, *proxmoxtest.MockCl
 		},
 		Spec: infrav1.ProxmoxClusterSpec{
 			IPv4Config: &infrav1.IPConfigSpec{
-				Addresses: []string{"10.0.0.10-10.0.0.20"},
+				Addresses: []string{"203.0.113.10-203.0.113.20"},
 				Prefix:    24,
-				Gateway:   "10.0.0.1",
+				Gateway:   "203.0.113.1",
 			},
-			DNSServers: []string{"1.2.3.4"},
+			DNSServers: []string{"192.0.2.4"},
 		},
 		Status: infrav1.ProxmoxClusterStatus{
 			NodeLocations: &infrav1.NodeLocations{},

--- a/internal/service/vmservice/ip_test.go
+++ b/internal/service/vmservice/ip_test.go
@@ -31,7 +31,7 @@ import (
 	. "github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/consts"
 )
 
-const ipTag = "ip_net0_10.10.10.10"
+const ipTag = "ip_net0_192.0.2.10"
 
 // TestReconcileIPAddresses_CreateDefaultClaim tests if the cluster provided InclusterIPPool IPAddressClaim gets created.
 func TestReconcileIPAddresses_CreateDefaultClaim(t *testing.T) {
@@ -90,7 +90,7 @@ func TestReconcileIPAddresses_CreateAdditionalClaim(t *testing.T) {
 	machineScope.SetVirtualMachine(vm)
 
 	createIPPools(t, kubeClient, machineScope)
-	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "10.10.10.10", 0, &defaultPool)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "192.0.2.10", 0, &defaultPool)
 
 	requeue, err := reconcileIPAddresses(context.Background(), machineScope)
 
@@ -133,7 +133,7 @@ func TestReconcileIPAddresses_AddIPTag(t *testing.T) {
 	machineScope.SetVirtualMachine(vm)
 
 	createIPPools(t, kubeClient, machineScope)
-	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "10.10.10.10", 0, &defaultPool)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "192.0.2.10", 0, &defaultPool)
 
 	proxmoxClient.EXPECT().TagVM(context.Background(), vm, ipTag).Return(task, nil).Once()
 
@@ -179,8 +179,8 @@ func TestReconcileIPAddresses_SetIPAddresses(t *testing.T) {
 		},
 	}
 	createIPPools(t, kubeClient, machineScope)
-	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "10.10.10.10", 0, &defaultPool)
-	createIPAddress(t, kubeClient, machineScope, "net1", "10.100.10.10", 0, &extraPool0)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "192.0.2.10", 0, &defaultPool)
+	createIPAddress(t, kubeClient, machineScope, "net1", "203.0.113.100", 0, &extraPool0)
 
 	vm := newStoppedVM()
 	vm.VirtualMachineConfig.Tags = ipTag
@@ -194,13 +194,13 @@ func TestReconcileIPAddresses_SetIPAddresses(t *testing.T) {
 	require.NotNil(t, machineScope.ProxmoxMachine.GetIPAddressesNet("net0"))
 	require.Equal(
 		t,
-		infrav1.IPAddressesSpec{NetName: string(infrav1.DefaultNetworkDevice), IPv4: []string{"10.10.10.10"}, IPv6: nil},
+		infrav1.IPAddressesSpec{NetName: string(infrav1.DefaultNetworkDevice), IPv4: []string{"192.0.2.10"}, IPv6: nil},
 		*machineScope.ProxmoxMachine.GetIPAddressesNet(infrav1.DefaultNetworkDevice),
 	)
 	require.NotNil(t, machineScope.ProxmoxMachine.GetIPAddressesNet("net1"))
 	require.Equal(
 		t,
-		infrav1.IPAddressesSpec{NetName: "net1", IPv4: []string{"10.100.10.10"}, IPv6: nil},
+		infrav1.IPAddressesSpec{NetName: "net1", IPv4: []string{"203.0.113.100"}, IPv6: nil},
 		*machineScope.ProxmoxMachine.GetIPAddressesNet("net1"),
 	)
 
@@ -252,9 +252,9 @@ func TestReconcileIPAddresses_MultipleDevices(t *testing.T) {
 	machineScope.SetVirtualMachine(vm)
 
 	createIPPools(t, kubeClient, machineScope)
-	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "10.10.10.10", 0, &defaultPool)
-	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "10.11.10.10", 1, &ipv4pool0)
-	createIPAddress(t, kubeClient, machineScope, "net1", "10.100.10.10", 0, &ipv4pool1)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "192.0.2.10", 0, &defaultPool)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "198.51.100.10", 1, &ipv4pool0)
+	createIPAddress(t, kubeClient, machineScope, "net1", "203.0.113.100", 0, &ipv4pool1)
 	createIPAddress(t, kubeClient, machineScope, "net2", "fe80::ffee", 0, &ipv6pool)
 
 	requeue, err := reconcileIPAddresses(context.Background(), machineScope)
@@ -265,13 +265,13 @@ func TestReconcileIPAddresses_MultipleDevices(t *testing.T) {
 	require.Len(t, machineScope.ProxmoxMachine.GetIPAddresses(), 3+1)
 
 	require.Equal(t,
-		[]string{"10.10.10.10", "10.11.10.10"},
+		[]string{"192.0.2.10", "198.51.100.10"},
 		machineScope.ProxmoxMachine.GetIPAddressesNet(infrav1.DefaultNetworkDevice).IPv4,
 	)
 	require.Nil(t, machineScope.ProxmoxMachine.GetIPAddressesNet(infrav1.DefaultNetworkDevice).IPv6)
 
 	require.ElementsMatch(t,
-		[]string{"10.100.10.10"},
+		[]string{"203.0.113.100"},
 		machineScope.ProxmoxMachine.GetIPAddressesNet("net1").IPv4,
 	)
 	require.Nil(t, machineScope.ProxmoxMachine.GetIPAddressesNet("net1").IPv6)
@@ -347,9 +347,9 @@ func TestReconcileIPAddresses_IPv6(t *testing.T) {
 	vm.VirtualMachineConfig.Tags = ipTag
 	machineScope.SetVirtualMachine(vm)
 	createIPPools(t, kubeClient, machineScope)
-	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "10.10.10.10", 0, &defaultPool)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "192.0.2.10", 0, &defaultPool)
 	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "fe80::1", 1, &defaultPoolV6)
-	createIPAddress(t, kubeClient, machineScope, "net1", "10.100.10.10", 0, &extraPool0)
+	createIPAddress(t, kubeClient, machineScope, "net1", "203.0.113.100", 0, &extraPool0)
 
 	requeue, err := reconcileIPAddresses(context.Background(), machineScope)
 	require.NoError(t, err)
@@ -362,12 +362,12 @@ func TestReconcileIPAddresses_IPv6(t *testing.T) {
 
 	require.NotNil(t, machineScope.ProxmoxMachine.GetIPAddressesNet("net0"))
 	require.Equal(t,
-		infrav1.IPAddressesSpec{NetName: string(infrav1.DefaultNetworkDevice), IPv4: []string{"10.10.10.10"}, IPv6: []string{"fe80::1"}},
+		infrav1.IPAddressesSpec{NetName: string(infrav1.DefaultNetworkDevice), IPv4: []string{"192.0.2.10"}, IPv6: []string{"fe80::1"}},
 		*machineScope.ProxmoxMachine.GetIPAddressesNet("net0"),
 	)
 	require.NotNil(t, machineScope.ProxmoxMachine.GetIPAddressesNet("net1"))
 	require.Equal(t,
-		infrav1.IPAddressesSpec{NetName: "net1", IPv4: []string{"10.100.10.10"}, IPv6: nil},
+		infrav1.IPAddressesSpec{NetName: "net1", IPv4: []string{"203.0.113.100"}, IPv6: nil},
 		*machineScope.ProxmoxMachine.GetIPAddressesNet("net1"),
 	)
 
@@ -414,14 +414,14 @@ func TestReconcileIPAddresses_MachineIPPoolRef(t *testing.T) {
 	vm.VirtualMachineConfig.Tags = ipTag
 	machineScope.SetVirtualMachine(vm)
 
-	defaultIP := "10.10.10.10"
+	defaultIP := "192.0.2.10"
 	createIPPools(t, kubeClient, machineScope)
 	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, defaultIP, 0, &defaultPool)
-	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "10.50.10.10", 1, &extraPool0)
-	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "10.50.10.11", 2, &extraPool0)
-	createIPAddress(t, kubeClient, machineScope, "net1", "10.100.10.10", 0, &extraPool1)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "203.0.113.50", 1, &extraPool0)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "203.0.113.51", 2, &extraPool0)
+	createIPAddress(t, kubeClient, machineScope, "net1", "203.0.113.100", 0, &extraPool1)
 	createIPAddress(t, kubeClient, machineScope, "net1", "2001:db8::1", 1, &extraPool2)
-	createIPAddress(t, kubeClient, machineScope, "net1", "10.100.10.11", 2, &extraPool1)
+	createIPAddress(t, kubeClient, machineScope, "net1", "203.0.113.101", 2, &extraPool1)
 	createIPAddress(t, kubeClient, machineScope, "net1", "2001:db8::2", 3, &extraPool2)
 
 	requeue, err := reconcileIPAddresses(context.Background(), machineScope)
@@ -430,13 +430,13 @@ func TestReconcileIPAddresses_MachineIPPoolRef(t *testing.T) {
 
 	require.NotNil(t, machineScope.ProxmoxMachine.GetIPAddressesNet(infrav1.DefaultNetworkDevice))
 	require.Equal(t,
-		[]string{defaultIP, "10.50.10.10", "10.50.10.11"},
+		[]string{defaultIP, "203.0.113.50", "203.0.113.51"},
 		machineScope.ProxmoxMachine.GetIPAddressesNet(infrav1.DefaultNetworkDevice).IPv4,
 	)
 	require.Nil(t, machineScope.ProxmoxMachine.GetIPAddressesNet(infrav1.DefaultNetworkDevice).IPv6)
 	require.NotNil(t, machineScope.ProxmoxMachine.GetIPAddressesNet("net1"))
 	require.Equal(t,
-		infrav1.IPAddressesSpec{NetName: "net1", IPv4: []string{"10.100.10.10", "10.100.10.11"}, IPv6: []string{"2001:db8::1", "2001:db8::2"}},
+		infrav1.IPAddressesSpec{NetName: "net1", IPv4: []string{"203.0.113.100", "203.0.113.101"}, IPv6: []string{"2001:db8::1", "2001:db8::2"}},
 		*machineScope.ProxmoxMachine.GetIPAddressesNet("net1"),
 	)
 

--- a/internal/service/vmservice/power_test.go
+++ b/internal/service/vmservice/power_test.go
@@ -30,10 +30,10 @@ func TestReconcilePowerState_SetTaskRef(t *testing.T) {
 	machineScope, proxmoxClient, _ := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForVMPowerUpReason)
 	machineScope.ProxmoxMachine.Status.IPAddresses = []infrav1.IPAddressesSpec{{
 		NetName: string(infrav1.DefaultNetworkDevice),
-		IPv4:    []string{"10.10.10.10"},
+		IPv4:    []string{"192.0.2.10"},
 	}, {
 		NetName: "default",
-		IPv4:    []string{"10.10.10.10"},
+		IPv4:    []string{"192.0.2.10"},
 	}}
 
 	vm := newStoppedVM()

--- a/internal/service/vmservice/vm_test.go
+++ b/internal/service/vmservice/vm_test.go
@@ -56,7 +56,7 @@ func TestReconcileVM_QemuAgentCheckDisabled(t *testing.T) {
 	machineScope, proxmoxClient, _ := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForBootstrapReadyReason)
 	vm := newRunningVM()
 	machineScope.SetVirtualMachineID(int64(vm.VMID))
-	// machineScope.ProxmoxMachine.Status.IPAddresses = map[string]*infrav1.IPAddresses{infrav1.DefaultNetworkDevice: {IPv4: []string{"10.10.10.10"}}}
+	// machineScope.ProxmoxMachine.Status.IPAddresses = map[string]*infrav1.IPAddresses{infrav1.DefaultNetworkDevice: {IPv4: []string{"192.0.2.10"}}}
 	machineScope.ProxmoxMachine.Status.BootstrapDataProvided = ptr.To(true)
 	machineScope.ProxmoxMachine.Status.Initialization.Provisioned = ptr.To(true)
 	machineScope.ProxmoxMachine.Spec.Checks = &infrav1.ProxmoxMachineChecks{
@@ -69,14 +69,14 @@ func TestReconcileVM_QemuAgentCheckDisabled(t *testing.T) {
 	result, err := ReconcileVM(context.Background(), machineScope)
 	require.NoError(t, err)
 	require.Equal(t, infrav1.VirtualMachineStateReady, result.State)
-	// require.Equal(t, "10.10.10.10", machineScope.ProxmoxMachine.Status.Addresses[1].Address)
+	// require.Equal(t, "192.0.2.10", machineScope.ProxmoxMachine.Status.Addresses[1].Address)
 }
 
 func TestReconcileVM_CloudInitCheckDisabled(t *testing.T) {
 	machineScope, proxmoxClient, _ := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForCloudInitReason)
 	vm := newRunningVM()
 	machineScope.SetVirtualMachineID(int64(vm.VMID))
-	// machineScope.ProxmoxMachine.Status.IPAddresses = map[string]*infrav1.IPAddresses{infrav1.DefaultNetworkDevice: {IPv4: []string{"10.10.10.10"}}}
+	// machineScope.ProxmoxMachine.Status.IPAddresses = map[string]*infrav1.IPAddresses{infrav1.DefaultNetworkDevice: {IPv4: []string{"192.0.2.10"}}}
 	machineScope.ProxmoxMachine.Status.BootstrapDataProvided = ptr.To(true)
 	machineScope.ProxmoxMachine.Status.Initialization.Provisioned = ptr.To(true)
 	machineScope.ProxmoxMachine.Spec.Checks = &infrav1.ProxmoxMachineChecks{
@@ -96,7 +96,7 @@ func TestReconcileVM_InitCheckDisabled(t *testing.T) {
 	machineScope, proxmoxClient, _ := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForBootstrapReadyReason)
 	vm := newRunningVM()
 	machineScope.SetVirtualMachineID(int64(vm.VMID))
-	// machineScope.ProxmoxMachine.Status.IPAddresses = map[string]*infrav1.IPAddresses{infrav1.DefaultNetworkDevice: {IPv4: []string{"10.10.10.10"}}}
+	// machineScope.ProxmoxMachine.Status.IPAddresses = map[string]*infrav1.IPAddresses{infrav1.DefaultNetworkDevice: {IPv4: []string{"192.0.2.10"}}}
 	machineScope.ProxmoxMachine.Status.BootstrapDataProvided = ptr.To(true)
 	machineScope.ProxmoxMachine.Status.Initialization.Provisioned = ptr.To(true)
 	machineScope.ProxmoxMachine.Spec.Checks = &infrav1.ProxmoxMachineChecks{
@@ -109,7 +109,7 @@ func TestReconcileVM_InitCheckDisabled(t *testing.T) {
 	result, err := ReconcileVM(context.Background(), machineScope)
 	require.NoError(t, err)
 	require.Equal(t, infrav1.VirtualMachineStateReady, result.State)
-	// require.Equal(t, "10.10.10.10", machineScope.ProxmoxMachine.Status.Addresses[1].Address)
+	// require.Equal(t, "192.0.2.10", machineScope.ProxmoxMachine.Status.Addresses[1].Address)
 }
 
 func TestEnsureVirtualMachine_CreateVM_FullOptions(t *testing.T) {
@@ -539,16 +539,16 @@ func TestReconcileMachineAddresses_IPv4(t *testing.T) {
 	machineScope.SetVirtualMachineID(int64(vm.VMID))
 	machineScope.ProxmoxMachine.Status.IPAddresses = []infrav1.IPAddressesSpec{{
 		NetName: string(infrav1.DefaultNetworkDevice),
-		IPv4:    []string{"10.10.10.10"},
+		IPv4:    []string{"192.0.2.10"},
 	}, {
 		NetName: "default",
-		IPv4:    []string{"10.10.10.10"},
+		IPv4:    []string{"192.0.2.10"},
 	}}
 	machineScope.ProxmoxMachine.Status.BootstrapDataProvided = ptr.To(true)
 
 	require.NoError(t, reconcileMachineAddresses(machineScope))
 	require.Equal(t, machineScope.ProxmoxMachine.Status.Addresses[0].Address, machineScope.ProxmoxMachine.GetName())
-	require.Equal(t, machineScope.ProxmoxMachine.Status.Addresses[1].Address, "10.10.10.10")
+	require.Equal(t, machineScope.ProxmoxMachine.Status.Addresses[1].Address, "192.0.2.10")
 }
 
 func TestReconcileMachineAddresses_IPv6(t *testing.T) {
@@ -590,18 +590,18 @@ func TestReconcileMachineAddresses_DualStack(t *testing.T) {
 	machineScope.SetVirtualMachineID(int64(vm.VMID))
 	machineScope.ProxmoxMachine.Status.IPAddresses = []infrav1.IPAddressesSpec{{
 		NetName: string(infrav1.DefaultNetworkDevice),
-		IPv4:    []string{"10.10.10.10"},
+		IPv4:    []string{"192.0.2.10"},
 		IPv6:    []string{"2001:db8::2"},
 	}, {
 		NetName: "default",
-		IPv4:    []string{"10.10.10.10"},
+		IPv4:    []string{"192.0.2.10"},
 		IPv6:    []string{"2001:db8::2"},
 	}}
 	machineScope.ProxmoxMachine.Status.BootstrapDataProvided = ptr.To(true)
 
 	require.NoError(t, reconcileMachineAddresses(machineScope))
 	require.Equal(t, machineScope.ProxmoxMachine.Status.Addresses[0].Address, machineScope.ProxmoxMachine.GetName())
-	require.Equal(t, machineScope.ProxmoxMachine.Status.Addresses[1].Address, "10.10.10.10")
+	require.Equal(t, machineScope.ProxmoxMachine.Status.Addresses[1].Address, "192.0.2.10")
 	require.Equal(t, machineScope.ProxmoxMachine.Status.Addresses[2].Address, "2001:db8::2")
 }
 
@@ -685,10 +685,10 @@ func TestReconcileVM_CloudInitFailed(t *testing.T) {
 	machineScope.SetVirtualMachineID(int64(vm.VMID))
 	machineScope.ProxmoxMachine.Status.IPAddresses = []infrav1.IPAddressesSpec{{
 		NetName: string(infrav1.DefaultNetworkDevice),
-		IPv4:    []string{"10.10.10.10"},
+		IPv4:    []string{"192.0.2.10"},
 	}, {
 		NetName: "default",
-		IPv4:    []string{"10.10.10.10"},
+		IPv4:    []string{"192.0.2.10"},
 	}}
 	machineScope.ProxmoxMachine.Status.BootstrapDataProvided = ptr.To(true)
 	machineScope.ProxmoxMachine.Status.Initialization.Provisioned = ptr.To(true)
@@ -711,10 +711,10 @@ func TestReconcileVM_CloudInitRunning(t *testing.T) {
 	machineScope.SetVirtualMachineID(int64(vm.VMID))
 	machineScope.ProxmoxMachine.Status.IPAddresses = []infrav1.IPAddressesSpec{{
 		NetName: string(infrav1.DefaultNetworkDevice),
-		IPv4:    []string{"10.10.10.10"},
+		IPv4:    []string{"192.0.2.10"},
 	}, {
 		NetName: "default",
-		IPv4:    []string{"10.10.10.10"},
+		IPv4:    []string{"192.0.2.10"},
 	}}
 	machineScope.ProxmoxMachine.Status.BootstrapDataProvided = ptr.To(true)
 	machineScope.ProxmoxMachine.Status.Initialization.Provisioned = ptr.To(true)

--- a/internal/webhook/proxmoxcluster_webhook_test.go
+++ b/internal/webhook/proxmoxcluster_webhook_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Controller Test", func() {
 			g.Expect(k8sClient.Create(testEnv.GetContext(), &cluster)).To(Succeed())
 
 			g.Expect(k8sClient.Get(testEnv.GetContext(), client.ObjectKeyFromObject(&cluster), &cluster)).To(Succeed())
-			cluster.Spec.ControlPlaneEndpoint.Host = "10.10.10.2"
+			cluster.Spec.ControlPlaneEndpoint.Host = "192.0.2.2"
 
 			g.Expect(k8sClient.Update(testEnv.GetContext(), &cluster)).To(MatchError(ContainSubstring("addresses may not contain the endpoint IP")))
 
@@ -135,17 +135,17 @@ func validProxmoxCluster(name string) infrav1.ProxmoxCluster {
 		},
 		Spec: infrav1.ProxmoxClusterSpec{
 			ControlPlaneEndpoint: infrav1.APIEndpoint{
-				Host: "10.10.10.1",
+				Host: "192.0.2.1",
 				Port: 6443,
 			},
 			IPv4Config: &infrav1.IPConfigSpec{
 				Addresses: []string{
-					"10.10.10.2-10.10.10.10",
+					"192.0.2.2-192.0.2.10",
 				},
-				Gateway: "10.10.10.1",
+				Gateway: "192.0.2.1",
 				Prefix:  24,
 			},
-			DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+			DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 		},
 	}
 }
@@ -153,7 +153,7 @@ func validProxmoxCluster(name string) infrav1.ProxmoxCluster {
 func invalidProxmoxCluster(name string) infrav1.ProxmoxCluster {
 	cl := validProxmoxCluster(name)
 	cl.Spec.ControlPlaneEndpoint = infrav1.APIEndpoint{
-		Host: "10.10.10.2",
+		Host: "192.0.2.2",
 		Port: 6443,
 	}
 

--- a/pkg/cloudinit/network_test.go
+++ b/pkg/cloudinit/network_test.go
@@ -38,15 +38,15 @@ const (
       dhcp4: false
       dhcp6: false
       addresses:
-        - '10.10.10.12/24'
+        - '192.0.2.12/24'
       routes:
         - to: '0.0.0.0/0'
           metric: 100
-          via: "10.10.10.1"
+          via: "192.0.2.1"
       nameservers:
         addresses:
-          - '8.8.8.8'
-          - '8.8.4.4'`
+          - '192.0.2.53'
+          - '198.51.100.53'`
 
 	expectedValidNetworkConfigWithLinkMTU = `network:
   version: 2
@@ -58,15 +58,15 @@ const (
       dhcp4: false
       dhcp6: false
       addresses:
-        - '10.10.10.12/24'
+        - '192.0.2.12/24'
       routes:
         - to: '0.0.0.0/0'
           metric: 100
-          via: "10.10.10.1"
+          via: "192.0.2.1"
       nameservers:
         addresses:
-          - '8.8.8.8'
-          - '8.8.4.4'
+          - '192.0.2.53'
+          - '198.51.100.53'
       mtu: 9001`
 
 	expectedValidNetworkConfigWithoutDNS = `network:
@@ -79,11 +79,11 @@ const (
       dhcp4: false
       dhcp6: false
       addresses:
-        - '10.10.10.12/24'
+        - '192.0.2.12/24'
       routes:
         - to: '0.0.0.0/0'
           metric: 100
-          via: "10.10.10.1"`
+          via: "192.0.2.1"`
 
 	expectedValidNetworkConfigMultipleNics = `network:
   version: 2
@@ -95,30 +95,30 @@ const (
       dhcp4: false
       dhcp6: false
       addresses:
-        - '10.10.10.12/24'
+        - '192.0.2.12/24'
       routes:
         - to: '0.0.0.0/0'
           metric: 100
-          via: "10.10.10.1"
+          via: "192.0.2.1"
       nameservers:
         addresses:
-          - '8.8.8.8'
-          - '8.8.4.4'
+          - '192.0.2.53'
+          - '198.51.100.53'
     eth1:
       match:
         macaddress: b4:87:18:bf:a3:60
       dhcp4: false
       dhcp6: false
       addresses:
-        - '196.168.100.124/24'
+        - '198.51.100.124/24'
       routes:
         - to: '0.0.0.0/0'
           metric: 200
-          via: "196.168.100.254"
+          via: "198.51.100.254"
       nameservers:
         addresses:
-          - '8.8.8.8'
-          - '8.8.4.4'`
+          - '192.0.2.53'
+          - '198.51.100.53'`
 
 	expectedValidNetworkConfigDualStack = `network:
   version: 2
@@ -130,19 +130,19 @@ const (
       dhcp4: false
       dhcp6: false
       addresses:
-        - '10.10.10.12/24'
+        - '192.0.2.12/24'
         - '2001:db8::1/64'
       routes:
         - to: '0.0.0.0/0'
           metric: 100
-          via: "10.10.10.1"
+          via: "192.0.2.1"
         - to: '::/0'
           metric: 100
           via: "2001:db8::1"
       nameservers:
         addresses:
-          - '8.8.8.8'
-          - '8.8.4.4'`
+          - '192.0.2.53'
+          - '198.51.100.53'`
 
 	expectedValidNetworkConfigIPv6 = `network:
   version: 2
@@ -161,8 +161,8 @@ const (
           via: "2001:db8::1"
       nameservers:
         addresses:
-          - '8.8.8.8'
-          - '8.8.4.4'`
+          - '192.0.2.53'
+          - '198.51.100.53'`
 
 	expectedValidNetworkConfigDHCP = `network:
   version: 2
@@ -175,8 +175,8 @@ const (
       dhcp6: true
       nameservers:
         addresses:
-          - '8.8.8.8'
-          - '8.8.4.4'`
+          - '192.0.2.53'
+          - '198.51.100.53'`
 
 	expectedValidNetworkConfigDHCP4 = `network:
   version: 2
@@ -189,8 +189,8 @@ const (
       dhcp6: false
       nameservers:
         addresses:
-          - '8.8.8.8'
-          - '8.8.4.4'`
+          - '192.0.2.53'
+          - '198.51.100.53'`
 
 	expectedValidNetworkConfigDHCP6 = `network:
   version: 2
@@ -203,8 +203,8 @@ const (
       dhcp6: true
       nameservers:
         addresses:
-          - '8.8.8.8'
-          - '8.8.4.4'`
+          - '192.0.2.53'
+          - '198.51.100.53'`
 
 	expectedValidNetworkConfigWithDHCP = `network:
   version: 2
@@ -216,15 +216,15 @@ const (
       dhcp4: false
       dhcp6: true
       addresses:
-        - '10.10.10.12/24'
+        - '192.0.2.12/24'
       routes:
         - to: '0.0.0.0/0'
           metric: 100
-          via: "10.10.10.1"
+          via: "192.0.2.1"
       nameservers:
         addresses:
-          - '8.8.8.8'
-          - '8.8.4.4'`
+          - '192.0.2.53'
+          - '198.51.100.53'`
 
 	expectedValidNetworkConfigIPAndDHCP = `network:
   version: 2
@@ -236,15 +236,15 @@ const (
       dhcp4: true
       dhcp6: false
       addresses:
-        - '10.10.10.12/24'
+        - '192.0.2.12/24'
       routes:
         - to: '0.0.0.0/0'
           metric: 100
-          via: "10.10.10.1"
+          via: "192.0.2.1"
       nameservers:
         addresses:
-          - '8.8.8.8'
-          - '8.8.4.4'`
+          - '192.0.2.53'
+          - '198.51.100.53'`
 
 	expectedValidNetworkConfigWithRoutes = `network:
   version: 2
@@ -256,28 +256,28 @@ const (
       dhcp4: false
       dhcp6: true
       addresses:
-        - '10.10.10.12/24'
+        - '192.0.2.12/24'
       routes:
         - to: '0.0.0.0/0'
           metric: 100
-          via: "10.10.10.1"
+          via: "192.0.2.1"
       nameservers:
         addresses:
-          - '8.8.8.8'
-          - '8.8.4.4'
+          - '192.0.2.53'
+          - '198.51.100.53'
     eth1:
       match:
         macaddress: 92:60:a0:5b:22:c3
       dhcp4: false
       dhcp6: false
       addresses:
-        - '10.10.11.12/24'
+        - '198.51.100.12/24'
       routes:
         - to: '0.0.0.0/0'
           metric: 200
-          via: "10.10.11.1"
-        - { "to": "172.16.24.1/24",  "via": "10.10.10.254",  "metric": 50, }
-        - { "to": "2002::/64",  "via": "2001:db8::1", }`
+          via: "198.51.100.1"
+        - { "to": "203.0.113.24/24",  "via": "192.0.2.254",  "metric": 50, }
+        - { "to": "2001:db8:1::/64",  "via": "2001:db8::1", }`
 
 	expectedValidNetworkConfigWithFIBRules = `network:
   version: 2
@@ -289,28 +289,28 @@ const (
       dhcp4: false
       dhcp6: true
       addresses:
-        - '10.10.10.12/24'
+        - '192.0.2.12/24'
       routes:
         - to: '0.0.0.0/0'
           metric: 100
-          via: "10.10.10.1"
+          via: "192.0.2.1"
       nameservers:
         addresses:
-          - '8.8.8.8'
-          - '8.8.4.4'
+          - '192.0.2.53'
+          - '198.51.100.53'
     eth1:
       match:
         macaddress: 92:60:a0:5b:22:c3
       dhcp4: false
       dhcp6: false
       addresses:
-        - '10.10.11.12/24'
+        - '198.51.100.12/24'
       routes:
         - to: '0.0.0.0/0'
           metric: 200
-          via: "10.10.11.1"
+          via: "198.51.100.1"
       routing-policy:
-        - { "to": "0.0.0.0/0",  "from": "192.168.178.1/24",  "priority": 999,  "table": 100, }`
+        - { "to": "0.0.0.0/0",  "from": "198.51.100.1/24",  "priority": 999,  "table": 100, }`
 
 	expectedValidNetworkConfigMultipleNicsVRF = `network:
   version: 2
@@ -322,38 +322,38 @@ const (
       dhcp4: false
       dhcp6: false
       addresses:
-        - '10.10.10.12/24'
+        - '192.0.2.12/24'
       routes:
         - to: '0.0.0.0/0'
           metric: 100
-          via: "10.10.10.1"
+          via: "192.0.2.1"
       nameservers:
         addresses:
-          - '8.8.8.8'
-          - '8.8.4.4'
+          - '192.0.2.53'
+          - '198.51.100.53'
     eth1:
       match:
         macaddress: b4:87:18:bf:a3:60
       dhcp4: false
       dhcp6: false
       addresses:
-        - '196.168.100.124/24'
+        - '198.51.100.124/24'
       routes:
         - to: '0.0.0.0/0'
           metric: 200
-          via: "196.168.100.254"
+          via: "198.51.100.254"
       nameservers:
         addresses:
-          - '8.8.8.8'
-          - '8.8.4.4'
+          - '192.0.2.53'
+          - '198.51.100.53'
   vrfs:
     vrf-blue:
       table: 500
       routes:
-        - { "to": "default",  "via": "192.168.178.1",  "metric": 100,  "table": 100, }
-        - { "to": "10.10.10.0/24",  "via": "192.168.178.254",  "metric": 100, }
+        - { "to": "default",  "via": "198.51.100.1",  "metric": 100,  "table": 100, }
+        - { "to": "192.0.2.0/24",  "via": "198.51.100.254",  "metric": 100, }
       routing-policy:
-        - { "to": "0.0.0.0/0",  "from": "192.168.178.1/24",  "priority": 999,  "table": 100, }
+        - { "to": "0.0.0.0/0",  "from": "198.51.100.1/24",  "priority": 999,  "table": 100, }
       interfaces:
         - 'eth0'
         - 'eth1'`
@@ -368,44 +368,44 @@ const (
       dhcp4: false
       dhcp6: false
       addresses:
-        - '10.10.10.12/24'
+        - '192.0.2.12/24'
       routes:
         - to: '0.0.0.0/0'
           metric: 100
-          via: "10.10.10.1"
+          via: "192.0.2.1"
       nameservers:
         addresses:
-          - '8.8.8.8'
-          - '8.8.4.4'
+          - '192.0.2.53'
+          - '198.51.100.53'
     eth1:
       match:
         macaddress: b4:87:18:bf:a3:60
       dhcp4: false
       dhcp6: false
       addresses:
-        - '196.168.100.124/24'
+        - '198.51.100.124/24'
       routes:
         - to: '0.0.0.0/0'
           metric: 200
-          via: "196.168.100.254"
+          via: "198.51.100.254"
       nameservers:
         addresses:
-          - '8.8.8.8'
-          - '8.8.4.4'
+          - '192.0.2.53'
+          - '198.51.100.53'
   vrfs:
     vrf-blue:
       table: 500
       routes:
-        - { "to": "default",  "via": "192.168.178.1",  "metric": 100,  "table": 100, }
-        - { "to": "10.10.10.0/24",  "via": "192.168.178.254",  "metric": 100, }
+        - { "to": "default",  "via": "198.51.100.1",  "metric": 100,  "table": 100, }
+        - { "to": "192.0.2.0/24",  "via": "198.51.100.254",  "metric": 100, }
       routing-policy:
-        - { "to": "0.0.0.0/0",  "from": "192.168.178.1/24",  "priority": 999,  "table": 100, }
+        - { "to": "0.0.0.0/0",  "from": "198.51.100.1/24",  "priority": 999,  "table": 100, }
       interfaces:
         - 'eth0'
     vrf-red:
       table: 501
       routing-policy:
-        - { "to": "0.0.0.0/0",  "from": "192.168.100.0/24",  "priority": 999,  "table": 101, }
+        - { "to": "0.0.0.0/0",  "from": "198.51.100.0/24",  "priority": 999,  "table": 101, }
       interfaces:
         - 'eth1'`
 
@@ -419,15 +419,15 @@ const (
       dhcp4: false
       dhcp6: false
       addresses:
-        - '10.10.10.12/24'
+        - '192.0.2.12/24'
       routes:
         - to: '0.0.0.0/0'
           metric: 100
-          via: "10.10.10.1"
+          via: "192.0.2.1"
       nameservers:
         addresses:
-          - '8.8.8.8'
-          - '8.8.4.4'
+          - '192.0.2.53'
+          - '198.51.100.53'
     asdf !.tag:
       match:
         macaddress: b4:87:18:bf:a3:60
@@ -448,7 +448,7 @@ const (
     vrf-blue:
       table: 500
       routes:
-        - { "to": "::",  "via": "192.168.178.1", }
+        - { "to": "::",  "via": "198.51.100.1", }
       interfaces:
         - 'on: [NO, "False"]'`
 
@@ -460,7 +460,7 @@ const (
     vrf-blue:
       table: 500
       routing-policy:
-        - { "from": "10.10.0.0/16", }`
+        - { "from": "192.0.2.0/24", }`
 )
 
 func TestNetworkConfig_Render(t *testing.T) {
@@ -487,11 +487,11 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Name:       "eth0",
 						MacAddress: "92:60:a0:5b:22:c2",
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("10.10.10.12/24"),
-							Gateway:   "10.10.10.1",
+							IPAddress: netip.MustParsePrefix("192.0.2.12/24"),
+							Gateway:   "192.0.2.1",
 							Metric:    ptr.To(int32(100)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					},
 				},
 			},
@@ -509,11 +509,11 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Name:       "eth0",
 						MacAddress: "92:60:a0:5b:22:c2",
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("10.10.10.12/24"),
-							Gateway:   "10.10.10.1",
+							IPAddress: netip.MustParsePrefix("192.0.2.12/24"),
+							Gateway:   "192.0.2.1",
 							Metric:    ptr.To(int32(100)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 						LinkMTU:    ptr.To(int32(9001)),
 					},
 				},
@@ -533,11 +533,11 @@ func TestNetworkConfig_Render(t *testing.T) {
 						MacAddress: "92:60:a0:5b:22:c2",
 						DHCP6:      true,
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("10.10.10.12/24"),
-							Gateway:   "10.10.10.1",
+							IPAddress: netip.MustParsePrefix("192.0.2.12/24"),
+							Gateway:   "192.0.2.1",
 							Metric:    ptr.To(int32(100)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					},
 				},
 			},
@@ -556,11 +556,11 @@ func TestNetworkConfig_Render(t *testing.T) {
 						MacAddress: "92:60:a0:5b:22:c2",
 						DHCP4:      true,
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("10.10.10.12/24"),
-							Gateway:   "10.10.10.1",
+							IPAddress: netip.MustParsePrefix("192.0.2.12/24"),
+							Gateway:   "192.0.2.1",
 							Metric:    ptr.To(int32(100)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					},
 				},
 			},
@@ -579,26 +579,26 @@ func TestNetworkConfig_Render(t *testing.T) {
 						MacAddress: "92:60:a0:5b:22:c2",
 						DHCP6:      true,
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("10.10.10.12/24"),
-							Gateway:   "10.10.10.1",
+							IPAddress: netip.MustParsePrefix("192.0.2.12/24"),
+							Gateway:   "192.0.2.1",
 							Metric:    ptr.To(int32(100)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					}, {
 						Type:       "ethernet",
 						Name:       "eth1",
 						MacAddress: "92:60:a0:5b:22:c3",
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("10.10.11.12/24"),
-							Gateway:   "10.10.11.1",
+							IPAddress: netip.MustParsePrefix("198.51.100.12/24"),
+							Gateway:   "198.51.100.1",
 							Metric:    ptr.To(int32(200)),
 						}},
 						Routes: []types.RoutingData{{
-							To:     ptr.To("172.16.24.1/24"),
+							To:     ptr.To("203.0.113.24/24"),
 							Metric: ptr.To(int32(50)),
-							Via:    ptr.To("10.10.10.254"),
+							Via:    ptr.To("192.0.2.254"),
 						}, {
-							To:  ptr.To("2002::/64"),
+							To:  ptr.To("2001:db8:1::/64"),
 							Via: ptr.To("2001:db8::1"),
 						},
 						},
@@ -620,23 +620,23 @@ func TestNetworkConfig_Render(t *testing.T) {
 						MacAddress: "92:60:a0:5b:22:c2",
 						DHCP6:      true,
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("10.10.10.12/24"),
-							Gateway:   "10.10.10.1",
+							IPAddress: netip.MustParsePrefix("192.0.2.12/24"),
+							Gateway:   "192.0.2.1",
 							Metric:    ptr.To(int32(100)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					}, {
 						Type: "ethernet",
 						Name: "eth1",
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("10.10.11.12/24"),
-							Gateway:   "10.10.11.1",
+							IPAddress: netip.MustParsePrefix("198.51.100.12/24"),
+							Gateway:   "198.51.100.1",
 							Metric:    ptr.To(int32(200)),
 						}},
 						MacAddress: "92:60:a0:5b:22:c3",
 						FIBRules: []types.FIBRuleData{{
 							To:       ptr.To("0.0.0.0/0"),
-							From:     ptr.To("192.168.178.1/24"),
+							From:     ptr.To("198.51.100.1/24"),
 							Priority: ptr.To(int64(999)),
 							Table:    ptr.To(int32(100)),
 						},
@@ -658,10 +658,10 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Name:       "eth0",
 						MacAddress: "92:60:a0:5b:22:c2",
 						IPConfigs: []types.IPConfig{{
-							Gateway: "10.10.10.1",
+							Gateway: "192.0.2.1",
 							Metric:  ptr.To(int32(100)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					},
 				},
 			},
@@ -679,10 +679,10 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Name:       "eth0",
 						MacAddress: "92:60:a0:5b:22:c2",
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("10.10.10.12/24"),
+							IPAddress: netip.MustParsePrefix("192.0.2.12/24"),
 							Metric:    ptr.To(int32(100)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					},
 				},
 			},
@@ -699,11 +699,11 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Type: "ethernet",
 						Name: "eth0",
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("10.10.10.11/24"),
-							Gateway:   "10.10.10.1",
+							IPAddress: netip.MustParsePrefix("192.0.2.11/24"),
+							Gateway:   "192.0.2.1",
 							Metric:    ptr.To(int32(100)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					},
 				},
 			},
@@ -721,21 +721,21 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Name:       "eth0",
 						MacAddress: "92:60:a0:5b:22:c2",
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("10.10.10.11/24"),
-							Gateway:   "10.10.10.1",
+							IPAddress: netip.MustParsePrefix("192.0.2.11/24"),
+							Gateway:   "192.0.2.1",
 							Metric:    ptr.To(int32(100)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					}, {
 						Type:       "ethernet",
 						Name:       "eth1",
 						MacAddress: "92:60:a0:5b:22:c5",
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("10.10.11.11/24"),
-							Gateway:   "10.10.11.254",
+							IPAddress: netip.MustParsePrefix("198.51.100.11/24"),
+							Gateway:   "198.51.100.254",
 							Metric:    ptr.To(int32(100)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					},
 				},
 			},
@@ -753,8 +753,8 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Name:       "eth0",
 						MacAddress: "92:60:a0:5b:22:c2",
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("10.10.10.12/24"),
-							Gateway:   "10.10.10.1",
+							IPAddress: netip.MustParsePrefix("192.0.2.12/24"),
+							Gateway:   "192.0.2.1",
 							Metric:    ptr.To(int32(100)),
 						}},
 					},
@@ -774,22 +774,22 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Name:       "eth0",
 						MacAddress: "92:60:a0:5b:22:c2",
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("10.10.10.12/24"),
-							Gateway:   "10.10.10.1",
+							IPAddress: netip.MustParsePrefix("192.0.2.12/24"),
+							Gateway:   "192.0.2.1",
 							Metric:    ptr.To(int32(100)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					},
 					{
 						Type:       "ethernet",
 						Name:       "eth1",
 						MacAddress: "b4:87:18:bf:a3:60",
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("196.168.100.124/24"),
-							Gateway:   "196.168.100.254",
+							IPAddress: netip.MustParsePrefix("198.51.100.124/24"),
+							Gateway:   "198.51.100.254",
 							Metric:    ptr.To(int32(200)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					},
 				},
 			},
@@ -817,15 +817,15 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Name:       "eth0",
 						MacAddress: "92:60:a0:5b:22:c2",
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("10.10.10.12/24"),
-							Gateway:   "10.10.10.1",
+							IPAddress: netip.MustParsePrefix("192.0.2.12/24"),
+							Gateway:   "192.0.2.1",
 							Metric:    ptr.To(int32(100)),
 						}, {
 							IPAddress: netip.MustParsePrefix("2001:db8::1/64"),
 							Gateway:   "2001:db8::1",
 							Metric:    ptr.To(int32(100)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					},
 				},
 			},
@@ -847,7 +847,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 							Gateway:   "2001:db8::1",
 							Metric:    ptr.To(int32(100)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					},
 				},
 			},
@@ -866,7 +866,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 						MacAddress: "92:60:a0:5b:22:c2",
 						DHCP4:      true,
 						DHCP6:      true,
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					},
 				},
 			},
@@ -885,7 +885,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 						MacAddress: "92:60:a0:5b:22:c2",
 						DHCP4:      true,
 						DHCP6:      false,
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					},
 				},
 			},
@@ -904,7 +904,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 						MacAddress: "92:60:a0:5b:22:c2",
 						DHCP4:      false,
 						DHCP6:      true,
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					},
 				},
 			},
@@ -922,22 +922,22 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Name:       "eth0",
 						MacAddress: "92:60:a0:5b:22:c2",
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("10.10.10.12/24"),
-							Gateway:   "10.10.10.1",
+							IPAddress: netip.MustParsePrefix("192.0.2.12/24"),
+							Gateway:   "192.0.2.1",
 							Metric:    ptr.To(int32(100)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					},
 					{
 						Type:       "ethernet",
 						Name:       "eth1",
 						MacAddress: "b4:87:18:bf:a3:60",
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("196.168.100.124/24"),
-							Gateway:   "196.168.100.254",
+							IPAddress: netip.MustParsePrefix("198.51.100.124/24"),
+							Gateway:   "198.51.100.254",
 							Metric:    ptr.To(int32(200)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					},
 					{
 						Type:       "vrf",
@@ -946,17 +946,17 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Interfaces: []string{"eth0", "eth1"},
 						Routes: []types.RoutingData{{
 							To:     ptr.To("default"),
-							Via:    ptr.To("192.168.178.1"),
+							Via:    ptr.To("198.51.100.1"),
 							Metric: ptr.To(int32(100)),
 							Table:  ptr.To(int32(100)),
 						}, {
-							To:     ptr.To("10.10.10.0/24"),
-							Via:    ptr.To("192.168.178.254"),
+							To:     ptr.To("192.0.2.0/24"),
+							Via:    ptr.To("198.51.100.254"),
 							Metric: ptr.To(int32(100)),
 						}},
 						FIBRules: []types.FIBRuleData{{
 							To:       ptr.To("0.0.0.0/0"),
-							From:     ptr.To("192.168.178.1/24"),
+							From:     ptr.To("198.51.100.1/24"),
 							Priority: ptr.To(int64(999)),
 							Table:    ptr.To(int32(100)),
 						}},
@@ -977,22 +977,22 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Name:       "eth0",
 						MacAddress: "92:60:a0:5b:22:c2",
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("10.10.10.12/24"),
-							Gateway:   "10.10.10.1",
+							IPAddress: netip.MustParsePrefix("192.0.2.12/24"),
+							Gateway:   "192.0.2.1",
 							Metric:    ptr.To(int32(100)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					},
 					{
 						Type:       "ethernet",
 						Name:       "eth1",
 						MacAddress: "b4:87:18:bf:a3:60",
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("196.168.100.124/24"),
-							Gateway:   "196.168.100.254",
+							IPAddress: netip.MustParsePrefix("198.51.100.124/24"),
+							Gateway:   "198.51.100.254",
 							Metric:    ptr.To(int32(200)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					},
 					{
 						Type:       "vrf",
@@ -1001,17 +1001,17 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Interfaces: []string{"eth0"},
 						Routes: []types.RoutingData{{
 							To:     ptr.To("default"),
-							Via:    ptr.To("192.168.178.1"),
+							Via:    ptr.To("198.51.100.1"),
 							Metric: ptr.To(int32(100)),
 							Table:  ptr.To(int32(100)),
 						}, {
-							To:     ptr.To("10.10.10.0/24"),
-							Via:    ptr.To("192.168.178.254"),
+							To:     ptr.To("192.0.2.0/24"),
+							Via:    ptr.To("198.51.100.254"),
 							Metric: ptr.To(int32(100)),
 						}},
 						FIBRules: []types.FIBRuleData{{
 							To:       ptr.To("0.0.0.0/0"),
-							From:     ptr.To("192.168.178.1/24"),
+							From:     ptr.To("198.51.100.1/24"),
 							Priority: ptr.To(int64(999)),
 							Table:    ptr.To(int32(100)),
 						}},
@@ -1023,7 +1023,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Interfaces: []string{"eth1"},
 						FIBRules: []types.FIBRuleData{{
 							To:       ptr.To("0.0.0.0/0"),
-							From:     ptr.To("192.168.100.0/24"),
+							From:     ptr.To("198.51.100.0/24"),
 							Priority: ptr.To(int64(999)),
 							Table:    ptr.To(int32(101)),
 						}},
@@ -1044,7 +1044,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Name:  "vrf-blue",
 						Table: int32(500),
 						FIBRules: []types.FIBRuleData{{
-							From: ptr.To("10.10.0.0/16"),
+							From: ptr.To("192.0.2.0/24"),
 						}},
 					},
 				},
@@ -1083,11 +1083,11 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Name:       "NO &anchor",
 						MacAddress: "92:60:a0:5b:22:c2",
 						IPConfigs: []types.IPConfig{{
-							IPAddress: netip.MustParsePrefix("10.10.10.12/24"),
-							Gateway:   "10.10.10.1",
+							IPAddress: netip.MustParsePrefix("192.0.2.12/24"),
+							Gateway:   "192.0.2.1",
 							Metric:    ptr.To(int32(100)),
 						}},
-						DNSServers: []string{"8.8.8.8", "8.8.4.4"},
+						DNSServers: []string{"192.0.2.53", "198.51.100.53"},
 					},
 					{
 						Type:       "ethernet",
@@ -1107,7 +1107,7 @@ func TestNetworkConfig_Render(t *testing.T) {
 						Interfaces: []string{"on: [NO, \"False\"]"},
 						Routes: []types.RoutingData{{
 							To:  ptr.To("::"),
-							Via: ptr.To("192.168.178.1"),
+							Via: ptr.To("198.51.100.1"),
 						}},
 					},
 				}},

--- a/pkg/convert/capi_test.go
+++ b/pkg/convert/capi_test.go
@@ -97,7 +97,7 @@ spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 10.0.0.0/16
+        - 203.0.113.0/24
 `
 	id := ResourceID{APIVersion: "cluster.x-k8s.io/v1beta1", Kind: "Cluster"}
 	out, err := ConvertCAPI([]byte(input), id, testfile, 2, noopWarn, nil)

--- a/pkg/convert/capmox_test.go
+++ b/pkg/convert/capmox_test.go
@@ -34,7 +34,7 @@ metadata:
   name: test
 spec:
   controlPlaneEndpoint:
-    host: 10.0.0.1
+    host: 203.0.113.1
     port: 6443
 `
 			id := ResourceID{
@@ -173,7 +173,7 @@ metadata:
   # a comment
 spec:
   controlPlaneEndpoint:
-    host: 10.0.0.1
+    host: 203.0.113.1
     port: 6443
 `
 	id := ResourceID{
@@ -201,7 +201,7 @@ metadata:
   name: test
 spec:
   controlPlaneEndpoint:
-    host: 10.0.0.1
+    host: 203.0.113.1
     port: 6443
   unknownExtraField: value
 `

--- a/pkg/convert/convert_test.go
+++ b/pkg/convert/convert_test.go
@@ -42,7 +42,7 @@ metadata:
   name: test
 spec:
   controlPlaneEndpoint:
-    host: 10.0.0.1
+    host: 203.0.113.1
     port: 6443
 `
 
@@ -200,7 +200,7 @@ metadata:
   name: test
 spec:
   controlPlaneEndpoint:
-    host: 10.0.0.1
+    host: 203.0.113.1
     port: 6443
 `
 
@@ -397,7 +397,7 @@ metadata:
   name: test
 spec:
   controlPlaneEndpoint:
-    host: 10.0.0.1
+    host: 203.0.113.1
     port: 6443
 `
 			out, err := Convert([]byte(input), Options{

--- a/pkg/convert/defaults_test.go
+++ b/pkg/convert/defaults_test.go
@@ -28,7 +28,7 @@ func TestPruneDefaults_NullFields(t *testing.T) {
 kind: ProxmoxCluster
 spec:
   controlPlaneEndpoint:
-    host: 10.0.0.1
+    host: 203.0.113.1
     port: 6443
   zoneConfigs: null
   externalManagedControlPlane: null

--- a/pkg/ignition/enrich_test.go
+++ b/pkg/ignition/enrich_test.go
@@ -80,10 +80,10 @@ func TestEnricher_Enrich(t *testing.T) {
 			{
 				Name: "eth0",
 				IPConfigs: []types.IPConfig{
-					{IPAddress: netip.MustParsePrefix("10.1.1.9/24"), Gateway: "10.1.1.1", Default: true},
+					{IPAddress: netip.MustParsePrefix("192.0.2.9/24"), Gateway: "192.0.2.1", Default: true},
 					{IPAddress: netip.MustParsePrefix("2001:db8::1/64"), Gateway: "2001:db8::1", Default: true},
 				},
-				DNSServers: []string{"10.1.1.1"},
+				DNSServers: []string{"192.0.2.1"},
 			},
 		},
 	}
@@ -107,7 +107,7 @@ func TestEnricher_Enrich(t *testing.T) {
 			}
 		}
 	}
-	require.Contains(t, environment, "CUSTOM_PRIVATE_IPV4=10.1.1.9")
+	require.Contains(t, environment, "CUSTOM_PRIVATE_IPV4=192.0.2.9")
 	require.Contains(t, environment, "CUSTOM_PRIVATE_IPV6=2001:db8::1")
 
 	cfg, _, err := ignition.Parse(userdata)

--- a/pkg/ignition/network_test.go
+++ b/pkg/ignition/network_test.go
@@ -32,12 +32,12 @@ var (
 		"00-eth0.network": []byte(`[Match]
 MACAddress=E2:B8:FE:E7:50:75
 [Network]
-DNS=10.0.1.1
+DNS=198.51.100.1
 [Address]
-Address=10.0.0.98/25
+Address=203.0.113.98/25
 [Route]
 Destination=0.0.0.0/0
-Gateway=10.0.0.1
+Gateway=203.0.113.1
 Metric=100
 [Address]
 Address=2001:db8:1::10/64
@@ -49,16 +49,16 @@ Metric=100
 		"01-eth1.network": []byte(`[Match]
 MACAddress=E2:8E:95:1F:EB:36
 [Network]
-DNS=10.0.1.1
+DNS=198.51.100.1
 [Address]
-Address=10.0.1.84/25
+Address=198.51.100.84/25
 [Route]
 Destination=0.0.0.0/0
-Gateway=10.0.1.1
+Gateway=198.51.100.1
 Metric=200
 [RoutingPolicyRule]
-To=8.7.6.5/32
-From=1.1.1.1/32
+To=198.51.100.87/32
+From=192.0.2.11/32
 Priority=100
 Table=500
 `),
@@ -74,12 +74,12 @@ Table=644
 		"00-eth0.network": []byte(`[Match]
 MACAddress=E2:B8:FE:E7:50:75
 [Network]
-DNS=10.0.1.1
+DNS=198.51.100.1
 [Address]
-Address=10.0.0.98/25
+Address=203.0.113.98/25
 [Route]
 Destination=0.0.0.0/0
-Gateway=10.0.0.1
+Gateway=203.0.113.1
 Metric=100
 [Address]
 Address=2001:db8:1::10/64
@@ -92,24 +92,24 @@ Metric=100
 MACAddress=E2:8E:95:1F:EB:36
 [Network]
 VRF=vrf0
-DNS=10.0.1.1
+DNS=198.51.100.1
 [Address]
-Address=10.0.1.84/25
+Address=198.51.100.84/25
 [Route]
 Destination=0.0.0.0/0
-Gateway=10.0.1.1
+Gateway=198.51.100.1
 Metric=200
 `),
 
 		"02-vrf2.network": []byte(`[Match]
 Name=vrf0
 [Route]
-Destination=3.4.5.6
-Gateway=10.0.1.1
+Destination=203.0.113.34
+Gateway=198.51.100.1
 Metric=100
 [RoutingPolicyRule]
-To=8.7.6.5/32
-From=1.1.1.1/32
+To=198.51.100.87/32
+From=192.0.2.11/32
 Priority=100
 Table=644
 `),
@@ -140,24 +140,24 @@ func TestRenderNetworkConfigData(t *testing.T) {
 						Name:       "eth0",
 						MacAddress: "E2:B8:FE:E7:50:75",
 						IPConfigs: []types.IPConfig{
-							{IPAddress: netip.MustParsePrefix("10.0.0.98/25"), Gateway: "10.0.0.1", Metric: ptr.To(int32(100))},
+							{IPAddress: netip.MustParsePrefix("203.0.113.98/25"), Gateway: "203.0.113.1", Metric: ptr.To(int32(100))},
 							{IPAddress: netip.MustParsePrefix("2001:db8:1::10/64"), Gateway: "2001:db8:1::1", Metric: ptr.To(int32(100))},
 						},
 						ProxName:   infrav1.DefaultNetworkDevice,
-						DNSServers: []string{"10.0.1.1"},
+						DNSServers: []string{"198.51.100.1"},
 					},
 					{
 						Type:       "ethernet",
 						Name:       "eth1",
 						MacAddress: "E2:8E:95:1F:EB:36",
 						IPConfigs: []types.IPConfig{
-							{IPAddress: netip.MustParsePrefix("10.0.1.84/25"), Gateway: "10.0.1.1", Metric: ptr.To(int32(200))},
+							{IPAddress: netip.MustParsePrefix("198.51.100.84/25"), Gateway: "198.51.100.1", Metric: ptr.To(int32(200))},
 						},
 						ProxName:   "net1",
-						DNSServers: []string{"10.0.1.1"},
+						DNSServers: []string{"198.51.100.1"},
 						FIBRules: []types.FIBRuleData{{
-							To:       ptr.To("8.7.6.5/32"),
-							From:     ptr.To("1.1.1.1/32"),
+							To:       ptr.To("198.51.100.87/32"),
+							From:     ptr.To("192.0.2.11/32"),
 							Priority: ptr.To(int64(100)),
 							Table:    ptr.To(int32(500)),
 						}},
@@ -178,21 +178,21 @@ func TestRenderNetworkConfigData(t *testing.T) {
 						Name:       "eth0",
 						MacAddress: "E2:B8:FE:E7:50:75",
 						IPConfigs: []types.IPConfig{
-							{IPAddress: netip.MustParsePrefix("10.0.0.98/25"), Gateway: "10.0.0.1", Metric: ptr.To(int32(100))},
+							{IPAddress: netip.MustParsePrefix("203.0.113.98/25"), Gateway: "203.0.113.1", Metric: ptr.To(int32(100))},
 							{IPAddress: netip.MustParsePrefix("2001:db8:1::10/64"), Gateway: "2001:db8:1::1", Metric: ptr.To(int32(100))},
 						},
 						ProxName:   infrav1.DefaultNetworkDevice,
-						DNSServers: []string{"10.0.1.1"},
+						DNSServers: []string{"198.51.100.1"},
 					},
 					{
 						Type:       "ethernet",
 						Name:       "eth1",
 						MacAddress: "E2:8E:95:1F:EB:36",
 						IPConfigs: []types.IPConfig{
-							{IPAddress: netip.MustParsePrefix("10.0.1.84/25"), Gateway: "10.0.1.1", Metric: ptr.To(int32(200))},
+							{IPAddress: netip.MustParsePrefix("198.51.100.84/25"), Gateway: "198.51.100.1", Metric: ptr.To(int32(200))},
 						},
 						ProxName:   "net1",
-						DNSServers: []string{"10.0.1.1"},
+						DNSServers: []string{"198.51.100.1"},
 					},
 					{
 						Type:       "vrf",
@@ -201,13 +201,13 @@ func TestRenderNetworkConfigData(t *testing.T) {
 						Table:      644,
 						Interfaces: []string{"eth1"},
 						Routes: []types.RoutingData{{
-							To:     ptr.To("3.4.5.6"),
-							Via:    ptr.To("10.0.1.1"),
+							To:     ptr.To("203.0.113.34"),
+							Via:    ptr.To("198.51.100.1"),
 							Metric: ptr.To(int32(100)),
 						}},
 						FIBRules: []types.FIBRuleData{{
-							To:       ptr.To("8.7.6.5/32"),
-							From:     ptr.To("1.1.1.1/32"),
+							To:       ptr.To("198.51.100.87/32"),
+							From:     ptr.To("192.0.2.11/32"),
 							Priority: ptr.To(int64(100)),
 						}},
 					},

--- a/pkg/kubernetes/ipam/ipam_test.go
+++ b/pkg/kubernetes/ipam/ipam_test.go
@@ -109,7 +109,7 @@ func (s *IPAMTestSuite) Test_CreateOrUpdateInClusterIPPool() {
 	s.Equal(ipamConfig.Gateway, pool.Spec.Gateway)
 	s.Equal(pool.Spec.Prefix, 24)
 
-	s.cluster.Spec.IPv4Config.Gateway = "10.11.0.0"
+	s.cluster.Spec.IPv4Config.Gateway = "198.51.100.1"
 	s.cluster.Spec.IPv4Config.Metric = ptr.To(int32(123))
 
 	ipamConfig = s.cluster.Spec.IPv4Config
@@ -236,9 +236,9 @@ func (s *IPAMTestSuite) Test_GetGlobalInClusterIPPool() {
 			Name: "test-global-cluster-icip",
 		},
 		Spec: ipamicv1.InClusterIPPoolSpec{
-			Addresses: []string{"10.10.10.1-10.10.10.100"},
+			Addresses: []string{"192.0.2.1-192.0.2.100"},
 			Prefix:    24,
-			Gateway:   "10.10.10.254",
+			Gateway:   "192.0.2.254",
 		},
 	}))
 
@@ -289,7 +289,7 @@ func (s *IPAMTestSuite) Test_GetIPPoolAnnotations() {
 	s.NoError(err)
 	s.NotNil(ip)
 	s.NotEmpty(ip.Spec.Address)
-	s.Equal(ip.Spec.Address, "10.10.10.11")
+	s.Equal(ip.Spec.Address, "192.0.2.11")
 
 	annotations, err := s.helper.GetIPPoolAnnotations(s.ctx, ip)
 	s.NotNil(annotations)
@@ -303,9 +303,9 @@ func (s *IPAMTestSuite) Test_GetIPPoolAnnotations() {
 			},
 		},
 		Spec: ipamicv1.InClusterIPPoolSpec{
-			Addresses: []string{"10.10.11.1-10.10.11.100"},
+			Addresses: []string{"198.51.100.1-198.51.100.100"},
 			Prefix:    24,
-			Gateway:   "10.10.11.254",
+			Gateway:   "198.51.100.254",
 		},
 	}))
 
@@ -348,9 +348,9 @@ func (s *IPAMTestSuite) Test_GetIPPoolAnnotations() {
 				Kind:     gvk.Kind,
 				Name:     "test-ippool-annotations",
 			},
-			Address: "10.10.11.11",
+			Address: "198.51.100.11",
 			Prefix:  ptr.To[int32](24),
-			Gateway: "10.10.11.254",
+			Gateway: "198.51.100.254",
 		},
 	}
 
@@ -404,9 +404,9 @@ func (s *IPAMTestSuite) Test_CreateIPAddressClaimv2() {
 			Name:      "test-additional-cluster-icip",
 		},
 		Spec: ipamicv1.InClusterIPPoolSpec{
-			Addresses: []string{"10.10.10.1-10.10.10.100"},
+			Addresses: []string{"192.0.2.1-192.0.2.100"},
 			Prefix:    24,
-			Gateway:   "10.10.10.254",
+			Gateway:   "192.0.2.254",
 		},
 	}))
 
@@ -437,9 +437,9 @@ func (s *IPAMTestSuite) Test_CreateIPAddressClaimv2() {
 			Name: "test-global-cluster-icip",
 		},
 		Spec: ipamicv1.InClusterIPPoolSpec{
-			Addresses: []string{"10.10.10.1-10.10.10.100"},
+			Addresses: []string{"192.0.2.1-192.0.2.100"},
 			Prefix:    24,
-			Gateway:   "10.10.10.254",
+			Gateway:   "192.0.2.254",
 		},
 	}))
 
@@ -525,7 +525,7 @@ func (s *IPAMTestSuite) Test_GetIPAddress() {
 	s.NoError(err)
 	s.NotNil(ip)
 	s.NotEmpty(ip.Spec.Address)
-	s.Equal(ip.Spec.Address, "10.10.10.11")
+	s.Equal(ip.Spec.Address, "192.0.2.11")
 }
 
 func getCluster() *infrav1.ProxmoxCluster {
@@ -545,8 +545,8 @@ func getCluster() *infrav1.ProxmoxCluster {
 		},
 		Spec: infrav1.ProxmoxClusterSpec{
 			IPv4Config: &infrav1.IPConfigSpec{
-				Addresses: []string{"10.10.0.1/24"},
-				Gateway:   "10.0.0.0",
+				Addresses: []string{"192.0.2.1/24"},
+				Gateway:   "203.0.113.0",
 				Prefix:    24,
 			},
 		},
@@ -576,9 +576,9 @@ func (s *IPAMTestSuite) dummyIPAddress(owner client.Object, poolName string) *ip
 				Kind:     gvk.Kind,
 				Name:     poolName,
 			},
-			Address: "10.10.10.11",
+			Address: "192.0.2.11",
 			Prefix:  ptr.To[int32](24),
-			Gateway: "10.10.10.1",
+			Gateway: "192.0.2.1",
 		},
 	}
 }


### PR DESCRIPTION
Fixes #693

## Summary
- replace private and public example IPv4 literals in tests with RFC 5737 documentation addresses
- keep existing test relationships intact for addresses, gateways, DNS servers, routes, and expected rendered output
- leave special route/loopback values such as `0.0.0.0/0` and `127.0.0.1` unchanged

## Verification
- `make test WHAT="./api/v1alpha1 ./api/v1alpha2 ./cmd/convert ./internal/controller ./internal/inject ./internal/service/vmservice ./internal/webhook ./pkg/cloudinit ./pkg/convert ./pkg/ignition ./pkg/kubernetes/ipam"`
- `git diff --check`

## AI assistance
This PR was prepared with OpenAI Codex assistance. I reviewed the diff, ran the verification above, and included the required `Co-authored-by` trailer in the commit.