### PR TITLE
fix(webhook): honour an explicit defaultIPv4/defaultIPv6 false

### DIFF
--- a/internal/webhook/proxmoxmachine_webhook.go
+++ b/internal/webhook/proxmoxmachine_webhook.go
@@ -108,6 +108,18 @@ func b2i(b *bool) int {
 	return 0
 }
 
+// anyDefaultSet reports whether any network device expresses an explicit
+// opinion about a default IP family. An explicit false is an opinion: it means
+// "do not attach the host network to this interface".
+func anyDefaultSet(devices []infrav1.NetworkDevice, get func(infrav1.NetworkDevice) *bool) bool {
+	for _, device := range devices {
+		if get(device) != nil {
+			return true
+		}
+	}
+	return false
+}
+
 func validateNetworks(machine *infrav1.ProxmoxMachine) error {
 	if machine.Spec.Network == nil {
 		return nil
@@ -334,21 +346,17 @@ func (p *ProxmoxMachine) Default(_ context.Context, obj runtime.Object) error {
 		return nil
 	}
 
-	// Patch default networks if they are unset.
-	defaultIPv4Count := 0
-	defaultIPv6Count := 0
-
-	for _, networkDevice := range machine.Spec.Network.NetworkDevices {
-		defaultIPv4Count += b2i(networkDevice.DefaultIPv4)
-		defaultIPv6Count += b2i(networkDevice.DefaultIPv6)
-	}
+	// Patch default networks if they are unset. Setting defaultIPv4/defaultIPv6
+	// to false on every device opts out of the cluster default pool entirely,
+	// so only default when no device sets the field at all.
+	devices := machine.Spec.Network.NetworkDevices
 
 	// We guarantee that DefaultNetworkDevice is a valid proxmox network device.
 	offset, _ := vmservice.NetNameToOffset(infrav1.DefaultNetworkDevice)
-	if defaultIPv4Count == 0 {
+	if !anyDefaultSet(devices, func(d infrav1.NetworkDevice) *bool { return d.DefaultIPv4 }) {
 		machine.Spec.Network.NetworkDevices[offset].DefaultIPv4 = new(true)
 	}
-	if defaultIPv6Count == 0 {
+	if !anyDefaultSet(devices, func(d infrav1.NetworkDevice) *bool { return d.DefaultIPv6 }) {
 		machine.Spec.Network.NetworkDevices[offset].DefaultIPv6 = new(true)
 	}
 

--- a/internal/webhook/proxmoxmachine_webhook_test.go
+++ b/internal/webhook/proxmoxmachine_webhook_test.go
@@ -205,6 +205,17 @@ var _ = Describe("Controller Test", func() {
 			g.Expect(*machine.Spec.Network.NetworkDevices[0].DefaultIPv6).To(BeTrue())
 		})
 
+		It("should not add default ipv4/ipv6 pool tags when explicitly disabled", func() {
+			machine := validProxmoxMachine("default-pools-disabled")
+			machine.Spec.Network.NetworkDevices[0].DefaultIPv4 = new(false)
+			machine.Spec.Network.NetworkDevices[0].DefaultIPv6 = new(false)
+			machine.Spec.Network.NetworkDevices[1].DefaultIPv4 = new(false)
+			machine.Spec.Network.NetworkDevices[1].DefaultIPv6 = new(false)
+			g.Expect(k8sClient.Create(testEnv.GetContext(), &machine)).To(Succeed())
+			g.Expect(*machine.Spec.Network.NetworkDevices[0].DefaultIPv4).To(BeFalse())
+			g.Expect(*machine.Spec.Network.NetworkDevices[0].DefaultIPv6).To(BeFalse())
+		})
+
 		It("should not allow non consecutive network interface names ", func() {
 			machine := validProxmoxMachine("non-consecutive-netname")
 			machine.Spec.Network.NetworkDevices[1].Name = "net2"


### PR DESCRIPTION
**What this PR does / why we need it:**

The `ProxmoxMachine` defaulting webhook counts default interfaces with `b2i()`, which maps both `nil` and `*false` to `0`. Setting `defaultIPv4: false` on every network device is therefore indistinguishable from leaving the field unset, and the webhook force-sets `defaultIPv4: true` on `net0`.

The machine then draws an address from the cluster default pool (`<cluster>-v4-icip`) *in addition to* the address from its explicit `ipPoolRef`, so the primary NIC ends up with two IPv4 addresses and the cluster default pool is silently consumed by machines that never asked for it. Users hitting this have reported that disabling `defaultIPv4` on the template has no effect, because the provisioned `ProxmoxMachine` still comes back with `defaultIPv4: true`.

`defaultIPv4`/`defaultIPv6` are `*bool` with no CRD default, precisely so that unset, true and false are distinguishable, and the field is documented as "attaches the ipv4 host network to this interface" — an explicit `false` already means "do not attach". This PR applies the default only when no device expresses an opinion; an explicit `false` on every device now opts out of the cluster default pool.

`b2i()` is unchanged and still used by `validateNetworks()`, where counting `true` values and rejecting more than one default is the correct semantics.

Behaviour is unchanged when the field is unset anywhere (net0 still defaults to `true`) or when another device is explicitly set to `true`.

**Which issue(s) this PR fixes:**

Fixes #868 
Refs #763, #810

**Special notes for your reviewer:**

- Production change is confined to `Default()`; a new helper `anyDefaultSet()` replaces the `b2i()`-based count so `nil` and `false` are distinguished.
- Alternative considered: the maintainer's zone-based single-pool workaround documented in #810. It does not make `defaultIPv4: false` representable and, in our testing on v0.9.0, `AddInClusterZoneRef` panics (off-by-one: `index` set to `len(slice)` after `append`, then indexed) — so we did not pursue it.

**Release note:**

```release-note
Fixed: an explicit `defaultIPv4: false` / `defaultIPv6: false` on every network device is now honoured. Previously the defaulting webhook conflated an explicit `false` with `unset` and re-attached the cluster default IP pool to net0.
```