### PR TITLE
test: wee improvements

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -96,7 +96,7 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(proxmoxMachineReconciler.SetupWithManager(testEnv.Manager)).To(Succeed())
 
-	go startTestManager()
+	startTestManager()
 })
 
 func startTestManager() {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -96,12 +96,17 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(proxmoxMachineReconciler.SetupWithManager(testEnv.Manager)).To(Succeed())
 
+	go startTestManager()
+})
+
+func startTestManager() {
+	GinkgoHelper()
 	go func() {
 		defer GinkgoRecover()
 		err := testEnv.StartManager()
 		Expect(err).NotTo(HaveOccurred())
 	}()
-})
+}
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")

--- a/internal/webhook/webhook_suite_test.go
+++ b/internal/webhook/webhook_suite_test.go
@@ -71,7 +71,7 @@ var _ = BeforeSuite(func() {
 
 	//+kubebuilder:scaffold:webhook
 
-	go startTestManager()
+	startTestManager()
 
 	// wait for the webhook server to get ready
 	dialer := &net.Dialer{Timeout: time.Second}

--- a/internal/webhook/webhook_suite_test.go
+++ b/internal/webhook/webhook_suite_test.go
@@ -71,11 +71,7 @@ var _ = BeforeSuite(func() {
 
 	//+kubebuilder:scaffold:webhook
 
-	go func() {
-		defer GinkgoRecover()
-		err = testEnv.StartManager()
-		Expect(err).NotTo(HaveOccurred())
-	}()
+	go startTestManager()
 
 	// wait for the webhook server to get ready
 	dialer := &net.Dialer{Timeout: time.Second}
@@ -90,6 +86,15 @@ var _ = BeforeSuite(func() {
 	}).Should(Succeed())
 
 })
+
+func startTestManager() {
+	GinkgoHelper()
+	go func() {
+		defer GinkgoRecover()
+		err := testEnv.StartManager()
+		Expect(err).NotTo(HaveOccurred())
+	}()
+}
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")

--- a/pkg/ignition/enrich_test.go
+++ b/pkg/ignition/enrich_test.go
@@ -99,7 +99,12 @@ func TestEnricher_Enrich(t *testing.T) {
 	var jsonData interface{}
 	err = json.Unmarshal(userdata, &jsonData)
 	require.NoError(t, err)
-	files := jsonData.(map[string]interface{})["storage"].(map[string]interface{})["files"].([]interface{})
+	root, ok := jsonData.(map[string]any)
+	require.True(t, ok, "expected root to be map[string]any")
+	storage, ok := root["storage"].(map[string]any)
+	require.True(t, ok, "expected storage to be map[string]any")
+	require.IsType(t, []any{}, storage["files"], "expected storage.files to be a slice")
+	files := storage["files"].([]any)
 	for _, file := range files {
 		if v, exists := file.(map[string]interface{})["path"]; exists {
 			if v.(string) == "/etc/proxmox-env" {


### PR DESCRIPTION
*Issue #, if available:*

follow-up to #768 (onsi group bump).

*Description of changes:*

- Extract the inline `go func() { defer GinkgoRecover(); ... }()` pattern in `internal/controller/suite_test.go` and `internal/webhook/webhook_suite_test.go` into a named `startTestManager` helper marked with `GinkgoHelper()`. This causes Ginkgo to attribute manager startup failures to the `BeforeSuite` call site rather than inside the anonymous function.
- In `pkg/ignition/enrich_test.go`, replace the single chained `.(map).(map).([]any)` type assertion with separate `require.True` / `require.IsType` steps. Each step now fails with a clear message instead of a cryptic panic if the JSON structure is unexpected.

*Testing performed:*

`make test`