### PR TITLE
build(deps): bump go-proxmox from v0.6.0 to v0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/jarcoal/httpmock v1.4.1
-	github.com/luthermonson/go-proxmox v0.6.0
+	github.com/luthermonson/go-proxmox v0.7.0
 	github.com/onsi/ginkgo/v2 v2.30.0
 	github.com/onsi/gomega v1.41.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -496,8 +496,8 @@ github.com/leonklingele/grouper v1.1.2 h1:o1ARBDLOmmasUaNDesWqWCIFH3u7hoFlM84Yrj
 github.com/leonklingele/grouper v1.1.2/go.mod h1:6D0M/HVkhs2yRKRFZUoGjeDy7EZTfFBE9gl4kjmIGkA=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/luthermonson/go-proxmox v0.6.0 h1:VWvQKUCxIOnxcy1cHd7jlL83OlTEBRnX2pG/YiKC/+8=
-github.com/luthermonson/go-proxmox v0.6.0/go.mod h1:Q6ByFv9Zak9NvJwZJ36HMN5qwIZVj0isxf8u4YIk6lE=
+github.com/luthermonson/go-proxmox v0.7.0 h1:ZHnmrI7Wm2BSCo2nTW4ZbxCcQO6iT2l7FCrOmZUOaao=
+github.com/luthermonson/go-proxmox v0.7.0/go.mod h1:Q6ByFv9Zak9NvJwZJ36HMN5qwIZVj0isxf8u4YIk6lE=
 github.com/macabu/inamedparam v0.2.0 h1:VyPYpOc10nkhI2qeNUdh3Zket4fcZjEWe35poddBCpE=
 github.com/macabu/inamedparam v0.2.0/go.mod h1:+Pee9/YfGe5LJ62pYXqB89lJ+0k5bsR8Wgz/C0Zlq3U=
 github.com/magefile/mage v1.14.0 h1:6QDX3g6z1YvJ4olPhT1wksUcSa/V0a1B+pJb73fBjyo=

--- a/internal/service/vmservice/bootstrap.go
+++ b/internal/service/vmservice/bootstrap.go
@@ -222,7 +222,7 @@ func getNetworkConfigDataForDevice(ctx context.Context, machineScope *scope.Mach
 		return nil, errors.New("empty device name")
 	}
 
-	nets := machineScope.VirtualMachine.VirtualMachineConfig.MergeNets()
+	nets := machineScope.VirtualMachine.VirtualMachineConfig.Nets
 
 	macAddress := extractMACAddress(nets[string(device)])
 	if len(macAddress) == 0 {
@@ -382,7 +382,7 @@ func getVirtualNetworkDevices(_ context.Context, _ *scope.MachineScope, networkS
 }
 
 func vmHasMacAddresses(machineScope *scope.MachineScope) bool {
-	nets := machineScope.VirtualMachine.VirtualMachineConfig.MergeNets()
+	nets := machineScope.VirtualMachine.VirtualMachineConfig.Nets
 	if len(nets) == 0 {
 		return false
 	}

--- a/internal/service/vmservice/utils.go
+++ b/internal/service/vmservice/utils.go
@@ -161,7 +161,7 @@ func shouldUpdateNetworkDevices(machineScope *scope.MachineScope) bool {
 		return false
 	}
 
-	nets := machineScope.VirtualMachine.VirtualMachineConfig.MergeNets()
+	nets := machineScope.VirtualMachine.VirtualMachineConfig.Nets
 
 	devices := machineScope.ProxmoxMachine.Spec.Network.NetworkDevices
 	for _, v := range devices {

--- a/internal/service/vmservice/vm.go
+++ b/internal/service/vmservice/vm.go
@@ -304,10 +304,10 @@ func reconcileVirtualMachineConfig(ctx context.Context, machineScope *scope.Mach
 	sockets := ptr.Deref(machineScope.ProxmoxMachine.Spec.NumSockets, 0)
 	cores := ptr.Deref(machineScope.ProxmoxMachine.Spec.NumCores, 0)
 	memory := ptr.Deref(machineScope.ProxmoxMachine.Spec.MemoryMiB, 0)
-	if sockets > 0 && vmConfig.Sockets != int(sockets) {
+	if sockets > 0 && ptr.Deref(vmConfig.Sockets, 0) != int(sockets) {
 		vmOptions = append(vmOptions, proxmox.VirtualMachineOption{Name: optionSockets, Value: sockets})
 	}
-	if cores > 0 && vmConfig.Cores != int(cores) {
+	if cores > 0 && ptr.Deref(vmConfig.Cores, 0) != int(cores) {
 		vmOptions = append(vmOptions, proxmox.VirtualMachineOption{Name: optionCores, Value: cores})
 	}
 	if memory > 0 && int(vmConfig.Memory) != int(memory) {
@@ -451,11 +451,7 @@ func createVM(ctx context.Context, scope *scope.MachineScope) (proxmox.VMCloneRe
 	if scope.ProxmoxMachine.Spec.Format != nil {
 		options.Format = string(*scope.ProxmoxMachine.Spec.Format)
 	}
-	var full uint8
-	if ptr.Deref(scope.ProxmoxMachine.Spec.Full, true) {
-		full = 1
-	}
-	options.Full = full
+	options.Full = ptr.Deref(scope.ProxmoxMachine.Spec.Full, true)
 	if scope.ProxmoxMachine.Spec.Pool != nil {
 		options.Pool = *scope.ProxmoxMachine.Spec.Pool
 	}

--- a/internal/service/vmservice/vm_test.go
+++ b/internal/service/vmservice/vm_test.go
@@ -126,7 +126,7 @@ func TestEnsureVirtualMachine_CreateVM_FullOptions(t *testing.T) {
 		Name:        "test",
 		Description: "test vm",
 		Format:      "raw",
-		Full:        1,
+		Full:        true,
 		Pool:        "pool",
 		SnapName:    "snap",
 		Storage:     "storage",
@@ -169,7 +169,7 @@ func TestEnsureVirtualMachine_CreateVM_FullOptions_TemplateSelector(t *testing.T
 		Name:        "test",
 		Description: "test vm",
 		Format:      "raw",
-		Full:        1,
+		Full:        true,
 		Pool:        "pool",
 		SnapName:    "snap",
 		Storage:     "storage",
@@ -239,7 +239,7 @@ func TestEnsureVirtualMachine_CreateVM_SelectNode(t *testing.T) {
 	}
 	t.Cleanup(func() { selectNextNode = scheduler.ScheduleVM })
 
-	expectedOptions := proxmox.VMCloneRequest{Node: "node1", Name: "test", Target: "node3", Full: 1}
+	expectedOptions := proxmox.VMCloneRequest{Node: "node1", Name: "test", Target: "node3", Full: true}
 	response := proxmox.VMCloneResponse{NewID: 123, Task: newTask()}
 	proxmoxClient.EXPECT().CloneVM(context.Background(), 123, expectedOptions).Return(response, nil).Once()
 
@@ -262,7 +262,7 @@ func TestEnsureVirtualMachine_CreateVM_SelectNode_MachineAllowedNodes(t *testing
 	}
 	t.Cleanup(func() { selectNextNode = scheduler.ScheduleVM })
 
-	expectedOptions := proxmox.VMCloneRequest{Node: "node1", Name: "test", Target: "node2", Full: 1}
+	expectedOptions := proxmox.VMCloneRequest{Node: "node1", Name: "test", Target: "node2", Full: true}
 	response := proxmox.VMCloneResponse{NewID: 123, Task: newTask()}
 	proxmoxClient.EXPECT().CloneVM(context.Background(), 123, expectedOptions).Return(response, nil).Once()
 
@@ -299,7 +299,7 @@ func TestEnsureVirtualMachine_CreateVM_VMIDRange(t *testing.T) {
 		End:   1002,
 	}
 
-	expectedOptions := proxmox.VMCloneRequest{Node: "node1", NewID: 1001, Name: "test", Full: 1}
+	expectedOptions := proxmox.VMCloneRequest{Node: "node1", NewID: 1001, Name: "test", Full: true}
 	response := proxmox.VMCloneResponse{Task: newTask(), NewID: int64(1001)}
 	proxmoxClient.Mock.On("CheckID", context.Background(), int64(1000)).Return(false, nil)
 	proxmoxClient.Mock.On("CheckID", context.Background(), int64(1001)).Return(true, nil)
@@ -378,7 +378,7 @@ func TestEnsureVirtualMachine_CreateVM_VMIDRangeCheckExisting(t *testing.T) {
 	_, err = ensureVirtualMachine(context.Background(), machineScopeVMThousand)
 	require.NoError(t, err)
 
-	expectedOptions := proxmox.VMCloneRequest{Node: "node1", NewID: 1002, Name: "test", Full: 1}
+	expectedOptions := proxmox.VMCloneRequest{Node: "node1", NewID: 1002, Name: "test", Full: true}
 	response := proxmox.VMCloneResponse{Task: newTask(), NewID: int64(1002)}
 	proxmoxClient.EXPECT().CloneVM(context.Background(), 123, expectedOptions).Return(response, nil).Once()
 	proxmoxClient.Mock.On("CheckID", context.Background(), int64(1001)).Return(false, nil).Once()
@@ -671,7 +671,7 @@ func TestReconcileDisks_UnmountCloudInitISO(t *testing.T) {
 	machineScope, proxmoxClient, _ := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForBootstrapReadyReason)
 
 	vm := newRunningVM()
-	vm.VirtualMachineConfig.IDE0 = "local:iso/cloud-init.iso,media=cdrom"
+	vm.VirtualMachineConfig.IDEs = map[string]string{"ide0": "local:iso/cloud-init.iso,media=cdrom"}
 	machineScope.SetVirtualMachine(vm)
 
 	proxmoxClient.EXPECT().UnmountCloudInitISO(context.Background(), vm, "ide0").Return(nil)
@@ -732,7 +732,7 @@ func TestReconcileVM_CloudInitRunning(t *testing.T) {
 func TestReconcileVM_StateMachine(t *testing.T) {
 	machineScope, proxmoxClient, _ := setupReconcilerTest(t)
 	vm := newStoppedVM()
-	vm.VirtualMachineConfig.IDE0 = "local:iso/cloud-init.iso,media=cdrom"
+	vm.VirtualMachineConfig.IDEs = map[string]string{"ide0": "local:iso/cloud-init.iso,media=cdrom"}
 
 	machineScope.InfraCluster.ProxmoxCluster.Spec.IPv6Config = &infrav1.IPConfigSpec{
 		Addresses: []string{"2001:db8::/64"},
@@ -767,7 +767,7 @@ func TestReconcileVM_StateMachine(t *testing.T) {
 		Name:        "test",
 		Description: "test vm",
 		Format:      "raw",
-		Full:        1,
+		Full:        true,
 		Pool:        "pool",
 		SnapName:    "snap",
 		Storage:     "storage",

--- a/pkg/proxmox/goproxmox/api_client.go
+++ b/pkg/proxmox/goproxmox/api_client.go
@@ -85,7 +85,7 @@ func (c *APIClient) CloneVM(ctx context.Context, templateID int, clone capmox.VM
 		NewID:       clone.NewID,
 		Description: clone.Description,
 		Format:      clone.Format,
-		Full:        clone.Full,
+		Full:        proxmox.IntOrBool(clone.Full),
 		Name:        clone.Name,
 		Pool:        clone.Pool,
 		SnapName:    clone.SnapName,

--- a/pkg/proxmox/types.go
+++ b/pkg/proxmox/types.go
@@ -25,7 +25,7 @@ type VMCloneRequest struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 	Format      string `json:"format,omitempty"`
-	Full        uint8  `json:"full,omitempty"`
+	Full        bool   `json:"full,omitempty"`
 	Pool        string `json:"pool,omitempty"`
 	SnapName    string `json:"snapname,omitempty"`
 	Storage     string `json:"storage,omitempty"`


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Bumps `github.com/luthermonson/go-proxmox` from `v0.6.0` to `v0.7.0` and adapts to its source-level breaks. v0.7.0 is a cleanup release ([migration guide](https://github.com/luthermonson/go-proxmox/blob/v0.7.0/migration/v0.7.0.md)); the wire format is unchanged, so there is no behavioural change to Proxmox traffic.

- **`VirtualMachineConfig.MergeNets()` removed** — read the `.Nets` map directly (now populated by `UnmarshalJSON`). The same upstream refactor drops the indexed device fields, so a test fixture sets the `IDEs` map instead of `IDE0`. (luthermonson/go-proxmox#261)
- **`VirtualMachineConfig.Sockets`/`Cores` pointerized** (`int` → `*int`, so a Go zero value can't silently clobber a PVE server-side default) — read via `ptr.Deref`. (luthermonson/go-proxmox#199)
- **`VirtualMachineCloneOptions.Full` is now `IntOrBool`** — the `uint8` `VMCloneRequest.Full` only existed to mirror the old upstream field, so it becomes a `bool` (matching the already-`*bool` `ProxmoxMachine.Spec.Full`) and is converted to `IntOrBool` at the go-proxmox boundary. This also removes the small `uint8` dance in `createVM`.

No mock/manifest/codegen regeneration is required — the `Client` interface and API types are unchanged.

First of a planned stepwise series (v0.7.0 → v0.7.1 → v0.8.0).

*Testing performed:*

- `make test` — full suite passes, including the envtest controller/webhook suites.
- `make verify` — clean (regeneration produces no diff).
- `make lint` — the files changed here are clean. Note: `make lint` also reports two **pre-existing** issues in `pkg/convert/sentinel*.go` (introduced in `3b0bc99`, already on `main`) that are unrelated to and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
