### PR TITLE
ci: version consistency workflow and remove docker dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,11 +22,6 @@ updates:
       - github.com/onsi/ginkgo/v2
       - github.com/onsi/gomega
 
-- package-ecosystem: "docker"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,15 +118,15 @@ jobs:
           repository: shellspec/shellspec
           ref: 90e48c950239f3b8a9fdfa3e869592872c77b981 # v0.28.1
           path: .shellspec
-      - name: Add ShellSpec to PATH
-        run: echo "${{ github.workspace }}/.shellspec" >> "$GITHUB_PATH"
 
       - name: Install kcov
         run: apt-get update && apt-get install -y kcov
 
       - run: make verify
       - run: make test
-      - run: make test-sh
+      - run: |
+          SHELLSPEC_DIR=$(realpath .shellspec)
+          PATH="${SHELLSPEC_DIR}:${PATH}" make test-sh
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -1,0 +1,28 @@
+name: Version Consistency
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: verify-versions
+    # Run on push to main and on internal PRs (pre-screen is skipped for these).
+    # Fork PRs go through pre-screen instead; never run untrusted scripts here.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Verify version consistency
+        run: hack/verify-versions.sh


### PR DESCRIPTION
*Issue #, if available:* #669 (split)

*Description of changes:*

- `versions.yml` — adds a version consistency CI workflow that runs `hack/verify-versions.sh` on push to main and on internal PRs (fork PRs go through pre-screen instead). Catches version drift between go.mod, Dockerfile, .golangci-kal.yml, e2e config, and release metadata.
- `.github/dependabot.yml` — removes the Docker ecosystem; Go image versions are now managed by `hack/bump-go.sh` (from #765).

*Testing performed:*

- `make verify-versions` passes on the branch

🤖 Generated with [Claude Code](https://claude.com\/claude-code)