### PR TITLE
feat: enable ginkgolinter in golangci-lint and fix linting errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - copyloopvar
     - dogsled
     - errcheck
+    - ginkgolinter
     - goconst
     - gocritic
     - gocyclo

--- a/internal/controller/proxmoxcluster_controller_test.go
+++ b/internal/controller/proxmoxcluster_controller_test.go
@@ -450,7 +450,7 @@ func setCredentialsRefOnProxmoxCluster(proxmoxCluster *infrav1.ProxmoxCluster, s
 		return ph.Patch(testEnv.GetContext(), proxmoxCluster, patch.WithStatusObservedGeneration{})
 	}).WithTimeout(time.Second * 10).
 		WithPolling(time.Second).
-		Should(BeNil())
+		Should(Succeed())
 }
 
 func setRandomCredentialsRefOnProxmoxCluster(proxmoxCluster *infrav1.ProxmoxCluster) {
@@ -464,7 +464,7 @@ func setRandomCredentialsRefOnProxmoxCluster(proxmoxCluster *infrav1.ProxmoxClus
 		return ph.Patch(testEnv.GetContext(), proxmoxCluster, patch.WithStatusObservedGeneration{})
 	}).WithTimeout(time.Second * 10).
 		WithPolling(time.Second).
-		Should(BeNil())
+		Should(Succeed())
 }
 
 func createOwnerCluster(proxmoxCluster *infrav1.ProxmoxCluster) *clusterv1.Cluster {
@@ -499,7 +499,7 @@ func setCapiClusterOwnerRefOnProxmoxCluster(proxmoxCluster *infrav1.ProxmoxClust
 		return ph.Patch(testEnv.GetContext(), proxmoxCluster, patch.WithStatusObservedGeneration{})
 	}).WithTimeout(time.Second * 10).
 		WithPolling(time.Second).
-		Should(BeNil())
+		Should(Succeed())
 }
 
 func setRandomOwnerRefOnSecret(secret *corev1.Secret, ownerRef string) {
@@ -517,7 +517,7 @@ func setRandomOwnerRefOnSecret(secret *corev1.Secret, ownerRef string) {
 		return ph.Patch(testEnv.GetContext(), secret, patch.WithStatusObservedGeneration{})
 	}).WithTimeout(time.Second * 10).
 		WithPolling(time.Second).
-		Should(BeNil())
+		Should(Succeed())
 }
 
 func refreshCluster(proxmoxCluster *infrav1.ProxmoxCluster) *infrav1.ProxmoxCluster {

--- a/internal/webhook/proxmoxmachine_webhook_test.go
+++ b/internal/webhook/proxmoxmachine_webhook_test.go
@@ -201,8 +201,8 @@ var _ = Describe("Controller Test", func() {
 		It("should add default ipv4/ipv6 pool tags", func() {
 			machine := validProxmoxMachine("no-default-pools")
 			g.Expect(k8sClient.Create(testEnv.GetContext(), &machine)).To(Succeed())
-			g.Expect(*machine.Spec.Network.NetworkDevices[0].DefaultIPv4).To(Equal(true))
-			g.Expect(*machine.Spec.Network.NetworkDevices[0].DefaultIPv6).To(Equal(true))
+			g.Expect(*machine.Spec.Network.NetworkDevices[0].DefaultIPv4).To(BeTrue())
+			g.Expect(*machine.Spec.Network.NetworkDevices[0].DefaultIPv6).To(BeTrue())
 		})
 
 		It("should not allow non consecutive network interface names ", func() {

--- a/pkg/convert/sentinel.go
+++ b/pkg/convert/sentinel.go
@@ -149,7 +149,7 @@ func inferType(expr, yamlText string) string {
 		if _, err := strconv.Atoi(defaultVal); err == nil {
 			return typeInt
 		}
-		if defaultVal == "true" || defaultVal == "false" { //nolint:goconst
+		if defaultVal == "true" || defaultVal == "false" {
 			return typeBool
 		}
 		if strings.HasPrefix(defaultVal, "[") {

--- a/pkg/convert/sentinel_test.go
+++ b/pkg/convert/sentinel_test.go
@@ -484,7 +484,7 @@ func TestGenerateSentinel(t *testing.T) {
 
 	// bool sentinel
 	s = generateSentinel("bool", &intCounter, "")
-	if s != "true" {
+	if s != "true" { //nolint:goconst
 		t.Errorf("bool sentinel = %q, want true", s)
 	}
 


### PR DESCRIPTION
Issue: #809 
## Description:
This PR enables `ginkgolinter` by default in `golangci-lint` configuration.

## Changes included in this PR:
- Enabled `ginkgolinter` in `.golangci.yml`.
- Fixed existing `ginkgolinter` violations across the test suite (e.g., updating `.To(Equal(true))` to `.To(BeTrue())`, and `.Should(BeNil())` to `.Should(Succeed())` for error checks).

## Testing performed:
- Ran  make lint  to ensure the new linter rules pass.
- Ran  make test  to verify the updated test assertions still pass correctly.