### PR TITLE
fix: make VM start and delete idempotent against Proxmox (#727, #96)

### DIFF
--- a/internal/controller/proxmoxmachine_controller.go
+++ b/internal/controller/proxmoxmachine_controller.go
@@ -166,8 +166,18 @@ func (r *ProxmoxMachineReconciler) reconcileDelete(ctx context.Context, machineS
 		Reason: clusterv1.DeletingReason,
 	})
 
-	err := vmservice.DeleteVM(ctx, machineScope)
+	// Wait for a stop/destroy task started by an earlier pass instead of issuing
+	// another one. The deletion path is re-entered on every Machine and
+	// ProxmoxMachine event, not just on the requeue timer (#96).
+	inFlight, err := taskservice.InFlight(ctx, machineScope)
 	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if inFlight {
+		return reconcile.Result{RequeueAfter: infrav1.DefaultReconcilerRequeue}, nil
+	}
+
+	if _, err := vmservice.DeleteVM(ctx, machineScope); err != nil {
 		return reconcile.Result{}, err
 	}
 	// VM is being deleted

--- a/internal/service/taskservice/task.go
+++ b/internal/service/taskservice/task.go
@@ -63,6 +63,79 @@ func GetTask(ctx context.Context, machineScope *scope.MachineScope) (*proxmox.Ta
 	return task, nil
 }
 
+// AdoptActiveTask makes a task-issuing operation idempotent against Proxmox.
+//
+// Status.TaskRef is read through the controller-runtime cache, so a reconcile
+// that runs before a previous pass's status write has propagated sees no task
+// ref and happily issues a second, duplicate task. Asking Proxmox directly is
+// the only reliable answer to "did I already start this?".
+//
+// If a task of taskType is still running for this VM, its UPID is adopted into
+// Status.TaskRef and true is returned, telling the caller to requeue instead of
+// issuing another one.
+func AdoptActiveTask(ctx context.Context, machineScope *scope.MachineScope, taskType string) (bool, error) {
+	vmID := machineScope.ProxmoxMachine.GetVirtualMachineID()
+	if vmID < 100 {
+		return false, nil
+	}
+
+	task, err := machineScope.InfraCluster.ProxmoxClient.GetVMActiveTask(
+		ctx, machineScope.LocateProxmoxNode(), vmID, taskType)
+	if err != nil {
+		return false, err
+	}
+	if task == nil {
+		return false, nil
+	}
+
+	machineScope.Logger.Info("adopting in-flight Proxmox task instead of issuing a new one",
+		"taskType", taskType, "task", string(task.UPID))
+	machineScope.ProxmoxMachine.Status.TaskRef = new(string(task.UPID))
+
+	return true, nil
+}
+
+// InFlight reports whether the task referenced by Status.TaskRef is still
+// running, clearing the ref once it has completed.
+//
+// Unlike ReconcileInFlightTask it never touches the provisioning conditions or
+// the RetryAfter backoff, so it is safe to use on the deletion path, which owns
+// its own condition and must not be pushed back into the provisioning state
+// machine.
+func InFlight(ctx context.Context, machineScope *scope.MachineScope) (bool, error) {
+	if machineScope.ProxmoxMachine.Status.TaskRef == nil {
+		return false, nil
+	}
+
+	// GetTask collapses every lookup failure into ErrTaskNotFound, so an error
+	// here only ever means Proxmox no longer knows this task. Drop the ref so
+	// the caller can make progress rather than requeueing on it forever.
+	task, err := GetTask(ctx, machineScope)
+	if err != nil {
+		machineScope.Logger.V(4).Info("dropping unknown task ref",
+			"task", *machineScope.ProxmoxMachine.Status.TaskRef)
+		machineScope.ProxmoxMachine.Status.TaskRef = nil
+
+		// Intentionally not propagated: a task Proxmox has forgotten is not a
+		// failure, and returning the error here would requeue on it forever.
+		return false, nil //nolint:nilerr
+	}
+	if task == nil {
+		machineScope.ProxmoxMachine.Status.TaskRef = nil
+		return false, nil
+	}
+
+	if task.IsRunning {
+		machineScope.Logger.V(4).Info("waiting for in-flight task",
+			"taskType", task.Type, "task", string(task.UPID))
+		return true, nil
+	}
+
+	machineScope.ProxmoxMachine.Status.TaskRef = nil
+
+	return false, nil
+}
+
 // ReconcileInFlightTask determines if a task associated to the Proxmox VM object is in flight or not.
 func ReconcileInFlightTask(ctx context.Context, machineScope *scope.MachineScope) (bool, error) {
 	// skip if taskRef is nil.

--- a/internal/service/taskservice/task_test.go
+++ b/internal/service/taskservice/task_test.go
@@ -329,3 +329,117 @@ func TestReconcileInFlightTask_UnknownState(t *testing.T) {
 	var requeueErr *RequeueError
 	require.ErrorAs(t, err, &requeueErr)
 }
+
+func TestInFlight_NoTaskRef(t *testing.T) {
+	machineScope, _ := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Status.TaskRef = nil
+
+	inFlight, err := InFlight(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.False(t, inFlight)
+}
+
+func TestInFlight_TaskRunning(t *testing.T) {
+	machineScope, mockClient := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Status.TaskRef = new("UPID:node1:001")
+
+	task := &proxmox.Task{UPID: "UPID:node1:001", IsRunning: true, Status: "running", Type: "qmdestroy"}
+	mockClient.EXPECT().GetTask(context.Background(), "UPID:node1:001").Return(task, nil).Once()
+
+	inFlight, err := InFlight(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.True(t, inFlight)
+	// The ref is kept so the next pass keeps waiting on the same task.
+	require.NotNil(t, machineScope.ProxmoxMachine.Status.TaskRef)
+}
+
+func TestInFlight_TaskCompletedClearsRef(t *testing.T) {
+	machineScope, mockClient := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Status.TaskRef = new("UPID:node1:001")
+
+	task := &proxmox.Task{UPID: "UPID:node1:001", IsCompleted: true, Status: "stopped", Type: "qmdestroy"}
+	mockClient.EXPECT().GetTask(context.Background(), "UPID:node1:001").Return(task, nil).Once()
+
+	inFlight, err := InFlight(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.False(t, inFlight)
+	require.Nil(t, machineScope.ProxmoxMachine.Status.TaskRef)
+}
+
+func TestInFlight_NilTaskClearsRef(t *testing.T) {
+	machineScope, mockClient := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Status.TaskRef = new("UPID:node1:001")
+
+	mockClient.EXPECT().GetTask(context.Background(), "UPID:node1:001").Return(nil, nil).Once()
+
+	inFlight, err := InFlight(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.False(t, inFlight)
+	require.Nil(t, machineScope.ProxmoxMachine.Status.TaskRef)
+}
+
+// A ref pointing at a task Proxmox no longer knows about must be dropped, so
+// deletion can make progress instead of requeueing on it forever.
+func TestInFlight_UnknownTaskDropsRef(t *testing.T) {
+	machineScope, mockClient := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Status.TaskRef = new("UPID:node1:001")
+
+	mockClient.EXPECT().GetTask(context.Background(), "UPID:node1:001").
+		Return(nil, errors.New("boom")).Once()
+
+	inFlight, err := InFlight(context.Background(), machineScope)
+	require.NoError(t, err)
+	require.False(t, inFlight)
+	require.Nil(t, machineScope.ProxmoxMachine.Status.TaskRef)
+}
+
+func TestAdoptActiveTask_NoVMID(t *testing.T) {
+	machineScope, _ := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Spec.VirtualMachineID = nil
+
+	adopted, err := AdoptActiveTask(context.Background(), machineScope, "qmstart")
+	require.NoError(t, err)
+	require.False(t, adopted)
+}
+
+func TestAdoptActiveTask_ClientError(t *testing.T) {
+	machineScope, mockClient := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Spec.VirtualMachineID = new(int64(123))
+
+	mockClient.EXPECT().
+		GetVMActiveTask(context.Background(), machineScope.LocateProxmoxNode(), int64(123), "qmstart").
+		Return(nil, errors.New("boom")).Once()
+
+	adopted, err := AdoptActiveTask(context.Background(), machineScope, "qmstart")
+	require.Error(t, err)
+	require.False(t, adopted)
+}
+
+func TestAdoptActiveTask_NoActiveTask(t *testing.T) {
+	machineScope, mockClient := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Spec.VirtualMachineID = new(int64(123))
+
+	mockClient.EXPECT().
+		GetVMActiveTask(context.Background(), machineScope.LocateProxmoxNode(), int64(123), "qmstart").
+		Return(nil, nil).Once()
+
+	adopted, err := AdoptActiveTask(context.Background(), machineScope, "qmstart")
+	require.NoError(t, err)
+	require.False(t, adopted)
+	require.Nil(t, machineScope.ProxmoxMachine.Status.TaskRef)
+}
+
+func TestAdoptActiveTask_AdoptsUPID(t *testing.T) {
+	machineScope, mockClient := setupTaskTest(t)
+	machineScope.ProxmoxMachine.Spec.VirtualMachineID = new(int64(123))
+
+	task := &proxmox.Task{UPID: "UPID:node1:0001:qmstart:123:root@pam:", Status: "RUNNING"}
+	mockClient.EXPECT().
+		GetVMActiveTask(context.Background(), machineScope.LocateProxmoxNode(), int64(123), "qmstart").
+		Return(task, nil).Once()
+
+	adopted, err := AdoptActiveTask(context.Background(), machineScope, "qmstart")
+	require.NoError(t, err)
+	require.True(t, adopted)
+	require.Equal(t, string(task.UPID), *machineScope.ProxmoxMachine.Status.TaskRef)
+}

--- a/internal/service/vmservice/delete.go
+++ b/internal/service/vmservice/delete.go
@@ -27,32 +27,59 @@ import (
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	infrav1 "github.com/ionos-cloud/cluster-api-provider-proxmox/api/v1alpha2"
+	"github.com/ionos-cloud/cluster-api-provider-proxmox/internal/service/taskservice"
 	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/proxmox/goproxmox"
 	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/scope"
 )
 
 // DeleteVM implements the logic of destroying a VM.
-func DeleteVM(ctx context.Context, machineScope *scope.MachineScope) error {
+//
+// It returns true when a Proxmox task is in flight and the caller should
+// requeue rather than act further.
+func DeleteVM(ctx context.Context, machineScope *scope.MachineScope) (bool, error) {
 	vmID := machineScope.ProxmoxMachine.GetVirtualMachineID()
 	node := machineScope.LocateProxmoxNode()
 
-	if _, err := machineScope.InfraCluster.ProxmoxClient.DeleteVM(ctx, node, vmID); err != nil {
+	// Destroying a VM takes far longer than a reconcile interval, and the
+	// deletion path is re-entered on every Machine and ProxmoxMachine event.
+	// Without these checks each pass issues another qmstop/qmdestroy for a VM
+	// that is already stopping or being destroyed, which is what fills the
+	// Proxmox task log during a rolling update (#96).
+	for _, taskType := range []string{goproxmox.TaskTypeDestroyVM, goproxmox.TaskTypeStopVM} {
+		adopted, err := taskservice.AdoptActiveTask(ctx, machineScope, taskType)
+		if err != nil {
+			return false, err
+		}
+		if adopted {
+			return true, nil
+		}
+	}
+
+	task, err := machineScope.InfraCluster.ProxmoxClient.DeleteVM(ctx, node, vmID)
+	if err != nil {
 		if VMNotFound(err) || errors.Is(err, goproxmox.ErrVMIDFree) {
 			// remove machine from cluster status
 			machineScope.InfraCluster.ProxmoxCluster.RemoveNodeLocation(machineScope.Name(), util.IsControlPlaneMachine(machineScope.Machine))
 			// The VM is deleted so remove the finalizer.
 			ctrlutil.RemoveFinalizer(machineScope.ProxmoxMachine, infrav1.MachineFinalizer)
-			return machineScope.InfraCluster.PatchObject()
+			return false, machineScope.InfraCluster.PatchObject()
 		}
 		conditions.Set(machineScope.ProxmoxMachine, metav1.Condition{
 			Type:   infrav1.ProxmoxMachineVirtualMachineProvisionedCondition,
 			Status: metav1.ConditionFalse,
 			Reason: infrav1.ProxmoxMachineVirtualMachineProvisionedDeletionFailedReason,
 		})
-		return err
+		return false, err
 	}
 
-	return nil
+	// Track the destroy task so subsequent passes wait for it instead of
+	// issuing another one.
+	if task != nil {
+		machineScope.ProxmoxMachine.Status.TaskRef = new(string(task.UPID))
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // VMNotFound checks if the given err is related to that the VM is not found in Proxmox.

--- a/internal/service/vmservice/delete_test.go
+++ b/internal/service/vmservice/delete_test.go
@@ -21,10 +21,12 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/luthermonson/go-proxmox"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 
 	infrav1 "github.com/ionos-cloud/cluster-api-provider-proxmox/api/v1alpha2"
+	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/proxmox/goproxmox"
 )
 
 func TestDeleteVM_SuccessNotFound(t *testing.T) {
@@ -36,9 +38,139 @@ func TestDeleteVM_SuccessNotFound(t *testing.T) {
 		Node:    "node1",
 	}, false)
 
+	proxmoxClient.EXPECT().GetVMActiveTask(context.TODO(), "node1", int64(123), goproxmox.TaskTypeDestroyVM).Return(nil, nil).Once()
+	proxmoxClient.EXPECT().GetVMActiveTask(context.TODO(), "node1", int64(123), goproxmox.TaskTypeStopVM).Return(nil, nil).Once()
 	proxmoxClient.EXPECT().DeleteVM(context.TODO(), "node1", int64(123)).Return(nil, errors.New("vm does not exist: some reason")).Once()
 
-	require.NoError(t, DeleteVM(context.TODO(), machineScope))
+	inFlight, err := DeleteVM(context.TODO(), machineScope)
+	require.NoError(t, err)
+	require.False(t, inFlight)
 	require.Empty(t, machineScope.ProxmoxMachine.Finalizers)
 	require.Empty(t, machineScope.InfraCluster.ProxmoxCluster.GetNode(machineScope.Name(), false))
+}
+
+// A destroy task started by an earlier reconcile must be adopted rather than
+// triggering another qmdestroy (#96).
+func TestDeleteVM_AdoptsInFlightDestroyTask(t *testing.T) {
+	machineScope, proxmoxClient, _ := setupReconcilerTest(t)
+	vm := newRunningVM()
+	machineScope.ProxmoxMachine.Spec.VirtualMachineID = new(int64(vm.VMID))
+	machineScope.InfraCluster.ProxmoxCluster.AddNodeLocation(infrav1.NodeLocation{
+		Machine: corev1.LocalObjectReference{Name: machineScope.Name()},
+		Node:    "node1",
+	}, false)
+
+	task := &proxmox.Task{UPID: "UPID:node1:0000A:0000B:0000C:qmdestroy:123:root@pam:"}
+	proxmoxClient.EXPECT().GetVMActiveTask(context.TODO(), "node1", int64(123), goproxmox.TaskTypeDestroyVM).Return(task, nil).Once()
+
+	inFlight, err := DeleteVM(context.TODO(), machineScope)
+	require.NoError(t, err)
+	require.True(t, inFlight)
+	require.Equal(t, string(task.UPID), *machineScope.ProxmoxMachine.Status.TaskRef)
+	// No DeleteVM call, and the finalizer stays until the task completes.
+	require.NotEmpty(t, machineScope.ProxmoxMachine.Finalizers)
+}
+
+// Likewise for a stop task: the VM is on its way down, so do not re-issue.
+func TestDeleteVM_AdoptsInFlightStopTask(t *testing.T) {
+	machineScope, proxmoxClient, _ := setupReconcilerTest(t)
+	vm := newRunningVM()
+	machineScope.ProxmoxMachine.Spec.VirtualMachineID = new(int64(vm.VMID))
+	machineScope.InfraCluster.ProxmoxCluster.AddNodeLocation(infrav1.NodeLocation{
+		Machine: corev1.LocalObjectReference{Name: machineScope.Name()},
+		Node:    "node1",
+	}, false)
+
+	task := &proxmox.Task{UPID: "UPID:node1:0000A:0000B:0000C:qmstop:123:root@pam:"}
+	proxmoxClient.EXPECT().GetVMActiveTask(context.TODO(), "node1", int64(123), goproxmox.TaskTypeDestroyVM).Return(nil, nil).Once()
+	proxmoxClient.EXPECT().GetVMActiveTask(context.TODO(), "node1", int64(123), goproxmox.TaskTypeStopVM).Return(task, nil).Once()
+
+	inFlight, err := DeleteVM(context.TODO(), machineScope)
+	require.NoError(t, err)
+	require.True(t, inFlight)
+	require.Equal(t, string(task.UPID), *machineScope.ProxmoxMachine.Status.TaskRef)
+}
+
+// An error from the task lookup must abort the pass rather than fall through to
+// issuing a destroy blind.
+func TestDeleteVM_TaskLookupErrorAborts(t *testing.T) {
+	machineScope, proxmoxClient, _ := setupReconcilerTest(t)
+	vm := newRunningVM()
+	machineScope.ProxmoxMachine.Spec.VirtualMachineID = new(int64(vm.VMID))
+	machineScope.InfraCluster.ProxmoxCluster.AddNodeLocation(infrav1.NodeLocation{
+		Machine: corev1.LocalObjectReference{Name: machineScope.Name()},
+		Node:    "node1",
+	}, false)
+
+	proxmoxClient.EXPECT().
+		GetVMActiveTask(context.TODO(), "node1", int64(123), goproxmox.TaskTypeDestroyVM).
+		Return(nil, errors.New("boom")).Once()
+
+	inFlight, err := DeleteVM(context.TODO(), machineScope)
+	require.Error(t, err)
+	require.False(t, inFlight)
+	// Finalizer must survive so the VM is not orphaned.
+	require.NotEmpty(t, machineScope.ProxmoxMachine.Finalizers)
+}
+
+// The happy path: no task in flight, destroy issued, UPID recorded.
+func TestDeleteVM_RecordsDestroyTask(t *testing.T) {
+	machineScope, proxmoxClient, _ := setupReconcilerTest(t)
+	vm := newRunningVM()
+	machineScope.ProxmoxMachine.Spec.VirtualMachineID = new(int64(vm.VMID))
+	machineScope.InfraCluster.ProxmoxCluster.AddNodeLocation(infrav1.NodeLocation{
+		Machine: corev1.LocalObjectReference{Name: machineScope.Name()},
+		Node:    "node1",
+	}, false)
+
+	task := &proxmox.Task{UPID: "UPID:node1:0001:qmdestroy:123:root@pam:"}
+	proxmoxClient.EXPECT().GetVMActiveTask(context.TODO(), "node1", int64(123), goproxmox.TaskTypeDestroyVM).Return(nil, nil).Once()
+	proxmoxClient.EXPECT().GetVMActiveTask(context.TODO(), "node1", int64(123), goproxmox.TaskTypeStopVM).Return(nil, nil).Once()
+	proxmoxClient.EXPECT().DeleteVM(context.TODO(), "node1", int64(123)).Return(task, nil).Once()
+
+	inFlight, err := DeleteVM(context.TODO(), machineScope)
+	require.NoError(t, err)
+	require.True(t, inFlight)
+	require.Equal(t, string(task.UPID), *machineScope.ProxmoxMachine.Status.TaskRef)
+}
+
+// A delete failure that is not "already gone" must surface and keep the finalizer.
+func TestDeleteVM_DeleteErrorKeepsFinalizer(t *testing.T) {
+	machineScope, proxmoxClient, _ := setupReconcilerTest(t)
+	vm := newRunningVM()
+	machineScope.ProxmoxMachine.Spec.VirtualMachineID = new(int64(vm.VMID))
+	machineScope.InfraCluster.ProxmoxCluster.AddNodeLocation(infrav1.NodeLocation{
+		Machine: corev1.LocalObjectReference{Name: machineScope.Name()},
+		Node:    "node1",
+	}, false)
+
+	proxmoxClient.EXPECT().GetVMActiveTask(context.TODO(), "node1", int64(123), goproxmox.TaskTypeDestroyVM).Return(nil, nil).Once()
+	proxmoxClient.EXPECT().GetVMActiveTask(context.TODO(), "node1", int64(123), goproxmox.TaskTypeStopVM).Return(nil, nil).Once()
+	proxmoxClient.EXPECT().DeleteVM(context.TODO(), "node1", int64(123)).Return(nil, errors.New("VM is locked")).Once()
+
+	inFlight, err := DeleteVM(context.TODO(), machineScope)
+	require.Error(t, err)
+	require.False(t, inFlight)
+	require.NotEmpty(t, machineScope.ProxmoxMachine.Finalizers)
+}
+
+// Proxmox can accept the delete without handing back a task; nothing to track,
+// so the caller must not be told to requeue on a task that does not exist.
+func TestDeleteVM_NoTaskReturned(t *testing.T) {
+	machineScope, proxmoxClient, _ := setupReconcilerTest(t)
+	vm := newRunningVM()
+	machineScope.ProxmoxMachine.Spec.VirtualMachineID = new(int64(vm.VMID))
+	machineScope.InfraCluster.ProxmoxCluster.AddNodeLocation(infrav1.NodeLocation{
+		Machine: corev1.LocalObjectReference{Name: machineScope.Name()},
+		Node:    "node1",
+	}, false)
+
+	proxmoxClient.EXPECT().GetVMActiveTask(context.TODO(), "node1", int64(123), goproxmox.TaskTypeDestroyVM).Return(nil, nil).Once()
+	proxmoxClient.EXPECT().GetVMActiveTask(context.TODO(), "node1", int64(123), goproxmox.TaskTypeStopVM).Return(nil, nil).Once()
+	proxmoxClient.EXPECT().DeleteVM(context.TODO(), "node1", int64(123)).Return(nil, nil).Once()
+
+	inFlight, err := DeleteVM(context.TODO(), machineScope)
+	require.NoError(t, err)
+	require.False(t, inFlight)
+	require.Nil(t, machineScope.ProxmoxMachine.Status.TaskRef)
 }

--- a/internal/service/vmservice/power.go
+++ b/internal/service/vmservice/power.go
@@ -24,8 +24,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 
+	"github.com/ionos-cloud/cluster-api-provider-proxmox/internal/service/taskservice"
+
 	infrav1 "github.com/ionos-cloud/cluster-api-provider-proxmox/api/v1alpha2"
 	capmox "github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/proxmox"
+	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/proxmox/goproxmox"
 	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/scope"
 )
 
@@ -36,6 +39,22 @@ func reconcilePowerState(ctx context.Context, machineScope *scope.MachineScope) 
 	}
 
 	machineScope.V(4).Info("ensuring machine is started")
+
+	// Only a VM that still looks stopped is a duplicate-start candidate, and
+	// asking Proxmox costs a round trip, so the check is scoped to that case.
+	//
+	// Status.TaskRef is read through the controller-runtime cache. A pass that
+	// runs before the previous pass's status write has propagated sees no task
+	// ref, while the VM has not finished booting yet - so every local guard
+	// misses and a second qmstart is issued, which Proxmox rejects with "VM
+	// already running". Proxmox is the only reliable source for "did I already
+	// start this?".
+	if vm := machineScope.VirtualMachine; vm.IsStopped() || vm.IsHibernated() {
+		adopted, err := taskservice.AdoptActiveTask(ctx, machineScope, goproxmox.TaskTypeStartVM)
+		if err != nil || adopted {
+			return adopted, err
+		}
+	}
 
 	t, err := startVirtualMachine(ctx, machineScope.InfraCluster.ProxmoxClient, machineScope.VirtualMachine)
 	if err != nil {

--- a/internal/service/vmservice/power_test.go
+++ b/internal/service/vmservice/power_test.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/luthermonson/go-proxmox"
 	"github.com/stretchr/testify/require"
 
 	infrav1 "github.com/ionos-cloud/cluster-api-provider-proxmox/api/v1alpha2"
+	"github.com/ionos-cloud/cluster-api-provider-proxmox/pkg/proxmox/goproxmox"
 )
 
 func TestReconcilePowerState_SetTaskRef(t *testing.T) {
@@ -45,6 +47,70 @@ func TestReconcilePowerState_SetTaskRef(t *testing.T) {
 	require.True(t, requeue)
 	require.NoError(t, err)
 	require.NotEmpty(t, *machineScope.ProxmoxMachine.Status.TaskRef)
+}
+
+// Regression test for the duplicate qmstart: a reconcile that runs before the
+// previous pass's Status.TaskRef write has propagated through the cache must
+// not issue a second start. StartVM is deliberately not expected here - the
+// mock fails the test if it is called (#727).
+func TestReconcilePowerState_AdoptsInFlightStartTask(t *testing.T) {
+	ctx := context.TODO()
+	machineScope, proxmoxClient, _ := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForVMPowerUpReason)
+
+	vm := newStoppedVM()
+	vm.VMID = 123
+	machineScope.ProxmoxMachine.Spec.VirtualMachineID = new(int64(123))
+	machineScope.SetVirtualMachine(vm)
+	// Cache lag: the ref from the pass that already started the VM is not visible.
+	machineScope.ProxmoxMachine.Status.TaskRef = nil
+
+	task := &proxmox.Task{UPID: "UPID:node1:0000A:0000B:0000C:qmstart:123:root@pam:"}
+	proxmoxClient.EXPECT().
+		GetVMActiveTask(ctx, machineScope.LocateProxmoxNode(), int64(123), goproxmox.TaskTypeStartVM).
+		Return(task, nil).Once()
+
+	requeue, err := reconcilePowerState(ctx, machineScope)
+	require.NoError(t, err)
+	require.True(t, requeue)
+	require.Equal(t, string(task.UPID), *machineScope.ProxmoxMachine.Status.TaskRef)
+}
+
+// With no start in flight the VM must still be started as before.
+func TestReconcilePowerState_StartsWhenNoTaskInFlight(t *testing.T) {
+	ctx := context.TODO()
+	machineScope, proxmoxClient, _ := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForVMPowerUpReason)
+
+	vm := newStoppedVM()
+	vm.VMID = 123
+	machineScope.ProxmoxMachine.Spec.VirtualMachineID = new(int64(123))
+	machineScope.SetVirtualMachine(vm)
+
+	started := newTask()
+	proxmoxClient.EXPECT().
+		GetVMActiveTask(ctx, machineScope.LocateProxmoxNode(), int64(123), goproxmox.TaskTypeStartVM).
+		Return(nil, nil).Once()
+	proxmoxClient.EXPECT().StartVM(ctx, vm).Return(started, nil).Once()
+
+	requeue, err := reconcilePowerState(ctx, machineScope)
+	require.NoError(t, err)
+	require.True(t, requeue)
+	require.Equal(t, string(started.UPID), *machineScope.ProxmoxMachine.Status.TaskRef)
+}
+
+// A running VM is not a duplicate-start candidate, so Proxmox must not be
+// queried at all - the state machine just advances.
+func TestReconcilePowerState_RunningVMSkipsTaskLookup(t *testing.T) {
+	ctx := context.TODO()
+	machineScope, _, _ := setupReconcilerTestWithCondition(t, infrav1.ProxmoxMachineVirtualMachineProvisionedWaitingForVMPowerUpReason)
+
+	vm := newRunningVM()
+	machineScope.ProxmoxMachine.Spec.VirtualMachineID = new(int64(123))
+	machineScope.SetVirtualMachine(vm)
+
+	requeue, err := reconcilePowerState(ctx, machineScope)
+	require.NoError(t, err)
+	require.False(t, requeue)
+	require.Nil(t, machineScope.ProxmoxMachine.Status.TaskRef)
 }
 
 func TestStartVirtualMachine_Paused(t *testing.T) {

--- a/internal/service/vmservice/vm_test.go
+++ b/internal/service/vmservice/vm_test.go
@@ -842,6 +842,7 @@ func TestReconcileVM_StateMachine(t *testing.T) {
 	)
 
 	proxmoxClient.EXPECT().GetVM(context.Background(), "node2", int64(123)).Return(vm, nil).Once()
+	proxmoxClient.EXPECT().GetVMActiveTask(context.Background(), "node2", int64(123), goproxmox.TaskTypeStartVM).Return(nil, nil).Once()
 	proxmoxClient.EXPECT().StartVM(context.Background(), vm).Return(newTask(), nil).Once()
 
 	// Provide IPAddresses fields to fake network bootstrap.

--- a/pkg/proxmox/client.go
+++ b/pkg/proxmox/client.go
@@ -40,6 +40,12 @@ type Client interface {
 
 	GetTask(ctx context.Context, upID string) (*proxmox.Task, error)
 
+	// GetVMActiveTask returns the still-running task of the given type for vmID
+	// on nodeName, or nil when Proxmox has none. It lets callers make
+	// task-issuing operations idempotent against Proxmox itself, rather than
+	// against a possibly stale cached ProxmoxMachine status.
+	GetVMActiveTask(ctx context.Context, nodeName string, vmID int64, taskType string) (*proxmox.Task, error)
+
 	GetReservableMemoryBytes(ctx context.Context, nodeName string, nodeMemoryAdjustment int64) (uint64, error)
 
 	ResizeDisk(ctx context.Context, vm *proxmox.VirtualMachine, disk, size string) (*proxmox.Task, error)

--- a/pkg/proxmox/goproxmox/api_client.go
+++ b/pkg/proxmox/goproxmox/api_client.go
@@ -265,6 +265,49 @@ func (c *APIClient) CheckID(ctx context.Context, vmid int64) (bool, error) {
 	return cluster.CheckID(ctx, int(vmid))
 }
 
+// Proxmox task types used for idempotency checks.
+const (
+	// TaskTypeStartVM is the Proxmox task type for starting a VM.
+	TaskTypeStartVM = "qmstart"
+	// TaskTypeStopVM is the Proxmox task type for stopping a VM.
+	TaskTypeStopVM = "qmstop"
+	// TaskTypeDestroyVM is the Proxmox task type for destroying a VM.
+	TaskTypeDestroyVM = "qmdestroy"
+)
+
+// GetVMActiveTask returns the still-running task of the given type for vmID on
+// nodeName, or nil when Proxmox has none.
+//
+// Two quirks of the task list endpoint to be aware of:
+//
+//   - It does not populate proxmox.Task's IsRunning/IsCompleted booleans - only
+//     Task.Ping does - so the running check is made against Status.
+//   - It reports Status as "RUNNING", while the per-task status endpoint (and
+//     hence proxmox.TaskRunning) uses "running". The comparison must therefore
+//     be case-insensitive; a case-sensitive one silently matches nothing and
+//     every caller happily issues a duplicate task.
+func (c *APIClient) GetVMActiveTask(ctx context.Context, nodeName string, vmID int64, taskType string) (*proxmox.Task, error) {
+	node := (&proxmox.Node{}).New(c.Client, nodeName)
+
+	tasks, err := node.Tasks(ctx, &proxmox.NodeTasksOptions{
+		VMID:       int(vmID),
+		TypeFilter: taskType,
+		Source:     "active",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot list active %s tasks for vm %d on node %s: %w", taskType, vmID, nodeName, err)
+	}
+
+	for _, task := range tasks {
+		if task == nil || !strings.EqualFold(task.Status, proxmox.TaskRunning) {
+			continue
+		}
+		return task, nil
+	}
+
+	return nil, nil
+}
+
 // GetTask returns a task associated with upID.
 func (c *APIClient) GetTask(ctx context.Context, upID string) (*proxmox.Task, error) {
 	task := proxmox.NewTask(proxmox.UPID(upID), c.Client)

--- a/pkg/proxmox/goproxmox/api_client_test.go
+++ b/pkg/proxmox/goproxmox/api_client_test.go
@@ -740,3 +740,72 @@ func TestProxmoxAPIClient_CloudInitStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestProxmoxAPIClient_GetVMActiveTask(t *testing.T) {
+	const upid = "UPID:node1:0003072C:1D5E33B0:6A9FFD6C:qmdestroy:104:root@pam:"
+
+	tests := []struct {
+		name      string
+		status    string
+		expectHit bool
+	}{
+		// The task list endpoint reports uppercase RUNNING while
+		// proxmox.TaskRunning is "running". A case-sensitive comparison matched
+		// nothing here, so a duplicate qmdestroy was issued for a VM that was
+		// already being destroyed - and failed with "Configuration file
+		// 'nodes/<node>/qemu-server/<vmid>.conf' does not exist".
+		{name: "uppercase RUNNING as returned by the list endpoint", status: "RUNNING", expectHit: true},
+		{name: "lowercase running as returned by the status endpoint", status: "running", expectHit: true},
+		{name: "stopped task is not active", status: "stopped", expectHit: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := newTestClient(t)
+			httpmock.RegisterResponder(http.MethodGet, testBaseURL+"api2/json/nodes/node1/status",
+				newJSONResponder(200, proxmox.Node{}))
+			httpmock.RegisterResponder(http.MethodGet,
+				`=~^http://pve\.local\.test/api2/json/nodes/node1/tasks\?.*`,
+				newJSONResponder(200, []map[string]any{
+					{"upid": upid, "type": "qmdestroy", "id": "104", "node": "node1", "status": test.status},
+				}))
+
+			task, err := client.GetVMActiveTask(context.Background(), "node1", 104, TaskTypeDestroyVM)
+			require.NoError(t, err)
+
+			if !test.expectHit {
+				require.Nil(t, task)
+				return
+			}
+			require.NotNil(t, task)
+			require.Equal(t, upid, string(task.UPID))
+		})
+	}
+}
+
+func TestProxmoxAPIClient_GetVMActiveTask_NoTasks(t *testing.T) {
+	client := newTestClient(t)
+	httpmock.RegisterResponder(http.MethodGet, testBaseURL+"api2/json/nodes/node1/status",
+		newJSONResponder(200, proxmox.Node{}))
+	httpmock.RegisterResponder(http.MethodGet,
+		`=~^http://pve\.local\.test/api2/json/nodes/node1/tasks\?.*`,
+		newJSONResponder(200, []map[string]any{}))
+
+	task, err := client.GetVMActiveTask(context.Background(), "node1", 104, TaskTypeDestroyVM)
+	require.NoError(t, err)
+	require.Nil(t, task)
+}
+
+func TestProxmoxAPIClient_GetVMActiveTask_ListError(t *testing.T) {
+	client := newTestClient(t)
+	httpmock.RegisterResponder(http.MethodGet, testBaseURL+"api2/json/nodes/node1/status",
+		newJSONResponder(200, proxmox.Node{}))
+	httpmock.RegisterResponder(http.MethodGet,
+		`=~^http://pve\.local\.test/api2/json/nodes/node1/tasks\?.*`,
+		httpmock.NewStringResponder(500, `{"data":null}`))
+
+	task, err := client.GetVMActiveTask(context.Background(), "node1", 104, TaskTypeStopVM)
+	require.Error(t, err)
+	require.Nil(t, task)
+	require.Contains(t, err.Error(), "cannot list active qmstop tasks for vm 104 on node node1")
+}

--- a/pkg/proxmox/proxmoxtest/mock_client.go
+++ b/pkg/proxmox/proxmoxtest/mock_client.go
@@ -631,6 +631,67 @@ func (_c *MockClient_GetVM_Call) RunAndReturn(run func(context.Context, string, 
 	return _c
 }
 
+// GetVMActiveTask provides a mock function with given fields: ctx, nodeName, vmID, taskType
+func (_m *MockClient) GetVMActiveTask(ctx context.Context, nodeName string, vmID int64, taskType string) (*go_proxmox.Task, error) {
+	ret := _m.Called(ctx, nodeName, vmID, taskType)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetVMActiveTask")
+	}
+
+	var r0 *go_proxmox.Task
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, int64, string) (*go_proxmox.Task, error)); ok {
+		return rf(ctx, nodeName, vmID, taskType)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, int64, string) *go_proxmox.Task); ok {
+		r0 = rf(ctx, nodeName, vmID, taskType)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*go_proxmox.Task)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, int64, string) error); ok {
+		r1 = rf(ctx, nodeName, vmID, taskType)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClient_GetVMActiveTask_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetVMActiveTask'
+type MockClient_GetVMActiveTask_Call struct {
+	*mock.Call
+}
+
+// GetVMActiveTask is a helper method to define mock.On call
+//   - ctx context.Context
+//   - nodeName string
+//   - vmID int64
+//   - taskType string
+func (_e *MockClient_Expecter) GetVMActiveTask(ctx interface{}, nodeName interface{}, vmID interface{}, taskType interface{}) *MockClient_GetVMActiveTask_Call {
+	return &MockClient_GetVMActiveTask_Call{Call: _e.mock.On("GetVMActiveTask", ctx, nodeName, vmID, taskType)}
+}
+
+func (_c *MockClient_GetVMActiveTask_Call) Run(run func(ctx context.Context, nodeName string, vmID int64, taskType string)) *MockClient_GetVMActiveTask_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(int64), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *MockClient_GetVMActiveTask_Call) Return(_a0 *go_proxmox.Task, _a1 error) *MockClient_GetVMActiveTask_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClient_GetVMActiveTask_Call) RunAndReturn(run func(context.Context, string, int64, string) (*go_proxmox.Task, error)) *MockClient_GetVMActiveTask_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // QemuAgentStatus provides a mock function with given fields: ctx, vm
 func (_m *MockClient) QemuAgentStatus(ctx context.Context, vm *go_proxmox.VirtualMachine) error {
 	ret := _m.Called(ctx, vm)


### PR DESCRIPTION

*Issue #727 and #96 - duplicate qmstart / qmstop / qmdestroy tasks issued for the same VM.


# *Description of changes:*

## Problem

 Status.TaskRef is read through the controller-runtime cache. A reconcile that runs before a previous pass's status write has propagated sees no task ref and issues a duplicate Proxmox task.

 On the start path this yields two qmstart tasks in the same second, the second rejected:

 pvedaemon[3612164]: start VM 124: UPID:pve8:00371E04:...:qmstart:124:...
 pvedaemon[3612173]: start VM 124: UPID:pve8:00371E0D:...:qmstart:124:...
 pvedaemon[3612164]: VM 124 started with PID 3612180
 pvedaemon[3612173]: VM 124 already running

 Both existing guards legitimately miss: TaskRef is stale, and the VM has not finished booting, so IsStopped() is correctly true.

 The delete path had no in-flight guard at all, so every pass while a VM was terminating issued another qmstop/qmdestroy. Since the controller also watches Machine, passes are event-driven rather than timer-driven, which is why this is worst during a rolling update. The duplicate destroy then lands after the first has removed the config and fails with TASK ERROR: Configuration file 'nodes/<node>/qemu-server/<vmid>.conf' does not exist.

### Why re-checking TaskRef is not enough

 #727 suggests checking TaskRef in reconcilePowerState. That check can never fire: TaskRef is already gated in ReconcileInFlightTask and in ensureVirtualMachine earlier in the same pass, and every intermediate stage that sets it also requeues. All three would read the same stale cached value.

 ## Fix

 Ask Proxmox instead. GetVMActiveTask lists active tasks of a given type for a VMID; when one is found its UPID is adopted into Status.TaskRef and the caller requeues rather than issuing a duplicate. reconcileDelete gains an in-flight gate, and DeleteVM now records the destroy task's UPID instead of discarding it. The start-path check only runs for a VM that still looks stopped, so the common path costs no extra API call.

 One Proxmox quirk worth flagging for reviewers: the task list endpoint reports "status":"RUNNING", while the per-task status endpoint (and proxmox.TaskRunning) uses "running". A case-sensitive comparison silently matches nothing — there is a regression test for this.

# Testing performed:
make verify, make lint and make test pass. New unit tests cover both adopt paths, the case-sensitivity trap, and assert StartVM is not called when a start is already in flight.

Verified on a live cluster during a KCP rolling update: exactly one UPID per (VM, task type), the adopt guard firing 7 times, zero already running, and no duplicate-destroy task errors.