### PR TITLE
ci: unset GITHUB_ACTIONS when running shell tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ lint-sh: ## Run shellcheck on hack/ scripts.
 
 .PHONY: test-sh
 test-sh: ## Run ShellSpec tests for hack/ scripts with kcov coverage.
-	cd hack/spec && shellspec --kcov --kcov-options='--include-path=$(CURDIR)/hack/' $(SHELLSPEC_ARGS)
+	cd hack/spec && env -u GITHUB_ACTIONS shellspec --kcov --kcov-options='--include-path=$(CURDIR)/hack/' $(SHELLSPEC_ARGS)
 
 .PHONY: tilt-up
 tilt-up: ## Start Tilt in a kind cluster.


### PR DESCRIPTION
*Issue #, if available:* n/a (follow-up to #822/#823)

*Description of changes:*

Now that `test-sh` actually runs in CI (on `ubuntu-26.04`), a latent issue surfaced: `verify-versions.sh` emits `::error::` workflow-command annotations to **stdout** when `GITHUB_ACTIONS` is set. The specs assert only on exit **status** and **stderr**, so in CI that unexpected stdout produced **12 shellspec warnings and a non-zero exit** — even though 0 examples actually failed. Locally (no `GITHUB_ACTIONS`) the suite is clean, which is why it passed pre-merge.

Fix: unset `GITHUB_ACTIONS` for the `make test-sh` run so the specs test the script's logic, not its Actions annotation side-channel.

*Testing performed:*

- `GITHUB_ACTIONS=true make test-sh` before: `158 examples, 0 failures, 12 warnings`, exit 2. After: `158 examples, 0 failures`, exit 0, `sonarqube.xml` still produced.
- `make test-sh` without the var: unchanged (`158 examples, 0 failures`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)