### PR TITLE
ci: run test-sh on ubuntu-26.04 (24.04 has no kcov)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -8,6 +8,8 @@ self-hosted-runner:
     - "capmox"
     - "dcd-playground"
     - "capmox-e2e"
+    # GitHub-hosted preview runner; not yet in actionlint's built-in label list.
+    - "ubuntu-26.04"
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.
 # Empty array means no configuration variable is allowed.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@
 #                No PR code execution.
 #   test-go    — PR Go code runs in a digest-pinned Go container with
 #                permissions:{} to avoid cache poisoning.
-#   test-sh    — PR shell tests run on ubuntu-slim with permissions:{},
+#   test-sh    — PR shell tests run on ubuntu-26.04 with permissions:{},
 #                gated by pre-screen exactly like test-go.
 #   sonar      — environment-gated SONAR_TOKEN; upstream and PR trees in
 #                separate paths. Scanner reads PR sources with upstream config
@@ -132,7 +132,8 @@ jobs:
     needs: pre-screen
     # Same pre-screen gate as test-go: fork PRs touching hack/ are already blocked, so running PR shell code here is as safe as test-go.
     if: always() && (needs.pre-screen.result == 'success' || needs.pre-screen.result == 'skipped')
-    runs-on: ubuntu-slim
+    # ubuntu-26.04 ships yq and, unlike 24.04, has kcov (v43, emits sonarqube.xml) in its repos.
+    runs-on: ubuntu-26.04
     permissions: {}
     env:
       GOTOOLCHAIN: local


### PR DESCRIPTION
*Issue #, if available:* n/a (follow-up to #822)

*Description of changes:*

#822 split `test-sh` onto `ubuntu-slim`, but `ubuntu-slim` is Ubuntu 24.04 — which **dropped the `kcov` package** (present through 22.04 at v38, absent in 24.04, returns in 25.04+ at v43). So `sudo apt-get install kcov` fails there with `Unable to locate package kcov`, and kcov v43 ships no prebuilt binary.

`ubuntu-26.04` (public preview) has kcov v43 in its repos (native `sonarqube.xml`, no xsltproc) and ships `yq` preinstalled — exactly what `test-sh` needs. It is a normal VM runner, so `sudo apt-get` and `$GITHUB_PATH` behave normally.

- `test.yml` — `test-sh` runs on `ubuntu-26.04`.
- `actionlint.yaml` — declares `ubuntu-26.04` (actionlint does not yet know this preview label, so the `actionlint` CI job would otherwise fail).

*Testing performed:*

- `actionlint` clean on all workflows (with the new label declared).
- The kcov→`sonarqube.xml` chain was verified locally on kcov 43 during #822 (158 examples, 0 failures, `sonarqube.xml` produced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)