### PR TITLE
feat(e2e): report groups and progress to github

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,11 @@ ARTIFACTS ?= $(ROOT_DIR)/_artifacts
 SKIP_CLEANUP ?= false
 SKIP_CREATE_MGMT_CLUSTER ?= false
 
+# report groups and progress to github
+ifeq ($(GITHUB_ACTIONS),true)
+GINKGO_ARGS += --github-output
+endif
+
 .PHONY: e2e-image
 e2e-image:
 	docker build --tag="$(REPOSITORY):e2e" .


### PR DESCRIPTION
Run ginkgo with `--github-output` when in github action.

This causes ginkgo to emit group markers for specs, turning them into collapsible sections.
It also emits progress reports (poll-progress).

Besides the obvious log analysis quality of life improvement, It should allow github to better estimate the run progress.

