### PR TITLE
ci: opt into fork-PR checkout after actions/checkout v7 block

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,8 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          # Fork checkout is safe here: no secrets (permissions:{}), and the pre-screen gates fork PRs.
+          allow-unsafe-pr-checkout: true
 
       # Container runs as root; the workspace is owned by the runner UID. Without this, `git diff` in `make verify` would fail with "dubious ownership".
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -147,6 +149,8 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          # Fork checkout is safe here: no secrets, and the pre-screen blocks fork PRs touching hack/.
+          allow-unsafe-pr-checkout: true
 
       # The shell helpers shell out to `go list` / `go mod edit`; pin Go to go.mod.
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -208,6 +212,8 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          # Fork checkout is safe here: data-only, nothing executes pr/, so SONAR_TOKEN can't leak.
+          allow-unsafe-pr-checkout: true
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
*Issue #, if available:*

None. Fixes external (fork) PR CI, broken by the `actions/checkout` 6.0.3 → 7.0.0 bump — e.g. [run 28521119774](https://github.com/ionos-cloud/cluster-api-provider-proxmox/actions/runs/28521119774) (PR #825) fails with `Refusing to check out fork pull request code`.

*Description of changes:*

`actions/checkout` v7.0.0 ([actions/checkout#2454](https://github.com/actions/checkout/pull/2454)) refuses fork-PR head checkout from `pull_request_target` / `workflow_run` by default. This breaks every external PR's `test` workflow.

Sets `allow-unsafe-pr-checkout: true` on exactly the three fork-head checkouts affected in `test.yml`, each with a comment stating the containment and the forbidden future change:

- **`test-go` / `test-sh`** — execute fork code, but with `permissions: {}`, no secrets, and the base-controlled pre-screen gate. Safety rests on that containment, not on non-execution.
- **`sonar`** — data-only; the scanner reads `pr/` and nothing executes it, so fork code never coincides with `SONAR_TOKEN`. This is the documented safe use of the opt-in.

The `e2e` checkout hit the same block; it is fixed separately by the reusable-workflow redesign in #704 (already on `main`), so it is out of scope here.

Unaffected checkouts (pre-screen base, sonar `upstream` at `base.sha`, pinned ShellSpec) target base/third-party refs, so the guard never fires and they are left unchanged. Internal and dependabot PRs (same-repo head) are not forks and were never affected. No action bump needed — the input already exists in the pinned v7.0.0.

*Testing performed:*

- YAML validated locally; guard trigger conditions cross-checked against the `actions/checkout` v7.0.0 `assertSafePrCheckout` source (refuses only when: fork PR **and** `pull_request_target`/`workflow_run` **and** the checkout targets the fork head repo/ref/sha).
- Full verification requires merge: `pull_request_target` runs the **base branch's** workflow, so an external PR only exercises this fix once it is on `main`.

---
<sub>🤖 Analysis and write-up by Claude (Claude Code, Opus 4.8), directed by @wikkyk. Please verify before merge.</sub>