### PR TITLE
build(deps): bump go-proxmox from v0.7.0 to v0.7.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/jarcoal/httpmock v1.4.1
-	github.com/luthermonson/go-proxmox v0.7.0
+	github.com/luthermonson/go-proxmox v0.7.1
 	github.com/onsi/ginkgo/v2 v2.30.0
 	github.com/onsi/gomega v1.41.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -496,8 +496,8 @@ github.com/leonklingele/grouper v1.1.2 h1:o1ARBDLOmmasUaNDesWqWCIFH3u7hoFlM84Yrj
 github.com/leonklingele/grouper v1.1.2/go.mod h1:6D0M/HVkhs2yRKRFZUoGjeDy7EZTfFBE9gl4kjmIGkA=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/luthermonson/go-proxmox v0.7.0 h1:ZHnmrI7Wm2BSCo2nTW4ZbxCcQO6iT2l7FCrOmZUOaao=
-github.com/luthermonson/go-proxmox v0.7.0/go.mod h1:Q6ByFv9Zak9NvJwZJ36HMN5qwIZVj0isxf8u4YIk6lE=
+github.com/luthermonson/go-proxmox v0.7.1 h1:uglHM+x8rTKaIxM3C42z5i+Nt/X6E93l/BitqmH7zUs=
+github.com/luthermonson/go-proxmox v0.7.1/go.mod h1:Q6ByFv9Zak9NvJwZJ36HMN5qwIZVj0isxf8u4YIk6lE=
 github.com/macabu/inamedparam v0.2.0 h1:VyPYpOc10nkhI2qeNUdh3Zket4fcZjEWe35poddBCpE=
 github.com/macabu/inamedparam v0.2.0/go.mod h1:+Pee9/YfGe5LJ62pYXqB89lJ+0k5bsR8Wgz/C0Zlq3U=
 github.com/magefile/mage v1.14.0 h1:6QDX3g6z1YvJ4olPhT1wksUcSa/V0a1B+pJb73fBjyo=


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Bumps `github.com/luthermonson/go-proxmox` from `v0.7.0` to `v0.7.1`. Second of the planned stepwise series (v0.7.0 → v0.7.1 → v0.8.0).

v0.7.1 is a **correctness-only patch** ([migration guide](https://github.com/luthermonson/go-proxmox/blob/v0.7.1/migration/v0.7.1.md)): every change is a JSON-tag/scalar-type fix on exported response structs, so the wire format is the only thing that moves. **No capmox code change is required** — the affected types are all unused here:

- The two source-level breaks are on `StorageContent` (`Encryption`→`Encrypted`; `Verification` `string`→`*StorageContentVerification`); capmox has no `StorageContent` reference.
- The deprecate-and-replace pair — `AgentNetworkIPAddress.MacAddress` and the firewall `Ntp`→`NDP` fields, both slated for removal in v0.8.0 — is also unused: capmox sets `status.addresses` from IPAM, not the guest agent, and references no firewall type. This keeps the upcoming v0.8.0 step limited to the `Delete()` signature change.
- The internal JSON-tag fixes (`CephMonMap`, `FirewallRule.IcmpType`) touch tags only, not field names, and those types are unused.

go-proxmox's own `go.mod` is unchanged in v0.7.1, so there is no transitive dependency ripple — the diff is just the `go.mod`/`go.sum` version + checksum swap.

> Stacked on #813 (the v0.7.0 bump); review that first. This PR's base will retarget to `main` automatically once #813 merges.

*Testing performed:*

- `make test` — full suite passes, including the envtest controller/webhook suites.
- `make verify` — regeneration (manifests/mocks) produces no diff; the `Client` interface and API types are unchanged, so nothing regenerates.
- `make lint` — the files changed here (`go.mod`/`go.sum`) are clean. As on #813, `make lint` also reports two **pre-existing** issues in `pkg/convert/sentinel*.go` (introduced in `3b0bc99`, already on `main`) that are unrelated to and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
