### PR TITLE
Issue 758 status reconstruction

### DIFF
--- a/internal/service/vmservice/ip.go
+++ b/internal/service/vmservice/ip.go
@@ -129,10 +129,14 @@ func reconcileAddressRecovery(ctx context.Context, machineScope *scope.MachineSc
 	netPoolAddresses := make(map[infrav1.NetName]map[corev1.TypedLocalObjectReference][]ipamv1.IPAddress)
 	incomplete, err := collectDeviceAddresses(ctx, machineScope, netPoolAddresses, resolveExistingIPAddress)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "resolving existing IPAddressClaims for status recovery")
 	}
+	// incomplete: at least one expected IPAddressClaim did not resolve cleanly.
+	// len == 0: Spec.Network declares no NetworkDevices, so there is nothing to
+	// republish (a populated map always carries the synthetic "default" net).
+	// Either way, leave it to the regular provisioning path.
 	if incomplete || len(netPoolAddresses) == 0 {
-		machineScope.Logger.Info("address recovery skipped: not all expected IPAddressClaims resolved cleanly")
+		machineScope.Logger.Info("address recovery skipped: no fully-resolved IPAddressClaims to republish")
 		return nil
 	}
 

--- a/internal/service/vmservice/ip.go
+++ b/internal/service/vmservice/ip.go
@@ -69,6 +69,21 @@ func reconcileIPAddresses(ctx context.Context, machineScope *scope.MachineScope)
 	}
 
 	machineScope.Logger.V(4).Info("updating the ProxmoxMachine's IP addresses.")
+	writeIPAddressStatus(pm, netPoolAddresses)
+
+	conditions.Set(pm, metav1.Condition{
+		Type:   infrav1.ProxmoxMachineVirtualMachineProvisionedCondition,
+		Status: metav1.ConditionFalse,
+		Reason: infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForBootstrapDataReconciliationReason,
+	})
+
+	return true, nil
+}
+
+// writeIPAddressStatus republishes ProxmoxMachine.status.ipAddresses from the
+// resolved per-net/pool addresses. Within each net the addresses are ordered by
+// their pool-offset annotation and split into IPv4/IPv6 before being stored.
+func writeIPAddressStatus(pm *infrav1.ProxmoxMachine, netPoolAddresses map[infrav1.NetName]map[corev1.TypedLocalObjectReference][]ipamv1.IPAddress) {
 	for net, pools := range netPoolAddresses {
 		addresses := slices.Concat(slices.Collect(maps.Values(pools))...)
 		slices.SortFunc(addresses, func(a, b ipamv1.IPAddress) int {
@@ -88,14 +103,70 @@ func reconcileIPAddresses(ctx context.Context, machineScope *scope.MachineScope)
 		}
 		pm.SetIPAddresses(ipSpec)
 	}
+}
 
-	conditions.Set(pm, metav1.Condition{
-		Type:   infrav1.ProxmoxMachineVirtualMachineProvisionedCondition,
-		Status: metav1.ConditionFalse,
-		Reason: infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForBootstrapDataReconciliationReason,
-	})
+// reconcileAddressRecovery republishes ProxmoxMachine IP/address status for an
+// already-running machine (e.g. one restored from a backup) whose status was
+// lost. It is read-only with respect to both Proxmox and the IPAM objects: it
+// never creates claims, mutates the VM, or changes the provisioning condition.
+// It is a no-op unless the VM is running and status.ipAddresses is empty, and it
+// only republishes when every expected IPAddressClaim resolves cleanly. Orphaned
+// or conflicting IPAM objects are deliberately left to the regular provisioning
+// path.
+func reconcileAddressRecovery(ctx context.Context, machineScope *scope.MachineScope) error {
+	pm := machineScope.ProxmoxMachine
 
-	return true, nil
+	// Only act on already-running machines that are missing their IP status.
+	if machineScope.VirtualMachine == nil || !machineScope.VirtualMachine.IsRunning() {
+		return nil
+	}
+	if len(pm.Status.IPAddresses) > 0 || pm.Spec.Network == nil {
+		return nil
+	}
+
+	machineScope.Logger.V(4).Info("attempting IP/address status recovery for running machine with empty status")
+
+	netPoolAddresses := make(map[infrav1.NetName]map[corev1.TypedLocalObjectReference][]ipamv1.IPAddress)
+	incomplete, err := collectDeviceAddresses(ctx, machineScope, netPoolAddresses, resolveExistingIPAddress)
+	if err != nil {
+		return err
+	}
+	if incomplete || len(netPoolAddresses) == 0 {
+		machineScope.Logger.Info("address recovery skipped: not all expected IPAddressClaims resolved cleanly")
+		return nil
+	}
+
+	writeIPAddressStatus(pm, netPoolAddresses)
+
+	addr, err := getClusterAPIMachineAddresses(machineScope)
+	if err != nil {
+		// status.ipAddresses was repopulated; CAPI machine addresses could not be
+		// derived (e.g. no default network). Leave that to the regular path.
+		machineScope.Logger.Info("recovered status.ipAddresses but could not derive machine addresses", "reason", err.Error())
+		return nil
+	}
+	machineScope.SetAddresses(addr)
+
+	machineScope.Logger.Info("recovered ProxmoxMachine IP and address status from existing IPAM claims")
+	record.Eventf(pm, "RecoveredIPAddressStatus", "Republished IP/address status for running machine from existing IPAM claims")
+	return nil
+}
+
+// resolveExistingIPAddress is the read-only resolver used by the status-recovery
+// path. It returns the resolved address only when the expected IPAddressClaim is
+// fully resolved; for any other state it returns no address (and never creates,
+// mutates, or sets conditions), which causes recovery to be skipped.
+func resolveExistingIPAddress(ctx context.Context, machineScope *scope.MachineScope, ipClaimDef ipam.IPClaimDef) ([]ipamv1.IPAddress, error) {
+	resolution, err := machineScope.IPAMHelper.ResolveIPAddressClaim(ctx, machineScope.ProxmoxMachine, ipClaimDef)
+	if err != nil {
+		return nil, err
+	}
+	if resolution.Status == ipam.ClaimResolved {
+		return []ipamv1.IPAddress{*resolution.Address}, nil
+	}
+	machineScope.Logger.V(4).Info("address recovery: IPAddressClaim not resolved",
+		"claim", resolution.ClaimName, "status", resolution.Status, "device", ipClaimDef.Device)
+	return []ipamv1.IPAddress{}, nil
 }
 
 // Todo: add tagging to its own stage.
@@ -203,10 +274,23 @@ func handleIPAddresses(ctx context.Context, machineScope *scope.MachineScope, ip
 	}
 }
 
+// ipAddressResolver resolves the IPAddress(es) for a single device/pool claim
+// definition. handleDevices uses the create-capable handleIPAddresses; the
+// read-only status-recovery path uses resolveExistingIPAddress.
+type ipAddressResolver func(ctx context.Context, machineScope *scope.MachineScope, ipClaimDef ipam.IPClaimDef) ([]ipamv1.IPAddress, error)
+
 func handleDevices(ctx context.Context, machineScope *scope.MachineScope, addresses map[infrav1.NetName]map[corev1.TypedLocalObjectReference][]ipamv1.IPAddress) (bool, error) {
+	return collectDeviceAddresses(ctx, machineScope, addresses, handleIPAddresses)
+}
+
+// collectDeviceAddresses walks the machine's network devices and pools, resolves
+// each device/pool claim via the supplied resolver, and groups the resulting
+// addresses into the per-net/pool map (including the synthetic "default" net).
+// It returns requeue=true when any claim did not resolve to an address.
+func collectDeviceAddresses(ctx context.Context, machineScope *scope.MachineScope, addresses map[infrav1.NetName]map[corev1.TypedLocalObjectReference][]ipamv1.IPAddress, resolve ipAddressResolver) (bool, error) {
 	// paranoidly handle callers handing us an empty map
 	if addresses == nil {
-		return false, errors.New("handleDevices called without a map")
+		return false, errors.New("collectDeviceAddresses called without a map")
 	}
 
 	networkSpec := ptr.Deref(machineScope.ProxmoxMachine.Spec.Network, infrav1.NetworkSpec{})
@@ -248,7 +332,7 @@ func handleDevices(ctx context.Context, machineScope *scope.MachineScope, addres
 				ipClaimDef.Annotations[infrav1.ProxmoxDefaultGatewayAnnotation] = "true"
 			}
 
-			ipAddresses, err := handleIPAddresses(ctx, machineScope, ipClaimDef)
+			ipAddresses, err := resolve(ctx, machineScope, ipClaimDef)
 			if err != nil {
 				return true, errors.Wrapf(err, "unable to handle IPAddress for device %+v, pool %s", net.Name, ipPool.Name)
 			}

--- a/internal/service/vmservice/recovery_test.go
+++ b/internal/service/vmservice/recovery_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2023-2026 IONOS Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vmservice
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	ipamicv1 "sigs.k8s.io/cluster-api-ipam-provider-in-cluster/api/v1alpha2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/util/conditions"
+
+	infrav1 "github.com/ionos-cloud/cluster-api-provider-proxmox/api/v1alpha2"
+)
+
+func TestReconcileAddressRecovery_RecoversStatus(t *testing.T) {
+	machineScope, _, kubeClient := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedCloningReason)
+
+	defaultPool := corev1.TypedLocalObjectReference{
+		APIGroup: new(ipamicv1.GroupVersion.String()),
+		Kind:     reflect.ValueOf(ipamicv1.InClusterIPPool{}).Type().Name(),
+		Name:     getDefaultPoolRefs(machineScope).InClusterIPPoolRefV4.Name,
+	}
+	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
+		NetworkDevices: []infrav1.NetworkDevice{{
+			Name:        infrav1.DefaultNetworkDevice,
+			DefaultIPv4: new(true),
+		}},
+	}
+
+	createIPPools(t, kubeClient, machineScope)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "10.10.10.10", 0, &defaultPool)
+
+	// already-running VM with empty status, e.g. restored from backup
+	machineScope.SetVirtualMachine(newRunningVM())
+	require.Empty(t, machineScope.ProxmoxMachine.GetIPAddresses())
+
+	err := reconcileAddressRecovery(context.Background(), machineScope)
+	require.NoError(t, err)
+
+	// status.ipAddresses republished
+	require.NotNil(t, machineScope.ProxmoxMachine.GetIPAddressesNet(infrav1.DefaultNetworkDevice))
+	require.Equal(t,
+		infrav1.IPAddressesSpec{NetName: string(infrav1.DefaultNetworkDevice), IPv4: []string{"10.10.10.10"}, IPv6: nil},
+		*machineScope.ProxmoxMachine.GetIPAddressesNet(infrav1.DefaultNetworkDevice),
+	)
+
+	// status.addresses republished (hostname + internal IP)
+	require.Contains(t, machineScope.ProxmoxMachine.Status.Addresses, clusterv1.MachineAddress{
+		Type:    clusterv1.MachineInternalIP,
+		Address: "10.10.10.10",
+	})
+
+	// recovery must not create any IPAM objects: the single pre-created claim remains
+	claims := getIPAddressClaimsPerPool(t, kubeClient, machineScope, defaultPool.Name)
+	require.NotNil(t, claims)
+	require.Len(t, *claims, 1)
+
+	// recovery must not advance/alter the provisioning state machine
+	require.Equal(t, infrav1.ProxmoxMachineVirtualMachineProvisionedCloningReason,
+		conditions.GetReason(machineScope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition))
+}
+
+func TestReconcileAddressRecovery_NoopWhenVMNotRunning(t *testing.T) {
+	machineScope, _, kubeClient := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedCloningReason)
+
+	defaultPool := corev1.TypedLocalObjectReference{
+		APIGroup: new(ipamicv1.GroupVersion.String()),
+		Kind:     reflect.ValueOf(ipamicv1.InClusterIPPool{}).Type().Name(),
+		Name:     getDefaultPoolRefs(machineScope).InClusterIPPoolRefV4.Name,
+	}
+	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
+		NetworkDevices: []infrav1.NetworkDevice{{
+			Name:        infrav1.DefaultNetworkDevice,
+			DefaultIPv4: new(true),
+		}},
+	}
+	createIPPools(t, kubeClient, machineScope)
+	createIPAddress(t, kubeClient, machineScope, infrav1.DefaultNetworkDevice, "10.10.10.10", 0, &defaultPool)
+
+	machineScope.SetVirtualMachine(newStoppedVM())
+
+	err := reconcileAddressRecovery(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.Empty(t, machineScope.ProxmoxMachine.GetIPAddresses())
+	require.Empty(t, machineScope.ProxmoxMachine.Status.Addresses)
+}
+
+func TestReconcileAddressRecovery_NoopWhenVMNil(t *testing.T) {
+	machineScope, _, kubeClient := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedCloningReason)
+
+	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
+		NetworkDevices: []infrav1.NetworkDevice{{
+			Name:        infrav1.DefaultNetworkDevice,
+			DefaultIPv4: new(true),
+		}},
+	}
+	createIPPools(t, kubeClient, machineScope)
+
+	// VirtualMachine intentionally not set on the scope
+	err := reconcileAddressRecovery(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.Empty(t, machineScope.ProxmoxMachine.GetIPAddresses())
+}
+
+func TestReconcileAddressRecovery_NoopWhenStatusAlreadyPopulated(t *testing.T) {
+	machineScope, _, _ := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedCloningReason)
+
+	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
+		NetworkDevices: []infrav1.NetworkDevice{{
+			Name:        infrav1.DefaultNetworkDevice,
+			DefaultIPv4: new(true),
+		}},
+	}
+	existing := infrav1.IPAddressesSpec{NetName: string(infrav1.DefaultNetworkDevice), IPv4: []string{"10.20.30.40"}}
+	machineScope.ProxmoxMachine.SetIPAddresses(existing)
+
+	machineScope.SetVirtualMachine(newRunningVM())
+
+	err := reconcileAddressRecovery(context.Background(), machineScope)
+	require.NoError(t, err)
+
+	// unchanged (idempotent no-op)
+	require.Equal(t, existing, *machineScope.ProxmoxMachine.GetIPAddressesNet(infrav1.DefaultNetworkDevice))
+}
+
+func TestReconcileAddressRecovery_NoopWhenNetworkNil(t *testing.T) {
+	machineScope, _, _ := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedCloningReason)
+
+	machineScope.ProxmoxMachine.Spec.Network = nil
+	machineScope.SetVirtualMachine(newRunningVM())
+
+	err := reconcileAddressRecovery(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.Empty(t, machineScope.ProxmoxMachine.GetIPAddresses())
+}
+
+func TestReconcileAddressRecovery_SkipsWhenClaimMissing(t *testing.T) {
+	machineScope, _, kubeClient := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedCloningReason)
+
+	machineScope.ProxmoxMachine.Spec.Network = &infrav1.NetworkSpec{
+		NetworkDevices: []infrav1.NetworkDevice{{
+			Name:        infrav1.DefaultNetworkDevice,
+			DefaultIPv4: new(true),
+		}},
+	}
+	createIPPools(t, kubeClient, machineScope)
+	// no IPAddressClaim / IPAddress created -> claim resolves as missing
+
+	machineScope.SetVirtualMachine(newRunningVM())
+
+	err := reconcileAddressRecovery(context.Background(), machineScope)
+	require.NoError(t, err)
+
+	// no status written and no IPAM object created
+	require.Empty(t, machineScope.ProxmoxMachine.GetIPAddresses())
+	require.Empty(t, machineScope.ProxmoxMachine.Status.Addresses)
+	require.Empty(t, getIPAddressClaims(t, kubeClient, machineScope))
+}

--- a/internal/service/vmservice/recovery_test.go
+++ b/internal/service/vmservice/recovery_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023-2026 IONOS Cloud.
+Copyright 2026 IONOS Cloud.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/service/vmservice/vm.go
+++ b/internal/service/vmservice/vm.go
@@ -79,6 +79,14 @@ func ReconcileVM(ctx context.Context, scope *scope.MachineScope) (infrav1.Virtua
 		return vm, err
 	} // VirtualMachineProvisioned reason is Cloning
 
+	// Recover IP/address status for already-running machines (e.g. restored from
+	// backup) whose status was lost. This is read-only and a no-op during normal
+	// provisioning; it does not advance the provisioning state machine below.
+	if err := reconcileAddressRecovery(ctx, scope); err != nil {
+		scope.Logger.V(4).Info("after reconcileAddressRecovery", "machineName", scope.ProxmoxMachine.GetName(), "err", err)
+		return vm, err
+	}
+
 	if requeue, err := reconcileVirtualMachineConfig(ctx, scope); err != nil || requeue {
 		scope.Logger.V(4).Info("after reconcileVirtualMachineConfig", "machineName", scope.ProxmoxMachine.GetName(), "requeue", requeue, "err", err)
 		return vm, err


### PR DESCRIPTION
**Issue  #758

**Description of changes:**

After a Velero restore of a CAPMOX management cluster, already-running workload VMs can lose their address state: `ProxmoxMachine.status.ipAddresses` and `status.addresses` come back empty even though the VM, Node, and the `IPAddressClaim`/`IPAddress` objects are all healthy. This leaves CAPI `Machine.status.addresses` empty and breaks downstream controllers — e.g. TalosControlPlane/CABPT fail with `no addresses were found for node`.

The root cause is that `ReconcileVM`'s reason-gated state machine never republishes status for these machines. For an already-running VM, `ensureVirtualMachine` leaves the `VirtualMachineProvisioned` reason at `Cloning`, and `reconcileVirtualMachineConfig` early-returns because the VM is running, so the reason never advances to `WaitingForStaticIPAllocation`. As a result `reconcileIPAddresses` and `reconcileMachineAddresses` are never reached and status stays empty.

This PR adds `reconcileAddressRecovery`, a read-only, idempotent step run right after `ensureVirtualMachine`. When the VM is running and `status.ipAddresses` is empty, it reconstructs status purely from the existing IPAM objects (reusing the claim-rooted `ResolveIPAddressClaim` from the first PR) and republishes `status.ipAddresses` and `status.addresses`. It:

- never creates `IPAddressClaim`/`IPAddress` objects, mutates the Proxmox VM, or advances the provisioning condition;
- republishes only when **every** expected claim resolves cleanly (`ClaimResolved`) — orphaned or conflicting IPAM objects are deliberately left to the regular provisioning path / follow-up PRs;
- is a no-op during normal provisioning (a freshly cloned VM is not running at the IP stage, and once status is populated it never fires again).

Supporting refactors (behaviour unchanged for the provisioning path): the shared device/pool walk is extracted into `collectDeviceAddresses(ctx, scope, addresses, resolve)` with a pluggable resolver (`handleIPAddresses` for provisioning, `resolveExistingIPAddress` read-only for recovery), and the status-write loop is extracted into `writeIPAddressStatus`, reused by both paths.

**Testing performed:**

- `go test ./internal/service/vmservice/...` → 169 pass, including 6 new `reconcileAddressRecovery` tests (recovers status from existing claims; no-op when VM not running / VM absent / status already populated / `Spec.Network` nil; skips without writing status or creating objects when a claim is missing) and all pre-existing provisioning tests (regression guard for the refactor).
- `go test ./pkg/kubernetes/ipam/...` → 24 pass.
- `go vet` and `gofmt` clean on the changed files.
- `make lint` clean for the changed files.
- `make verify` clean on the committed tree — no generated-file drift, no API changes.

