### PR TITLE
feat: keep test.yml's pinned Go image in sync via bump-go.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ make test-sh          # Run ShellSpec tests for hack/ scripts with kcov coverage
 Several dependencies appear in multiple files and must be updated atomically. Use the helper scripts in `hack/` rather than editing files manually:
 
 ```bash
-hack/bump-go.sh 1.26.0          # go.mod, Dockerfile, .golangci-kal.yml
+hack/bump-go.sh 1.26.0 [<digest>] # go.mod, Dockerfile, .golangci-kal.yml, .github/workflows/test.yml's pinned image (digest looked up live if omitted)
 hack/bump-capi.sh 1.11.0        # go.mod require+replace, e2e config, test/e2e/data/shared/<contract>/metadata.yaml
 hack/bump-golangci-lint.sh v2.10.0 # go.mod require+replace, .custom-gcl.yaml
 hack/bump-k8s.sh 0.33.0         # go.mod k8s.io/{api,apimachinery,client-go,code-generator}, test/e2e/config KUBERNETES_VERSION, docs --kubernetes-version

--- a/hack/bump-go.sh
+++ b/hack/bump-go.sh
@@ -3,17 +3,19 @@
 #   - go.mod
 #   - Dockerfile
 #   - .golangci-kal.yml (run.go)
+#   - .github/workflows/test.yml (pinned Go container image)
 #
-# Usage:   ./hack/bump-go.sh <new-version>
+# Usage:   ./hack/bump-go.sh <new-version> [<digest>]
 # Example: ./hack/bump-go.sh 1.26.0
+# Example: ./hack/bump-go.sh 1.26.4 sha256:0dcba0d95dbfb072e9917a106b9e07d7cc298097dc83e9307056ef1889de654d
 
 set -euo pipefail
 
 # shellcheck source=hack/helpers.sh
 source "$(dirname "$0")/helpers.sh"
 
-if [[ $# -ne 1 ]]; then
-    echo "Usage: $0 <new-version>" >&2
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    echo "Usage: $0 <new-version> [<digest>]" >&2
     echo "Example: $0 1.26.0" >&2
     exit 1
 fi
@@ -21,11 +23,14 @@ fi
 # Go versions don't use a 'v' prefix
 NEW=$(strip_v_prefix "$1")
 validate_semver "${NEW}"
+DIGEST="${2:-}"
+if [[ -n "${DIGEST}" ]]; then validate_sha256 "${DIGEST}"; fi
 
 NEW_MINOR=$(echo "${NEW}" | cut -d. -f1-2)
 
 gomod_set_go "${NEW}"
 dockerfile_set_go "${NEW_MINOR}"
 golangcikal_set_go "${NEW_MINOR}"
+testworkflow_set_go_image "${NEW}" "${DIGEST}"
 
 gomod_tidy

--- a/hack/helpers.sh
+++ b/hack/helpers.sh
@@ -35,6 +35,19 @@ validate_semver() {
     return
 }
 
+# validate_sha256 exits with an error if the argument is not a valid sha256
+# digest, with or without a leading "sha256:" prefix.
+validate_sha256() {
+    local raw="$1" v
+    v="${raw#sha256:}"
+    if ! [[ "${v}" =~ ^[0-9a-f]{64}$ ]]; then
+        echo "ERROR: invalid sha256 digest '${raw}'" >&2
+        echo "Expected: 64 hex characters, with or without a 'sha256:' prefix" >&2
+        exit 1
+    fi
+    return
+}
+
 # validate_capi exits with an error if the argument is not a valid cluster-api
 # contract version.
 # Accepts v1betaN (e.g. v1beta2).
@@ -241,6 +254,50 @@ golangcikal_get_go() {
     return
 }
 
+# TEST_WORKFLOW_FILE pins the Go container image used by the test-go job.
+TEST_WORKFLOW_FILE="${REPO_ROOT}/.github/workflows/test.yml"
+
+# testworkflow_get_go_minor returns the Go major.minor of the active test-go
+# matrix entry (e.g. "1.26"). Returns empty string if the file does not exist.
+testworkflow_get_go_minor() {
+    if [[ -f "${TEST_WORKFLOW_FILE}" ]]; then
+        awk '/^[[:space:]]*- go: "/{match($0, /[0-9]+\.[0-9]+/); print substr($0, RSTART, RLENGTH); exit}' "${TEST_WORKFLOW_FILE}"
+    fi
+    return
+}
+
+# testworkflow_get_go_tag returns the image tag comment of the active
+# test-go matrix entry (e.g. "1.26.4-trixie").
+testworkflow_get_go_tag() {
+    if [[ -f "${TEST_WORKFLOW_FILE}" ]]; then
+        awk '/^[[:space:]]*image: golang@sha256:/{sub(/.*# /, ""); print; exit}' "${TEST_WORKFLOW_FILE}"
+    fi
+    return
+}
+
+# testworkflow_get_go_digest returns the pinned sha256 digest (without the
+# "sha256:" prefix) of the active test-go matrix entry.
+testworkflow_get_go_digest() {
+    if [[ -f "${TEST_WORKFLOW_FILE}" ]]; then
+        awk '/^[[:space:]]*image: golang@sha256:/{match($0, /sha256:[0-9a-f]+/); print substr($0, RSTART+7, RLENGTH-7); exit}' "${TEST_WORKFLOW_FILE}"
+    fi
+    return
+}
+
+# docker_resolve_digest resolves the sha256 digest (without the "sha256:"
+# prefix) of a Docker image reference such as "golang:1.26.4-trixie".
+docker_resolve_digest() {
+    local image="$1" digest
+    digest=$(docker buildx imagetools inspect "${image}" --format '{{json .Manifest}}' | yq -p json '.digest')
+    digest="${digest#sha256:}"
+    if ! [[ "${digest}" =~ ^[0-9a-f]{64}$ ]]; then
+        echo "ERROR: failed to resolve digest for ${image}" >&2
+        return 1
+    fi
+    echo "${digest}"
+    return
+}
+
 # customgcl_get_version returns the golangci-lint version from .custom-gcl.yaml
 # (e.g. "v2.9.0"). Returns empty string if the file does not exist.
 customgcl_get_version() {
@@ -282,6 +339,36 @@ golangcikal_set_go() {
         if yqsi ".run.go = \"${new}\" | .run.go style=\"double\"" "${f}"; then
             echo ".golangci-kal.yml: Updated Go ${old} to ${new}"
         fi
+    fi
+    return
+}
+
+# testworkflow_set_go_image writes the pinned Go image digest for the
+# active test-go matrix entry, given a new Go version. If a digest is
+# given, it's used as-is; otherwise it's resolved via docker_resolve_digest.
+# Only takes effect when the version's major.minor matches the entry
+# already active.
+# Usage: testworkflow_set_go_image <new-version> [<digest>]
+testworkflow_set_go_image() {
+    local new="$1" given_digest="${2:-}" new_minor active_minor old_tag old_digest suffix new_tag new_digest
+    if [[ ! -f "${TEST_WORKFLOW_FILE}" ]]; then return; fi
+
+    new_minor=$(echo "${new}" | cut -d. -f1-2)
+    active_minor=$(testworkflow_get_go_minor)
+    if [[ "${active_minor}" != "${new_minor}" ]]; then return; fi
+
+    old_tag=$(testworkflow_get_go_tag)
+    old_digest=$(testworkflow_get_go_digest)
+    suffix=$(echo "${old_tag}" | sed -E 's/^[0-9]+\.[0-9]+\.[0-9]+//')
+    new_tag="${new}${suffix}"
+    if [[ -n "${given_digest}" ]]; then
+        new_digest="${given_digest#sha256:}"
+    else
+        new_digest=$(docker_resolve_digest "golang:${new_tag}")
+    fi
+
+    if sedi "s/^([[:space:]]*image: golang@sha256:)[0-9a-f]+( # ).*/\1${new_digest}\2${new_tag}/" "${TEST_WORKFLOW_FILE}"; then
+        echo ".github/workflows/test.yml: Updated golang@sha256:${old_digest} (${old_tag}) to golang@sha256:${new_digest} (${new_tag})"
     fi
     return
 }

--- a/hack/spec/bump_go_spec.sh
+++ b/hack/spec/bump_go_spec.sh
@@ -1,6 +1,6 @@
 Describe 'bump-go.sh'
-  setup() { setup_fixture_repo; setup_go_mock; return; }
-  cleanup() { cleanup_fixture_repo; cleanup_go_mock; return; }
+  setup() { setup_fixture_repo; setup_go_mock; setup_docker_mock; return; }
+  cleanup() { cleanup_docker_mock; cleanup_go_mock; cleanup_fixture_repo; return; }
   BeforeEach 'setup'
   AfterEach 'cleanup'
 
@@ -32,9 +32,40 @@ Describe 'bump-go.sh'
     The error should include 'Usage:'
   End
 
+  It 'fails with too many arguments'
+    When run script ../bump-go.sh 1.26.0 sha256:cafebabe extra
+    The status should be failure
+    The error should include 'Usage:'
+  End
+
   It 'fails with invalid version'
     When run script ../bump-go.sh 'not-a-version'
     The status should be failure
     The error should include 'invalid version format'
+  End
+
+  It 'fails with an invalid digest'
+    When run script ../bump-go.sh 1.26.0 not-a-digest
+    The status should be failure
+    The error should include 'invalid sha256 digest'
+  End
+
+  It 'resolves and updates the test workflow image for the active minor'
+    When run script ../bump-go.sh 1.25.3
+    The status should be success
+    The output should include '.github/workflows/test.yml: Updated golang@sha256:abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd (1.25.0-trixie) to golang@sha256:cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe (1.25.3-trixie)'
+  End
+
+  It 'does not touch the test workflow image on a Go minor bump'
+    When run script ../bump-go.sh 1.26.0
+    The status should be success
+    The output should not include 'test.yml'
+  End
+
+  It 'uses a given digest directly, without invoking docker'
+    printf '#!/usr/bin/env bash\nexit 1\n' > "${DOCKER_MOCK_DIR}/docker"
+    When run script ../bump-go.sh 1.25.3 sha256:1234123412341234123412341234123412341234123412341234123412341234
+    The status should be success
+    The output should include 'to golang@sha256:1234123412341234123412341234123412341234123412341234123412341234'
   End
 End

--- a/hack/spec/fixtures/.github/workflows/test.yml
+++ b/hack/spec/fixtures/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  test-go:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - go: "1.25"
+            image: golang@sha256:abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd # 1.25.0-trixie
+          #- go: "1.26"
+          #  image: golang@sha256:TODO # 1.26.0-trixie
+    container:
+      image: ${{ matrix.image }}
+    steps:
+      - run: make test

--- a/hack/spec/helpers_file_versions_spec.sh
+++ b/hack/spec/helpers_file_versions_spec.sh
@@ -1,6 +1,6 @@
 Describe 'helpers.sh — file version functions'
-  setup() { setup_fixture_repo; return; }
-  cleanup() { cleanup_fixture_repo; return; }
+  setup() { setup_fixture_repo; setup_docker_mock; return; }
+  cleanup() { cleanup_docker_mock; cleanup_fixture_repo; return; }
   BeforeEach 'setup'
   AfterEach 'cleanup'
 
@@ -49,6 +49,92 @@ Describe 'helpers.sh — file version functions'
       golangcikal_set_go '1.26' >/dev/null
       When call cat "${REPO_ROOT}/.golangci-kal.yml"
       The output should include 'go: "1.26"'
+    End
+  End
+
+  Describe 'testworkflow_get_go_minor'
+    It 'returns the Go major.minor of the active matrix entry'
+      When call testworkflow_get_go_minor
+      The output should equal '1.25'
+    End
+  End
+
+  Describe 'testworkflow_get_go_tag'
+    It 'returns the image tag comment of the active matrix entry'
+      When call testworkflow_get_go_tag
+      The output should equal '1.25.0-trixie'
+    End
+  End
+
+  Describe 'testworkflow_get_go_digest'
+    It 'returns the pinned sha256 digest of the active matrix entry'
+      When call testworkflow_get_go_digest
+      The output should equal 'abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd'
+    End
+  End
+
+  Describe 'docker_resolve_digest'
+    It 'resolves a digest via the mocked docker buildx imagetools inspect'
+      When call docker_resolve_digest 'golang:1.25.3-trixie'
+      The output should equal 'cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe'
+    End
+  End
+
+  Describe 'testworkflow_set_go_image'
+    It 'resolves and writes the digest and tag when the minor matches'
+      When call testworkflow_set_go_image '1.25.3'
+      The output should include 'Updated golang@sha256:abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd (1.25.0-trixie)'
+      The output should include 'to golang@sha256:cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe (1.25.3-trixie)'
+    End
+
+    It 'writes the new digest and tag to the file'
+      testworkflow_set_go_image '1.25.3' >/dev/null
+      When call testworkflow_get_go_digest
+      The output should equal 'cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe'
+    End
+
+    It 'preserves the tag suffix'
+      testworkflow_set_go_image '1.25.3' >/dev/null
+      When call testworkflow_get_go_tag
+      The output should equal '1.25.3-trixie'
+    End
+
+    It 'does not touch the file on a Go minor bump'
+      When call testworkflow_set_go_image '1.26.0'
+      The output should equal ''
+      The status should be success
+    End
+
+    It 'leaves the matrix entry untouched on a Go minor bump'
+      testworkflow_set_go_image '1.26.0' >/dev/null
+      When call testworkflow_get_go_digest
+      The output should equal 'abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd'
+    End
+
+    It 're-resolves and refreshes the digest even when the version is unchanged'
+      When call testworkflow_set_go_image '1.25.0'
+      The output should include 'Updated golang@sha256:abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd (1.25.0-trixie)'
+      The output should include 'to golang@sha256:cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe (1.25.0-trixie)'
+    End
+
+    It 'stays silent when the resolved digest already matches (idempotent)'
+      testworkflow_set_go_image '1.25.3' >/dev/null
+      When call testworkflow_set_go_image '1.25.3'
+      The output should equal ''
+      The status should be success
+    End
+
+    It 'uses a given digest directly, without invoking docker'
+      printf '#!/usr/bin/env bash\nexit 1\n' > "${DOCKER_MOCK_DIR}/docker"
+      When call testworkflow_set_go_image '1.25.3' 'sha256:1234123412341234123412341234123412341234123412341234123412341234'
+      The output should include 'to golang@sha256:1234123412341234123412341234123412341234123412341234123412341234 (1.25.3-trixie)'
+      The status should be success
+    End
+
+    It 'accepts a given digest without the sha256: prefix'
+      printf '#!/usr/bin/env bash\nexit 1\n' > "${DOCKER_MOCK_DIR}/docker"
+      When call testworkflow_set_go_image '1.25.3' '1234123412341234123412341234123412341234123412341234123412341234'
+      The output should include 'to golang@sha256:1234123412341234123412341234123412341234123412341234123412341234 (1.25.3-trixie)'
     End
   End
 

--- a/hack/spec/helpers_spec.sh
+++ b/hack/spec/helpers_spec.sh
@@ -49,6 +49,24 @@ Describe 'helpers.sh — pure functions'
     End
   End
 
+  Describe 'validate_sha256'
+    It 'accepts a valid digest'
+      When call validate_sha256 'cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe'
+      The status should be success
+    End
+
+    It 'accepts a valid digest with sha256: prefix'
+      When call validate_sha256 'sha256:cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe'
+      The status should be success
+    End
+
+    It 'rejects a malformed digest'
+      When run validate_sha256 'not-a-digest'
+      The status should be failure
+      The error should include 'invalid sha256 digest'
+    End
+  End
+
   Describe 'validate_capi'
     It 'accepts a valid contract'
       When call validate_capi 'v1beta2'

--- a/hack/spec/spec_helper.sh
+++ b/hack/spec/spec_helper.sh
@@ -16,6 +16,7 @@ setup_fixture_repo() {
   # Re-evaluate paths set at source time by helpers.sh.
   METADATA_FILE="${REPO_ROOT}/metadata.yaml"
   E2E_CONFIG_DIR="${REPO_ROOT}/test/e2e/config"
+  TEST_WORKFLOW_FILE="${REPO_ROOT}/.github/workflows/test.yml"
   return
 }
 
@@ -62,6 +63,37 @@ cleanup_go_mock() {
   fi
   if [[ -n "${ORIGINAL_PATH:-}" ]]; then
     export PATH="${ORIGINAL_PATH}"
+  fi
+  return
+}
+
+# setup_docker_mock creates a temporary directory with a mock `docker`
+# script emulating `docker buildx imagetools inspect`, and prepends it to
+# PATH.
+setup_docker_mock() {
+  DOCKER_MOCK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/capmox-docker-mock.XXXXXX")
+  cat > "${DOCKER_MOCK_DIR}/docker" <<'MOCK'
+#!/usr/bin/env bash
+if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "inspect" ]]; then
+  echo '{"mediaType":"application/vnd.oci.image.index.v1+json","digest":"sha256:cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe","size":9050}'
+  exit 0
+fi
+echo "mock docker: unexpected invocation: $*" >&2
+exit 1
+MOCK
+  chmod +x "${DOCKER_MOCK_DIR}/docker"
+  ORIGINAL_PATH_DOCKER="${PATH}"
+  export PATH="${DOCKER_MOCK_DIR}:${PATH}"
+  return
+}
+
+# cleanup_docker_mock removes the mock directory and restores PATH.
+cleanup_docker_mock() {
+  if [[ -n "${DOCKER_MOCK_DIR:-}" && -d "${DOCKER_MOCK_DIR}" ]]; then
+    rm -rf "${DOCKER_MOCK_DIR}"
+  fi
+  if [[ -n "${ORIGINAL_PATH_DOCKER:-}" ]]; then
+    export PATH="${ORIGINAL_PATH_DOCKER}"
   fi
   return
 }

--- a/hack/spec/verify_versions_spec.sh
+++ b/hack/spec/verify_versions_spec.sh
@@ -1,6 +1,6 @@
 Describe 'verify-versions.sh'
-  setup() { setup_fixture_repo; setup_go_mock; return; }
-  cleanup() { cleanup_fixture_repo; cleanup_go_mock; return; }
+  setup() { setup_fixture_repo; setup_go_mock; setup_docker_mock; return; }
+  cleanup() { cleanup_docker_mock; cleanup_go_mock; cleanup_fixture_repo; return; }
   BeforeEach 'setup'
   AfterEach 'cleanup'
 
@@ -24,6 +24,21 @@ Describe 'verify-versions.sh'
     The status should be failure
     The error should include 'Go version mismatch'
     The error should include '.golangci-kal.yml'
+  End
+
+  It 'detects Go version mismatch in the test workflow pinned image tag'
+    testworkflow_set_go_image '1.25.9' >/dev/null
+    When run script ../verify-versions.sh
+    The status should be failure
+    The error should include 'Go version mismatch'
+    The error should include '.github/workflows/test.yml'
+  End
+
+  It 'ignores the test workflow image when its minor differs from go.mod'
+    gomod_set_go '1.26.0' >/dev/null
+    When run script ../verify-versions.sh
+    The status should be failure
+    The error should not include 'test.yml'
   End
 
   It 'detects golangci-lint version mismatch in .custom-gcl.yaml'

--- a/hack/verify-versions.sh
+++ b/hack/verify-versions.sh
@@ -38,6 +38,17 @@ if [[ "${GOLANGCI_KAL_GO_VERSION}" != "${GO_VERSION_MINOR}" ]]; then
     fail "Go version mismatch: go.mod has '${GO_VERSION_ROOT}' (${GO_VERSION_MINOR}), .golangci-kal.yml run.go has '${GOLANGCI_KAL_GO_VERSION}'"
 fi
 
+# test.yml's pinned image tag should track go.mod when the matrix's Go
+# minor matches (a mismatch means the row is mid-transition).
+TESTWORKFLOW_GO_MINOR=$(testworkflow_get_go_minor)
+if [[ "${TESTWORKFLOW_GO_MINOR}" == "${GO_VERSION_MINOR}" ]]; then
+    TESTWORKFLOW_GO_TAG=$(testworkflow_get_go_tag)
+    TESTWORKFLOW_GO_VERSION=$(echo "${TESTWORKFLOW_GO_TAG}" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' || true)
+    if [[ "${TESTWORKFLOW_GO_VERSION}" != "${GO_VERSION_ROOT}" ]]; then
+        fail "Go version mismatch: go.mod has '${GO_VERSION_ROOT}', .github/workflows/test.yml pinned image tag is '${TESTWORKFLOW_GO_TAG}'"
+    fi
+fi
+
 # ---- golangci-lint version ----
 # The golangci-lint require directive, replace directive, and .custom-gcl.yaml
 # must all use the same version. Dependabot bumps `require` but leaves


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

The `test-go` job in `.github/workflows/test.yml` pins its container image by digest (`golang@sha256:... # 1.26.4-trixie`) for supply-chain safety, but nothing kept that pin in sync with `go.mod`'s Go version — bumping Go required manually finding and pasting in a new digest.

- `hack/bump-go.sh` now also updates `test.yml`'s pinned image. By default it resolves the new digest live via `docker buildx imagetools inspect` (no pull required); an optional second argument lets you pass a digest directly instead, bypassing Docker entirely.
- The image update only applies when the new version's Go minor matches the workflow's currently active matrix row — switching to a new Go minor activates a different, currently-commented-out row, which is a separate, deliberate workflow edit this script doesn't attempt.
- `hack/verify-versions.sh` gained a check that flags drift between `go.mod` and the pinned image tag when their Go minors agree.

*Testing performed:*

- `make test-sh` (ShellSpec, 181 examples) and `shellcheck hack/*.sh` pass, including new coverage for the resolve/explicit-digest paths (mocked `docker`, no real network needed).
- `hack/verify-versions.sh` passes against the real repo.
- Verified live end-to-end against a copy of the real `test.yml`: `docker buildx imagetools inspect` resolves the current digest for `golang:1.26.4-trixie` (confirmed it differs from the repo's existing stale pin — expected, since official image tags get rebuilt in place), the write is correct, and reruns are idempotent. Also verified the explicit-digest path with `docker` entirely removed from `PATH`, confirming it never shells out to Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)