### PR TITLE
fix: recover from controller VMID collisions

### DIFF
--- a/internal/service/vmservice/find.go
+++ b/internal/service/vmservice/find.go
@@ -39,7 +39,21 @@ var (
 
 	// ErrVMNotInitialized VM is not Initialized in Proxmox.
 	ErrVMNotInitialized = errors.New("vm not initialized")
+
+	// ErrVMIDCollision indicates that a controller-allocated VMID belongs to another VM.
+	ErrVMIDCollision = errors.New("vmid belongs to a different vm")
 )
+
+const vmIDAllocatedByControllerAnnotation = "vmid.capmox.cluster.x-k8s.io/allocated-by-controller"
+
+func vmIDCollisionIsRecoverable(s *scope.MachineScope) bool {
+	return s.ProxmoxMachine.Spec.ProviderID == "" &&
+		s.ProxmoxMachine.Annotations[vmIDAllocatedByControllerAnnotation] == "true"
+}
+
+func placeholderVMName(vmID int64) string {
+	return fmt.Sprintf("VM %d", vmID)
+}
 
 // FindVM returns the Proxmox VM if the vmID is set, otherwise
 // returns ErrVMNotCreated or ErrVMNotFound if the VM doesn't exist.
@@ -54,8 +68,16 @@ func FindVM(ctx context.Context, scope *scope.MachineScope) (*proxmox.VirtualMac
 			scope.Error(err, "unable to find vm")
 			return nil, ErrVMNotFound
 		}
+		if vm.Name == "" || vm.Name == placeholderVMName(vmID) {
+			scope.Info("vm is not initialized yet")
+			return nil, ErrVMNotInitialized
+		}
 		if vm.Name != scope.ProxmoxMachine.GetName() {
-			scope.Error(err, "vm is not initialized yet")
+			if vmIDCollisionIsRecoverable(scope) {
+				return nil, fmt.Errorf("vmid %d resolves to VM %q, expected %q: %w",
+					vmID, vm.Name, scope.ProxmoxMachine.GetName(), ErrVMIDCollision)
+			}
+			scope.Info("vm is not initialized yet")
 			return nil, ErrVMNotInitialized
 		}
 		return vm, nil
@@ -97,7 +119,7 @@ func updateVMLocation(ctx context.Context, s *scope.MachineScope) error {
 	// It might happen that even when a task is already finished,
 	// we still have to wait until we can get the correct
 	// information for a particular resource.
-	if vm.VirtualMachineConfig.Name == "" {
+	if vm.VirtualMachineConfig.Name == "" || vm.VirtualMachineConfig.Name == placeholderVMName(vmID) {
 		return errors.New("vm exists but does not have a name yet")
 	}
 
@@ -105,7 +127,10 @@ func updateVMLocation(ctx context.Context, s *scope.MachineScope) error {
 	// Proxmox machine, we need to stop right there.
 	machineName := s.ProxmoxMachine.GetName()
 	if vm.VirtualMachineConfig.Name != machineName {
-		err := fmt.Errorf("expected VM name to match %q but it was %q", vm.Name, machineName)
+		err := fmt.Errorf("expected VM name to match %q but it was %q", machineName, vm.VirtualMachineConfig.Name)
+		if vmIDCollisionIsRecoverable(s) {
+			return fmt.Errorf("%w: %v", ErrVMIDCollision, err)
+		}
 		conditions.Set(s.ProxmoxMachine, metav1.Condition{
 			Type:    infrav1.ProxmoxMachineVirtualMachineProvisionedCondition,
 			Status:  metav1.ConditionFalse,
@@ -130,4 +155,23 @@ func updateVMLocation(ctx context.Context, s *scope.MachineScope) error {
 	}
 
 	return nil
+}
+
+func recoverFromVMIDCollision(s *scope.MachineScope, cause error) error {
+	s.InfraCluster.ProxmoxCluster.RemoveNodeLocation(s.Name(), util.IsControlPlaneMachine(s.Machine))
+	if err := s.InfraCluster.PatchObject(); err != nil {
+		return errors.Wrap(err, "failed to release stale VM node location")
+	}
+
+	s.ProxmoxMachine.Spec.VirtualMachineID = nil
+	s.ProxmoxMachine.Status.ProxmoxNode = nil
+	delete(s.ProxmoxMachine.Annotations, vmIDAllocatedByControllerAnnotation)
+	conditions.Set(s.ProxmoxMachine, metav1.Condition{
+		Type:    infrav1.ProxmoxMachineVirtualMachineProvisionedCondition,
+		Status:  metav1.ConditionFalse,
+		Reason:  infrav1.ProxmoxMachineVirtualMachineProvisionedCloningReason,
+		Message: cause.Error(),
+	})
+
+	return cause
 }

--- a/internal/service/vmservice/find_test.go
+++ b/internal/service/vmservice/find_test.go
@@ -27,6 +27,8 @@ import (
 	infrav1 "github.com/ionos-cloud/cluster-api-provider-proxmox/api/v1alpha2"
 )
 
+const foreignVMName = "other-cluster-worker"
+
 func TestFindVM_FindByNodeAndID(t *testing.T) {
 	ctx := context.TODO()
 	machineScope, proxmoxClient, _ := setupReconcilerTest(t)
@@ -89,6 +91,52 @@ func TestFindVM_NotInitialized(t *testing.T) {
 	require.ErrorIs(t, err, ErrVMNotInitialized)
 }
 
+func TestFindVM_ControllerAllocatedVMIDCollision(t *testing.T) {
+	ctx := context.TODO()
+	machineScope, proxmoxClient, _ := setupReconcilerTest(t)
+	vm := newRunningVM()
+	vm.Name = foreignVMName
+	machineScope.ProxmoxMachine.Spec.VirtualMachineID = new(int64(vm.VMID))
+	machineScope.ProxmoxMachine.Status.ProxmoxNode = new("node2")
+	machineScope.SetAnnotation(vmIDAllocatedByControllerAnnotation, "true")
+
+	proxmoxClient.EXPECT().GetVM(ctx, "node2", int64(123)).Return(vm, nil).Once()
+
+	_, err := FindVM(ctx, machineScope)
+	require.ErrorIs(t, err, ErrVMIDCollision)
+}
+
+func TestFindVM_ControllerAllocatedPlaceholderNotInitialized(t *testing.T) {
+	ctx := context.TODO()
+	machineScope, proxmoxClient, _ := setupReconcilerTest(t)
+	vm := newRunningVM()
+	vm.Name = placeholderVMName(int64(vm.VMID))
+	machineScope.ProxmoxMachine.Spec.VirtualMachineID = new(int64(vm.VMID))
+	machineScope.ProxmoxMachine.Status.ProxmoxNode = new("node2")
+	machineScope.SetAnnotation(vmIDAllocatedByControllerAnnotation, "true")
+
+	proxmoxClient.EXPECT().GetVM(ctx, "node2", int64(123)).Return(vm, nil).Once()
+
+	_, err := FindVM(ctx, machineScope)
+	require.ErrorIs(t, err, ErrVMNotInitialized)
+}
+
+func TestFindVM_AdoptedNameMismatchNotRecoverable(t *testing.T) {
+	ctx := context.TODO()
+	machineScope, proxmoxClient, _ := setupReconcilerTest(t)
+	vm := newRunningVM()
+	vm.Name = "renamed-vm"
+	machineScope.ProxmoxMachine.Spec.VirtualMachineID = new(int64(vm.VMID))
+	machineScope.ProxmoxMachine.Spec.ProviderID = "proxmox://existing-vm"
+	machineScope.ProxmoxMachine.Status.ProxmoxNode = new("node2")
+	machineScope.SetAnnotation(vmIDAllocatedByControllerAnnotation, "true")
+
+	proxmoxClient.EXPECT().GetVM(ctx, "node2", int64(123)).Return(vm, nil).Once()
+
+	_, err := FindVM(ctx, machineScope)
+	require.ErrorIs(t, err, ErrVMNotInitialized)
+}
+
 func TestUpdateVMLocation_MissingName(t *testing.T) {
 	ctx := context.TODO()
 	machineScope, proxmoxClient, _ := setupReconcilerTest(t)
@@ -120,6 +168,26 @@ func TestUpdateVMLocation_NameMismatch(t *testing.T) {
 	require.Error(t, updateVMLocation(ctx, machineScope))
 	requireConditionIsFalse(t, machineScope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition)
 	require.True(t, machineScope.HasFailed())
+}
+
+func TestUpdateVMLocation_ControllerAllocatedVMIDCollision(t *testing.T) {
+	ctx := context.TODO()
+	machineScope, proxmoxClient, _ := setupReconcilerTest(t)
+	vm := newRunningVM()
+	vmr := newVMResource()
+	name := foreignVMName
+	vmr.Name = name
+	vm.VirtualMachineConfig.Name = name
+	machineScope.ProxmoxMachine.Spec.VirtualMachineID = new(int64(vm.VMID))
+	machineScope.SetAnnotation(vmIDAllocatedByControllerAnnotation, "true")
+
+	proxmoxClient.EXPECT().FindVMResource(ctx, uint64(123)).Return(vmr, nil).Once()
+	proxmoxClient.EXPECT().GetVM(ctx, "node1", int64(123)).Return(vm, nil).Once()
+
+	err := updateVMLocation(ctx, machineScope)
+	require.ErrorIs(t, err, ErrVMIDCollision)
+	require.False(t, machineScope.HasFailed())
+	require.Equal(t, int64(123), machineScope.GetVirtualMachineID())
 }
 
 func TestUpdateVMLocation_UpdateNode(t *testing.T) {

--- a/internal/service/vmservice/find_test.go
+++ b/internal/service/vmservice/find_test.go
@@ -27,8 +27,6 @@ import (
 	infrav1 "github.com/ionos-cloud/cluster-api-provider-proxmox/api/v1alpha2"
 )
 
-const foreignVMName = "other-cluster-worker"
-
 func TestFindVM_FindByNodeAndID(t *testing.T) {
 	ctx := context.TODO()
 	machineScope, proxmoxClient, _ := setupReconcilerTest(t)
@@ -95,7 +93,7 @@ func TestFindVM_ControllerAllocatedVMIDCollision(t *testing.T) {
 	ctx := context.TODO()
 	machineScope, proxmoxClient, _ := setupReconcilerTest(t)
 	vm := newRunningVM()
-	vm.Name = foreignVMName
+	vm.Name = t.Name()
 	machineScope.ProxmoxMachine.Spec.VirtualMachineID = new(int64(vm.VMID))
 	machineScope.ProxmoxMachine.Status.ProxmoxNode = new("node2")
 	machineScope.SetAnnotation(vmIDAllocatedByControllerAnnotation, "true")
@@ -175,7 +173,7 @@ func TestUpdateVMLocation_ControllerAllocatedVMIDCollision(t *testing.T) {
 	machineScope, proxmoxClient, _ := setupReconcilerTest(t)
 	vm := newRunningVM()
 	vmr := newVMResource()
-	name := foreignVMName
+	name := t.Name()
 	vmr.Name = name
 	vm.VirtualMachineConfig.Name = name
 	machineScope.ProxmoxMachine.Spec.VirtualMachineID = new(int64(vm.VMID))

--- a/internal/service/vmservice/vm.go
+++ b/internal/service/vmservice/vm.go
@@ -213,12 +213,17 @@ func ensureVirtualMachine(ctx context.Context, machineScope *scope.MachineScope)
 	if err != nil {
 		switch {
 		case errors.Is(err, ErrVMNotFound):
-			if err := updateVMLocation(ctx, machineScope); err != nil {
-				return false, errors.Wrap(err, "error trying to locate vm")
+			if locationErr := updateVMLocation(ctx, machineScope); locationErr != nil {
+				if errors.Is(locationErr, ErrVMIDCollision) {
+					return false, recoverFromVMIDCollision(machineScope, locationErr)
+				}
+				return false, errors.Wrap(locationErr, "error trying to locate vm")
 			}
 
 			// we always want to trigger reconciliation at this point.
 			return false, err
+		case errors.Is(err, ErrVMIDCollision):
+			return false, recoverFromVMIDCollision(machineScope, err)
 		case errors.Is(err, ErrVMNotInitialized):
 			return true, err
 		case !errors.Is(err, ErrVMNotCreated):
@@ -245,6 +250,7 @@ func ensureVirtualMachine(ctx context.Context, machineScope *scope.MachineScope)
 		// make sure spec.VirtualMachineID is always set.
 		machineScope.ProxmoxMachine.Status.TaskRef = new(string(resp.Task.UPID))
 		machineScope.SetVirtualMachineID(resp.NewID)
+		machineScope.SetAnnotation(vmIDAllocatedByControllerAnnotation, "true")
 
 		// requeue until cloning is finished
 		return true, nil

--- a/internal/service/vmservice/vm_test.go
+++ b/internal/service/vmservice/vm_test.go
@@ -23,6 +23,7 @@ import (
 
 	lutherproxmox "github.com/luthermonson/go-proxmox"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
@@ -142,6 +143,7 @@ func TestEnsureVirtualMachine_CreateVM_FullOptions(t *testing.T) {
 
 	require.Equal(t, "node2", *machineScope.ProxmoxMachine.Status.ProxmoxNode)
 	require.True(t, machineScope.InfraCluster.ProxmoxCluster.HasMachine(machineScope.Name(), false))
+	require.Equal(t, "true", machineScope.ProxmoxMachine.Annotations[vmIDAllocatedByControllerAnnotation])
 	requireConditionIsFalse(t, machineScope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition)
 }
 
@@ -415,6 +417,66 @@ func TestEnsureVirtualMachine_UpdateVMLocation_Error(t *testing.T) {
 
 	_, err := ensureVirtualMachine(context.Background(), machineScope)
 	require.Error(t, err)
+}
+
+func TestEnsureVirtualMachine_VMIDCollisionRecovers(t *testing.T) {
+	ctx := context.Background()
+	machineScope, proxmoxClient, _ := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedCloningReason)
+	machineScope.SetVirtualMachineID(123)
+	machineScope.ProxmoxMachine.Status.ProxmoxNode = new("node2")
+	machineScope.SetAnnotation(vmIDAllocatedByControllerAnnotation, "true")
+	machineScope.InfraCluster.ProxmoxCluster.AddNodeLocation(infrav1.NodeLocation{
+		Machine: corev1.LocalObjectReference{Name: machineScope.Name()},
+		Node:    "node2",
+	}, false)
+
+	foreignVM := newRunningVM()
+	foreignVM.Name = foreignVMName
+	foreignVM.VirtualMachineConfig.Name = foreignVM.Name
+	vmResource := newVMResource()
+	vmResource.Name = foreignVM.Name
+
+	proxmoxClient.EXPECT().GetVM(ctx, "node2", int64(123)).Return(nil, fmt.Errorf("not found")).Once()
+	proxmoxClient.EXPECT().FindVMResource(ctx, uint64(123)).Return(vmResource, nil).Once()
+	proxmoxClient.EXPECT().GetVM(ctx, "node1", int64(123)).Return(foreignVM, nil).Once()
+
+	requeue, err := ensureVirtualMachine(ctx, machineScope)
+	require.Error(t, err)
+	require.False(t, requeue)
+	require.False(t, machineScope.HasFailed())
+	require.Equal(t, infrav1.ProxmoxMachineVirtualMachineProvisionedCloningReason,
+		conditions.GetReason(machineScope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition))
+	require.Equal(t, int64(-1), machineScope.GetVirtualMachineID())
+	require.Nil(t, machineScope.ProxmoxMachine.Status.ProxmoxNode)
+	require.NotContains(t, machineScope.ProxmoxMachine.Annotations, vmIDAllocatedByControllerAnnotation)
+	require.False(t, machineScope.InfraCluster.ProxmoxCluster.HasMachine(machineScope.Name(), false))
+}
+
+func TestEnsureVirtualMachine_VMIDCollisionAtRecordedNodeRecovers(t *testing.T) {
+	ctx := context.Background()
+	machineScope, proxmoxClient, _ := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedCloningReason)
+	machineScope.SetVirtualMachineID(123)
+	machineScope.ProxmoxMachine.Status.ProxmoxNode = new("node1")
+	machineScope.SetAnnotation(vmIDAllocatedByControllerAnnotation, "true")
+	machineScope.InfraCluster.ProxmoxCluster.AddNodeLocation(infrav1.NodeLocation{
+		Machine: corev1.LocalObjectReference{Name: machineScope.Name()},
+		Node:    "node1",
+	}, false)
+
+	foreignVM := newRunningVM()
+	foreignVM.Name = foreignVMName
+	proxmoxClient.EXPECT().GetVM(ctx, "node1", int64(123)).Return(foreignVM, nil).Once()
+
+	requeue, err := ensureVirtualMachine(ctx, machineScope)
+	require.ErrorIs(t, err, ErrVMIDCollision)
+	require.False(t, requeue)
+	require.False(t, machineScope.HasFailed())
+	require.Equal(t, infrav1.ProxmoxMachineVirtualMachineProvisionedCloningReason,
+		conditions.GetReason(machineScope.ProxmoxMachine, infrav1.ProxmoxMachineVirtualMachineProvisionedCondition))
+	require.Equal(t, int64(-1), machineScope.GetVirtualMachineID())
+	require.Nil(t, machineScope.ProxmoxMachine.Status.ProxmoxNode)
+	require.NotContains(t, machineScope.ProxmoxMachine.Annotations, vmIDAllocatedByControllerAnnotation)
+	require.False(t, machineScope.InfraCluster.ProxmoxCluster.HasMachine(machineScope.Name(), false))
 }
 
 func TestReconcileVirtualMachineConfig_NoConfig(t *testing.T) {

--- a/internal/service/vmservice/vm_test.go
+++ b/internal/service/vmservice/vm_test.go
@@ -431,7 +431,7 @@ func TestEnsureVirtualMachine_VMIDCollisionRecovers(t *testing.T) {
 	}, false)
 
 	foreignVM := newRunningVM()
-	foreignVM.Name = foreignVMName
+	foreignVM.Name = t.Name()
 	foreignVM.VirtualMachineConfig.Name = foreignVM.Name
 	vmResource := newVMResource()
 	vmResource.Name = foreignVM.Name
@@ -464,7 +464,7 @@ func TestEnsureVirtualMachine_VMIDCollisionAtRecordedNodeRecovers(t *testing.T) 
 	}, false)
 
 	foreignVM := newRunningVM()
-	foreignVM.Name = foreignVMName
+	foreignVM.Name = t.Name()
 	proxmoxClient.EXPECT().GetVM(ctx, "node1", int64(123)).Return(foreignVM, nil).Once()
 
 	requeue, err := ensureVirtualMachine(ctx, machineScope)


### PR DESCRIPTION
Fixes #842
Description of changes:
Detects when a controller-allocated VMID resolves to another VM.
Releases the stale node location and clears the VMID, node status, and allocation annotation so reconciliation can retry with a new ID.
Handles collisions both at the recorded node and during cluster-wide VM relocation.
Treats Proxmox’s temporary VM <vmid> name as an uninitialized clone.
Preserves existing behavior for operator-pinned and already-adopted VMs.
Corrects the expected/actual VM-name error message.
Adds regression tests for collision recovery and placeholder names.
Testing performed:
go test ./internal/service/vmservice -run 'TestFindVM_|TestUpdateVMLocation_|TestEnsureVirtualMachine_VMIDCollision|TestEnsureVirtualMachine_CreateVM_FullOptions$' -count=1
go test ./internal/service/vmservice/... -count=1
go vet ./internal/service/vmservice/...
go test ./internal/service/... ./pkg/scope/... -count=1
make lint
make test
git diff --check
Also tested on stage cluster. Problem gone. Regressions not found