### PR TITLE
Update docs to replace resolutionPolicy with matchPolicy

### DIFF
--- a/docs/advanced-setups.md
+++ b/docs/advanced-setups.md
@@ -185,11 +185,11 @@ For example, you can set the `TEMPLATE_TAGS="tag1,tag2"` environment variable. Y
 Template selection is controlled by the `TemplateSelector` on the `ProxmoxMachine`:
 
 - `matchTags`: the list of tags that should be used when searching for a VM template.
-- `resolutionPolicy`: controls how `matchTags` are evaluated against the tags on a template. It supports two values:
+- `matchPolicy`: controls how `matchTags` are evaluated against the tags on a template. It supports two values:
   - `exact` (default): the template's tags must be an exact 1:1 match with `matchTags` (after normalisation). This preserves the behaviour from earlier releases.
   - `subset`: the template's tags must contain all of the `matchTags`, but may include additional tags.
 
-The lookup must always result in a unique template. If no template or more than one template matches the configured tags under the chosen `resolutionPolicy`, provisioning will fail.
+The lookup must always result in a unique template. If no template or more than one template matches the configured tags under the chosen `matchPolicy`, provisioning will fail.
 
 ### Using TemplateSelector with ClusterClass
 

--- a/docs/advanced-setups.md
+++ b/docs/advanced-setups.md
@@ -187,7 +187,8 @@ Template selection is controlled by the `TemplateSelector` on the `ProxmoxMachin
 - `matchTags`: the list of tags that should be used when searching for a VM template.
 - `matchPolicy`: controls how `matchTags` are evaluated against the tags on a template. It supports two values:
   - `exact` (default): the template's tags must be an exact 1:1 match with `matchTags` (after normalisation). This preserves the behaviour from earlier releases.
-  - `subset`: the template's tags must contain all of the `matchTags`, but may include additional tags.
+  - `bestSubset`: selects a template with a matching subset and the least additional tags.
+  - `uniqueSubset`: requires the template's tags to contain all MatchTags, but allows additional tags.
 
 The lookup must always result in a unique template. If no template or more than one template matches the configured tags under the chosen `matchPolicy`, provisioning will fail.
 


### PR DESCRIPTION
*Issue #866*

*Description of changes:*
Updated documentation to reflect correct value on the ProxmoxMachine TemplateSelector spec:
`spec.templateSelector.resolutionPolicy`->`spec.templateSelector.matchPolicy`
Reflected the correct values for `matchPolicy` options `bestSubset` and `uniqueSubset`
