### PR TITLE
ci: split test into test-go and test-sh jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,10 +116,16 @@ jobs:
       - run: make verify
       - run: make test
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      # Upload even on failure: sonar runs on test failure too, and `go test`
+      # writes the coverage profile before its non-zero exit, so a failing run
+      # still gets a sonar report. If the file is missing (catastrophic failure)
+      # the upload just fails and sonar has nothing to run against anyway.
+      - if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: go-coverage-${{ matrix.go }}
           path: cover.out
+          if-no-files-found: error
           retention-days: 7
 
   test-sh:
@@ -157,7 +163,10 @@ jobs:
 
       - run: make test-sh
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      # Upload even on failure (see test-go): kcov writes sonarqube.xml before
+      # make test-sh's exit code, so a failing run still feeds sonar.
+      - if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sh-coverage
           path: hack/spec/coverage/sonarqube.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,10 @@
 # workflow (a fork can't edit this file), with these layered controls:
 #   pre-screen — git-only checks (diff size, sensitive paths, file modes).
 #                No PR code execution.
-#   test       — PR code runs in a digest-pinned Go container with
-#                permissions:{} in a container to avoid cache poisoning.
+#   test-go    — PR Go code runs in a digest-pinned Go container with
+#                permissions:{} to avoid cache poisoning.
+#   test-sh    — PR shell tests run on ubuntu-slim with permissions:{},
+#                gated by pre-screen exactly like test-go.
 #   sonar      — environment-gated SONAR_TOKEN; upstream and PR trees in
 #                separate paths. Scanner reads PR sources with upstream config
 #                (fork PRs) or PR config (internal PRs); never runs PR code.
@@ -47,7 +49,7 @@ jobs:
           persist-credentials: false  # keep token out of .git/config so make verify / make test can't read it
 
       # Fetch by ref (refs/pull/N/head is always advertised); pin to event-context
-      # HEAD_SHA so we screen exactly what the test job will execute.
+      # HEAD_SHA so we screen exactly what the test jobs will execute.
       - name: Fetch PR head and verify it matches the event payload
         run: |
           set -euo pipefail
@@ -81,7 +83,7 @@ jobs:
             exit 1
           fi
 
-  test:
+  test-go:
     needs: pre-screen
     # always() bypasses GHA's "skip when needs.* == skipped"; the conjunction limits to success/skipped (not failure/cancelled).
     if: always() && (needs.pre-screen.result == 'success' || needs.pre-screen.result == 'skipped')
@@ -111,6 +113,35 @@ jobs:
       # Container runs as root; the workspace is owned by the runner UID. Without this, `git diff` in `make verify` would fail with "dubious ownership".
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      - run: make verify
+      - run: make test
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: go-coverage-${{ matrix.go }}
+          path: cover.out
+          retention-days: 7
+
+  test-sh:
+    needs: pre-screen
+    # Same pre-screen gate as test-go: fork PRs touching hack/ are already blocked, so running PR shell code here is as safe as test-go.
+    if: always() && (needs.pre-screen.result == 'success' || needs.pre-screen.result == 'skipped')
+    runs-on: ubuntu-slim
+    permissions: {}
+    env:
+      GOTOOLCHAIN: local
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+
+      # The shell helpers shell out to `go list` / `go mod edit`; ubuntu-slim has no Go toolchain.
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
       - name: Install ShellSpec
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -119,32 +150,25 @@ jobs:
           ref: 90e48c950239f3b8a9fdfa3e869592872c77b981 # v0.28.1
           path: .shellspec
       - name: Add ShellSpec to PATH
-        run: echo "${{ github.workspace }}/.shellspec" >> "$GITHUB_PATH"
+        run: realpath .shellspec >> "$GITHUB_PATH"
 
       - name: Install kcov
-        run: apt-get update && apt-get install -y kcov
+        run: sudo apt-get update && sudo apt-get install -y kcov
 
-      - run: make verify
-      - run: make test
       - run: make test-sh
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: go-coverage-${{ matrix.go }}
-          path: cover.out
-          retention-days: 7
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: sh-coverage-${{ matrix.go }}
+          name: sh-coverage
           path: hack/spec/coverage/sonarqube.xml
+          if-no-files-found: error
           retention-days: 7
 
   # SECURITY: holds SONAR_TOKEN. Never execute PR-supplied code, scripts, or actions in this job.
   sonar:
-    needs: test
-    # Default `if: success()` would skip sonar whenever test failed; on main and dependabot PRs that means flaky/genuine test failures silently bypass the quality gate. Run sonar whenever test actually executed.
-    if: always() && (needs.test.result == 'success' || needs.test.result == 'failure')
+    needs: [test-go, test-sh]
+    # Default `if: success()` would skip sonar whenever a test job failed; on main and dependabot PRs that means flaky/genuine test failures silently bypass the quality gate. Run sonar whenever both test jobs actually executed (success or failure), never when they were skipped (pre-screen blocked the PR) or cancelled.
+    if: always() && (needs.test-go.result == 'success' || needs.test-go.result == 'failure') && (needs.test-sh.result == 'success' || needs.test-sh.result == 'failure')
     runs-on: ubuntu-slim
     environment: sonar
     permissions:
@@ -177,7 +201,7 @@ jobs:
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: sh-coverage-1.26
+          name: sh-coverage
           path: ${{ runner.temp }}/sh-coverage
 
       # fail-fast against malformed coverage file


### PR DESCRIPTION
*Issue #, if available:* n/a (CI follow-up to #766)

*Description of changes:*

Splits the single `test` job into `test-go` and `test-sh`.

The combined job ran everything inside the Go container, which (a) does not ship `yq` — required by the `hack/` shell helpers — and (b) remaps the workspace path, so the ShellSpec checkout never landed on `PATH` (`shellspec: command not found`).

- `test-go` — unchanged Go container + matrix; runs `make verify` + `make test`, uploads Go coverage.
- `test-sh` — runs on `ubuntu-slim` (which ships `yq`), installs Go via `setup-go` and `kcov` via apt, runs `make test-sh`, uploads shell coverage. kcov 43+ emits `sonarqube.xml` natively (no xsltproc). `if-no-files-found: error` guards the coverage upload.
- `sonar` — now depends on both jobs and runs once both have executed.

Security model is unchanged: both test jobs keep `needs: pre-screen`, the same skip/success gate, `permissions: {}`, and the PR-head checkout with `persist-credentials: false`. Bonus: the two suites now run in parallel.

*Testing performed:*

- Ran `make test-sh` locally end-to-end (shellspec + kcov 43 + yq + go): 158 examples, 0 failures, `hack/spec/coverage/sonarqube.xml` produced.
- `actionlint` clean on all workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)