### PR TITLE
build(deps): bump go-proxmox from v0.7.1 to v0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/jarcoal/httpmock v1.4.1
-	github.com/luthermonson/go-proxmox v0.7.1
+	github.com/luthermonson/go-proxmox v0.8.0
 	github.com/onsi/ginkgo/v2 v2.30.0
 	github.com/onsi/gomega v1.41.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -496,8 +496,8 @@ github.com/leonklingele/grouper v1.1.2 h1:o1ARBDLOmmasUaNDesWqWCIFH3u7hoFlM84Yrj
 github.com/leonklingele/grouper v1.1.2/go.mod h1:6D0M/HVkhs2yRKRFZUoGjeDy7EZTfFBE9gl4kjmIGkA=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/luthermonson/go-proxmox v0.7.1 h1:uglHM+x8rTKaIxM3C42z5i+Nt/X6E93l/BitqmH7zUs=
-github.com/luthermonson/go-proxmox v0.7.1/go.mod h1:Q6ByFv9Zak9NvJwZJ36HMN5qwIZVj0isxf8u4YIk6lE=
+github.com/luthermonson/go-proxmox v0.8.0 h1:KwrgeLrTXTlAezj7zt/tU4bm70VFQiJfej/5sL8rqO8=
+github.com/luthermonson/go-proxmox v0.8.0/go.mod h1:Q6ByFv9Zak9NvJwZJ36HMN5qwIZVj0isxf8u4YIk6lE=
 github.com/macabu/inamedparam v0.2.0 h1:VyPYpOc10nkhI2qeNUdh3Zket4fcZjEWe35poddBCpE=
 github.com/macabu/inamedparam v0.2.0/go.mod h1:+Pee9/YfGe5LJ62pYXqB89lJ+0k5bsR8Wgz/C0Zlq3U=
 github.com/magefile/mage v1.14.0 h1:6QDX3g6z1YvJ4olPhT1wksUcSa/V0a1B+pJb73fBjyo=

--- a/pkg/proxmox/goproxmox/api_client.go
+++ b/pkg/proxmox/goproxmox/api_client.go
@@ -247,7 +247,7 @@ func (c *APIClient) DeleteVM(ctx context.Context, nodeName string, vmID int64) (
 		}
 	}
 
-	task, err := vm.Delete(ctx)
+	task, err := vm.Delete(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("cannot delete vm with id %d: %w", vmID, err)
 	}


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Bumps `github.com/luthermonson/go-proxmox` from `v0.7.1` to `v0.8.0`. Final step of the planned stepwise series (v0.7.0 → v0.7.1 → v0.8.0).

v0.8.0 has a **single source-level break** ([migration guide](https://github.com/luthermonson/go-proxmox/blob/v0.8.0/migration/v0.8.0.md)): `VirtualMachine.Delete` gains a second `*VirtualMachineDeleteOptions` parameter, aligning it with the `Container.Delete` pattern. capmox has exactly one caller, `DeleteVM` in `pkg/proxmox/goproxmox/api_client.go`, which now passes `nil` — documented upstream as byte-for-byte equivalent to the pre-v0.8.0 `Delete(ctx)` (no optional query params sent; PVE applies its defaults). **Behaviour is unchanged.** That one line plus the `go.mod`/`go.sum` swap is the entire diff.

Everything else in the release is internal and doesn't reach capmox:

- The two behaviour changes both miss us: `VirtualMachine.Ping` now propagates config-fetch errors (our only `.Ping()` caller is `Task.Ping` via `GetTask`), and `ensureTLSConfig` defaults to `MinVersion: TLS1.2` (only applies when go-proxmox owns the transport — capmox supplies its own via `WithHTTPClient`).
- The rest is gofmt/golangci churn (struct-field alignment, `switch`/`+=` refactors), exported-param *renames* (not part of the call signature), and websocket/`UploadReader` fixes on unused paths.
- The new `VirtualMachineDeleteOptions` (`Purge`, `SkipLock`, `DestroyUnreferencedDisks`) is the only new capmox-relevant surface; `nil` is the correct default for our stateless clone-VM teardown, so nothing is adopted here.

go-proxmox's own `go.mod` is unchanged in v0.8.0 (the `/go.mod` checksum is identical to v0.7.1's), so there is no transitive dependency ripple — the module diff is just the version + content checksum swap.

> Stacked on #815 (the v0.7.1 bump); review that first. This PR's base will retarget to `main` automatically once #815 merges.

*Testing performed:*

- `make test` — full suite passes, including the `vmservice` and `goproxmox` delete-path tests that exercise the changed call.
- `make verify` — regeneration (manifests/mocks/`go mod tidy`) produces no diff; the `Client` interface and API types capmox depends on are unchanged.
- `make lint` — the files changed here are clean. As on #813/#815, `make lint` also reports two **pre-existing** issues in `pkg/convert/sentinel*.go` (introduced in `3b0bc99`, already on `main`) that are unrelated to and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
